### PR TITLE
fix(defaultpacks): set basedomain

### DIFF
--- a/pkg/draft/defaultpacks/golang.go
+++ b/pkg/draft/defaultpacks/golang.go
@@ -9,6 +9,7 @@ import (
 const golangValues = `# Default values for golang.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+basedomain: example.com
 replicaCount: 2
 image:
   registry: docker.io

--- a/pkg/draft/defaultpacks/java.go
+++ b/pkg/draft/defaultpacks/java.go
@@ -9,6 +9,7 @@ import (
 const javaValues = `# Default values for Java.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+basedomain: example.com
 replicaCount: 2
 image:
   registry: docker.io

--- a/pkg/draft/defaultpacks/node.go
+++ b/pkg/draft/defaultpacks/node.go
@@ -9,6 +9,7 @@ import (
 const nodeValues = `# Default values for node.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+basedomain: example.com
 replicaCount: 2
 image:
   registry: docker.io

--- a/pkg/draft/defaultpacks/php.go
+++ b/pkg/draft/defaultpacks/php.go
@@ -9,6 +9,7 @@ import (
 const phpValues = `# Default values for PHP.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+basedomain: example.com
 replicaCount: 2
 image:
   registry: docker.io

--- a/pkg/draft/defaultpacks/python.go
+++ b/pkg/draft/defaultpacks/python.go
@@ -9,6 +9,7 @@ import (
 const pythonValues = `# Default values for python.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+basedomain: example.com
 replicaCount: 2
 image:
   registry: docker.io

--- a/pkg/draft/defaultpacks/ruby.go
+++ b/pkg/draft/defaultpacks/ruby.go
@@ -9,6 +9,7 @@ import (
 const rubyValues = `# Default values for Ruby.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+basedomain: example.com
 replicaCount: 2
 image:
   registry: docker.io


### PR DESCRIPTION
basedomain is refered to in all of the ingress templates, but unset
in default values file, which results in regex validation error for
the ingress object