### PR TITLE
Using multi-stage to compile the application

### DIFF
--- a/packs/java/Dockerfile
+++ b/packs/java/Dockerfile
@@ -1,3 +1,10 @@
-FROM maven:onbuild
+FROM maven:3.5-jdk-8-alpine as BUILD
+
+COPY . /usr/src/app
+RUN mvn -f /usr/src/app/pom.xml clean package
+
+FROM openjdk:8-jdk-alpine
 EXPOSE 4567
-CMD ["java", "-jar", "target/helloworld-jar-with-dependencies.jar"]
+COPY --from=BUILD /usr/src/app/target/*.jar /opt/app.jar
+WORKDIR /opt
+CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
The `onbuild` tags [have been deprecated on the official docker images](https://github.com/docker-library/docs/pull/911).

I've also added [the new multi-stage build](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) to compile the application during the `docker build`.