### PR TITLE
blindly check for .go files across the repository

### DIFF
--- a/packs/golang/detect
+++ b/packs/golang/detect
@@ -8,7 +8,7 @@ build=$(cd "$1/" && pwd)
 if test -f "${build}/Godeps/Godeps.json" || # godeps
    test -f "${build}/vendor/vendor.json" || # govendor
    test -f "${build}/glide.yaml" || # glide
-   (test -d "${build}/src" && test -n "$(find "${build}/src" -mindepth 2 -type f -name '*.go' | sed 1q)") # gb
+   test -n "$(find "${build}" -type f -name '*.go' | sed 1q)" # found a file with a .go extension
 then
   echo Go
 else


### PR DESCRIPTION
See https://github.com/heroku/heroku-buildpack-go/issues/115 for more context on why Heroku originally did not do this, but I think the number of users who have ruby apps with .go files in their repo is very small. Worst case scenario these users can just call `draft create --pack ruby` to explicitly override the system.

closes #101.