### PR TITLE
fix(nodejs): Fixing nodejs dockerfile to point to older version

### DIFF
--- a/pkg/draft/defaultpacks/node.go
+++ b/pkg/draft/defaultpacks/node.go
@@ -42,7 +42,7 @@ fi
 echo Node.js
 `
 
-const nodeDockerfile = `FROM node:onbuild
+const nodeDockerfile = `FROM node:6-onbuild
 EXPOSE 8080
 RUN npm install
 CMD ["npm", "start"]


### PR DESCRIPTION
Moving from 8-onbuild -> 6-onbuild
Fixes #80