### PR TITLE
draft init rewrite

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -388,8 +388,7 @@ func buildApp(ws *websocket.Conn, server *Server, appName string, buildContext i
 
 	// Break up registry auth json string into a RegistryAuth object.
 	var regAuth RegistryAuth
-	err = json.Unmarshal(data, &regAuth)
-	if err != nil {
+	if err := json.Unmarshal(data, &regAuth); err != nil {
 		handleClosingError(ws, "Could not json decode registry authentication string", err)
 	}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -16,7 +16,7 @@ service:
     internalPort: 44135
 registry:
   url: docker.io
-  org: microsoft
+  org: draft
   # This field follows the format of Docker's X-Registry-Auth header.
   #
   # See https://github.com/docker/docker/blob/master/docs/api/v1.22.md#push-an-image-on-the-registry
@@ -28,4 +28,4 @@ registry:
   # For token-based logins, use
   #
   # $ echo '{"registrytoken":"9cbaf023786cd7"}' | base64
-  authtoken: changeme
+  authtoken: e30K

--- a/cmd/draft/installer/config/config.go
+++ b/cmd/draft/installer/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/helm/pkg/proto/hapi/chart"
+)
+
+// FromClientConfig reads a kubernetes client config, searching for information that may indicate
+// this is a minikube/Azure Container Services/Google Container Engine cluster and return
+// configuration optimized for that cloud, as well as the cloud provider name.
+func FromClientConfig(config clientcmd.ClientConfig) (*chart.Config, string, error) {
+	var (
+		chartConfig       = new(chart.Config)
+		cloudProviderName string
+	)
+
+	rawConfig, err := config.RawConfig()
+	if err != nil {
+		return nil, "", err
+	}
+
+	if rawConfig.CurrentContext == "minikube" {
+		// we imply that the user has installed the registry addon
+		chartConfig.Raw = "registry:\n  url: $(REGISTRY_SERVICE_HOST)\nbasedomain: k8s.local\n"
+		cloudProviderName = rawConfig.CurrentContext
+	}
+
+	return chartConfig, cloudProviderName, nil
+}

--- a/cmd/draft/installer/install.go
+++ b/cmd/draft/installer/install.go
@@ -36,7 +36,7 @@ service:
     internalPort: 44135
 registry:
   url: docker.io
-  org: microsoft
+  org: draft
   # This field follows the format of Docker's X-Registry-Auth header.
   #
   # See https://github.com/docker/docker/blob/master/docs/api/v1.22.md#push-an-image-on-the-registry
@@ -48,7 +48,7 @@ registry:
   # For token-based logins, use
   #
   # $ echo '{"registrytoken":"9cbaf023786cd7"}' | base64 -w 0
-  authtoken: changeme
+  authtoken: e30K
 `
 
 const draftIgnore = `# Patterns to ignore when building packages.

--- a/docs/contributing/hacking.md
+++ b/docs/contributing/hacking.md
@@ -7,13 +7,12 @@ development environment for working on the Draft source code.
 
 To compile and test Draft binaries and to build Docker images, you will need:
 
+ - a [Kubernetes][] cluster with [Draft already installed][install]. We recommend [minikube][].
  - [docker][]
- - a [Docker Hub][] or [quay.io][quay] account
  - [git][]
- - [Go][] 1.7 or later, with support for compiling to `linux/amd64`
+ - [helm][], using the same version as recommended in the [installation guide][install].
+ - [Go][] 1.8 or later, with support for compiling to `linux/amd64`
  - [glide][]
- - a [Kubernetes][] cluster. We recommend [minikube][]
- - [helm][]
  - [upx][] (optional) to compress binaries for a smaller Docker image
 
 In most cases, install the prerequisite according to its instructions. See the next section
@@ -84,57 +83,6 @@ To test interactively, you will likely want to deploy your changes to Draft on a
 This requires a Docker registry where you can push your customized draftd images so Kubernetes can
 pull them.
 
-In most cases, a local Docker registry will not be accessible to your Kubernetes nodes. A public
-registry such as [Docker Hub][] or [Quay][] will suffice.
-
-To use DockerHub for draftd images:
-
-```shell
-$ export DOCKER_REGISTRY="docker.io"
-$ export IMAGE_PREFIX=<your DockerHub username>
-```
-
-To use quay.io:
-
-```shell
-$ export DOCKER_REGISTRY="quay.io"
-$ export IMAGE_PREFIX=<your quay.io username>
-```
-
-After your Docker registry is set up, you can deploy your images using:
-
-```shell
-$ make docker-build docker-push
-```
-
-Ensure that Helm's `tiller` server is running in the Kubernetes cluster:
-
-```shell
-$ helm init  # it may take a few seconds for tiller to install
-$ helm version
-Client: &version.Version{SemVer:"v2.2.0", GitCommit:"fc315ab59850ddd1b9b4959c89ef008fef5cdf89", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.2.0", GitCommit:"fc315ab59850ddd1b9b4959c89ef008fef5cdf89", GitTreeState:"clean"}
-```
-
-To install draftd, edit `chart/values.yaml` and change the fields under `registry` to your
-[Docker Hub][] or [quay.io][quay] account, and change the fields under `image` to the newly
-deployed draftd image:
-
-```
-$ $EDITOR chart/values.yaml
-```
-
-Then, install the chart:
-
-```shell
-$ draft init -f chart/values.yaml
-$ helm list  # check that Draft has a helm release
-NAME 	REVISION	UPDATED                 	STATUS  	CHART      	NAMESPACE
-draft	1       	Thu Feb 16 10:18:21 2017	DEPLOYED	draftd-0.1.0	kube-system
-```
-
-## Re-deploying Your Changes
-
 Because Draft deploys Kubernetes applications and Draft is a Kubernetes application itself, you can
 use Draft to deploy Draft. How neat is that?!
 
@@ -144,7 +92,7 @@ To build your changes and upload it to draftd, run
 $ make build docker-binary
 $ draft up
 --> Building Dockerfile
---> Pushing docker.io/microsoft/draftd:6f3b53003dcbf43821aea43208fc51455674d00e
+--> Pushing 10.0.0.237/draft/draftd:6f3b53003dcbf43821aea43208fc51455674d00e
 --> Deploying to Kubernetes
 --> Status: DEPLOYED
 --> Notes:
@@ -176,7 +124,6 @@ helm delete --purge draft
 
 
 [docker]: https://www.docker.com/
-[Docker Hub]: https://hub.docker.com/
 [git]: https://git-scm.com/
 [glide]: https://github.com/Masterminds/glide
 [go]: https://golang.org/
@@ -184,6 +131,5 @@ helm delete --purge draft
 [Homebrew]: https://brew.sh/
 [Kubernetes]: https://github.com/kubernetes/kubernetes
 [minikube]: https://github.com/kubernetes/minikube
-[Quay]: https://quay.io/
 [upstream]: https://help.github.com/articles/fork-a-repo/
 [upx]: https://upx.github.io

--- a/docs/design.md
+++ b/docs/design.md
@@ -193,26 +193,26 @@ image:
 
 _How do I add an existing chart to Draft?_
 
-Just copy (`helm fetch`) it into the `chart/` directory. You need to tweak the values file to
-read from `image.registry`, `image.org`, `image.name` and `image.tag` if you want draft to regenerate Docker
-images for you. See above.
+Just copy (`helm fetch`) it into the `chart/` directory. You need to tweak the values file to read
+from `image.registry`, `image.org`, `image.name` and `image.tag` if you want draft to regenerate
+Docker images for you. See above.
 
 _How do I deploy applications to production?_
 
 Draft is a developer tool. While you _could_ simply use `draft up` to do this, we'd recommend using
 `helm package` in conjuction with a CI/CD pipeline.
 
-Remember: You can always package a Draft-generated chart with `helm package chart/` and load the
-results up to a chart repository, taking advantage of the existing Helm ecosystem.
+Remember: You can always package a Draft-generated chart with `helm package` and load the results up
+to a chart repository, taking advantage of the existing Helm ecosystem.
 
 ## Other Architectural Considerations
 
-Instead of a draftd HTTP server, we could spawn a Draft pod "job" (via `draft up`) that runs only when
-`draft up` is called. In that case, the `draft` client would be the main focal point for server-side
-configuration. This has the advantage of requiring fewer resource demands server-side, but might
-make the client implementation (and security story) significantly more difficult. Furthermore, it
-might make two `draft up` operations between two clients differ (the "Works on My Machine!"
-problem).
+Instead of a draftd HTTP server, we could spawn a Draft pod "job" (via `draft up`) that runs only
+when `draft up` is called. In that case, the `draft` client would be the main focal point for
+server-side configuration. This has the advantage of requiring fewer resource demands server-side,
+but might make the client implementation (and security story) significantly more difficult.
+Furthermore, it might make two `draft up` operations between two clients differ (the "Works on My
+Machine!" problem).
 
 ## User Personas and Stories
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,8 +21,8 @@ We need some "scaffolding" to deploy our app into a [Kubernetes](https://kuberne
 $ draft create
 --> Python app detected
 --> Ready to sail
-$ ls
-Dockerfile  app.py  chart/  draft.toml  requirements.txt
+$ ls -a
+.draftignore  Dockerfile  app.py  chart/  draft.toml  requirements.txt
 ```
 
 The `chart/` and `Dockerfile` assets created by Draft default to a basic Python
@@ -144,6 +144,7 @@ The push refers to a repository [docker.io/microsoft/tufted-lamb]
 ## Great Success!
 
 Now when we run `curl http://tufted-lamb.example.com`, we can see our app has been updated and deployed to Kubernetes automatically!
+
 
 [Installation Guide]: install.md
 [Helm]: https://github.com/kubernetes/helm

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -32,7 +32,7 @@ On minikube, you can simply enable the ingress controller addon
 $ minikube addon enable ingress
 ```
 
-The ingress IP addres is minikube's IP:
+The ingress IP address is minikube's IP:
 
 ```shell
 $ minikube ip

--- a/docs/packs.md
+++ b/docs/packs.md
@@ -16,9 +16,9 @@ starter packs.
 
 ## The Starter Pack Structure
 
-A starter pack is organized inside a directory in `$(draft home)/packs`. Inside the pack's directory,
-there will be a template `chart/` and a `Dockerfile` that will be injected into the application
-when the starter pack is requested.
+A starter pack is organized inside a directory in `$(draft home)/packs`. Inside the pack's
+directory, there will be a template `chart/` and a `Dockerfile` that will be injected into the
+application when the starter pack is requested.
 
 Inside this directory, Draft will expect a structure like this:
 
@@ -60,10 +60,10 @@ See [Helm's documentation on Charts][charts] for more information on the Chart f
 
 ## Pack Detection
 
-When `draft create` is executed on an application, Draft starts iterating through the packs available
-in `$(draft home)/packs`. Each pack optionally has an executable file named `detect` in the root
-directory. The intention of this `detect` script is to determine if the pack should be used with
-the given application.
+When `draft create` is executed on an application, Draft starts iterating through the packs
+available in `$(draft home)/packs`. Each pack optionally has an executable file named `detect` in
+the root directory. The intention of this `detect` script is to determine if the pack should be used
+with the given application.
 
 A detect executable takes one argument: the directory in which `draft create` was executed. The
 executable should be portable across most systems (read: not a Ruby/Python script unless it's
@@ -89,5 +89,6 @@ echo Python
 If a pack does not include a detect executable, it is considered a "loser". Pack detection can be
 overridden with the `--pack` flag. The detect script will not be considered and Draft will bootstrap
 the app with the pack, no questions asked.
+
 
 [charts]: https://github.com/kubernetes/helm/blob/master/docs/charts.md

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,9 +5,9 @@ built-in Draft codebase. This guide explains how to use and create plugins.
 
 ## An Overview
 
-Draft plugins are add-on tools that integrate seamlessly with Draft. They provide a way to extend the
-core feature set of Draft, but without requiring every new feature to be written in Go and added to
-the core tool.
+Draft plugins are add-on tools that integrate seamlessly with Draft. They provide a way to extend
+the core feature set of Draft, but without requiring every new feature to be written in Go and added
+to the core tool.
 
 Draft plugins have the following features:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -37,9 +37,9 @@ that in a second.
 ```
 
 This is the environment name. Applications deployed by Draft can be configured in different manners
-based on the present environment. By default, `draft up` deploys using the `development` environment,
-but this can be tweaked by either setting `$DRAFT_ENV` or by supplying the environment name at
-runtime using `draft up --environment=staging`.
+based on the present environment. By default, `draft up` deploys using the `development`
+environment, but this can be tweaked by either setting `$DRAFT_ENV` or by supplying the environment
+name at runtime using `draft up --environment=staging`.
 
 ```
     name = "draft"
@@ -63,7 +63,9 @@ Here is a run-down on each of the fields:
  - `watch`: whether or not to deploy the app automatically when local files change.
  - `watch_delay`: the delay for local file changes to have stopped before deploying again (in seconds).
 
-Note: All updates to the `draft.toml` will take effect the next time `draft up --environment=<affected environment>` is invoked _except_ the `namespace` key/value pair. Once a deployment has occurred in the original namespace, it won't be transferred over to another.
+Note: All updates to the `draft.toml` will take effect the next time
+`draft up --environment=<affected environment>` is invoked _except_ the `namespace` key/value pair.
+Once a deployment has occurred in the original namespace, it won't be transferred over to another.
 
 
 [toml]: https://github.com/toml-lang/toml


### PR DESCRIPTION
closes #82
closes #102
closes #122
closes #152 
closes #167

This is a relatively "large" PR, so here's where we are at today:

- Users can no longer update draft configuration through `-f` and `--set`; user will be prompted for this information instead if required
- `--yes` is available if user wants to auto-accept the defaults
- If "minikube" is detected as the current context in ~/.kube/config, then we assume that they have installed the `ingress` and `registry` addons as well as ran `helm init` after the cluster was created. `draft init` detects this and drops some configuration to use these addons natively

TODO:

 - [x] prompt for missing information
 - [x] update "Getting started" documentation