### PR TITLE
E2e test fixes

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -16,7 +16,7 @@ for app in */; do
     pushd "${app}" > /dev/null
     # strip trailing forward slash
     app=${app%/}
-    draft up
+    draft up -e nowatch
     echo "checking that ${app} v1 was released"
     revision=$(helm list | grep "${app}" | awk '{print $2}')
     if [[ "$revision" != "1" ]]; then
@@ -25,7 +25,7 @@ for app in */; do
     fi
     echo "GOOD"
     # deploy the app again and check that the update is seen upstream
-    draft up
+    draft up -e nowatch
     echo "checking that ${app} v2 was released"
     revision=$(helm list | grep "${app}" | awk '{print $2}')
     if [[ "$revision" != "2" ]]; then

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -9,7 +9,7 @@
 cd $(dirname $0)
 PATH="$(pwd)/../bin:$PATH"
 
-echo "testing apps that are expected to pass"
+echo "# testing apps that are expected to pass"
 pushd testdata/good > /dev/null
 for app in */; do
     echo "switching to ${app}"
@@ -42,7 +42,7 @@ for app in */; do
 done
 popd > /dev/null
 
-echo "testing apps that are expected to fail"
+echo "# testing apps that are expected to fail"
 pushd testdata/bad > /dev/null
 for app in */; do
     echo "switching to ${app}"

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -7,6 +7,7 @@
 # success condition.
 
 cd $(dirname $0)
+PATH="$(pwd)/../bin:$PATH"
 
 echo "testing apps that are expected to pass"
 pushd testdata/good > /dev/null

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -19,6 +19,7 @@ for app in */; do
     draft up -e nowatch
     echo "checking that ${app} v1 was released"
     revision=$(helm list | grep "${app}" | awk '{print $2}')
+    name=$(helm list | grep "${app}" | awk '{print $1}')
     if [[ "$revision" != "1" ]]; then
         echo "Expected REVISION == 1, got $revision"
         exit 1
@@ -33,9 +34,9 @@ for app in */; do
         exit 1
     fi
     echo "GOOD"
-    echo "deleting the helm release for ${app}"
+    echo "deleting the helm release for ${app}: ${name}"
     # clean up
-    helm delete --purge "${app}"
+    helm delete --purge "${name}"
     echo "GOOD"
     popd > /dev/null
 done

--- a/tests/testdata/good/example-dockerfile-http/draft.toml
+++ b/tests/testdata/good/example-dockerfile-http/draft.toml
@@ -1,0 +1,10 @@
+[environments]
+  [environments.nowatch]
+    name = "example-dockerfile-http"
+    namespace = "default"
+    watch = false
+  [environments.watch]
+    name = "example-dockerfile-http"
+    namespace = "default"
+    watch = true
+    watch_delay = 1


### PR DESCRIPTION
Fix and enhance e2e tests to not block on watch feature of `draft up`. They were previously hanging.
Ensure we clean the right helm chart and get some clearer output.