### PR TITLE
trim whitespace from answer

### DIFF
--- a/cmd/draft/init.go
+++ b/cmd/draft/init.go
@@ -118,6 +118,7 @@ func (i *initCmd) run() error {
 			if err != nil {
 				return fmt.Errorf("Could not read input: %s", err)
 			}
+			text = strings.TrimSpace(text)
 			if text == "" || strings.ToLower(text) == "y" {
 				i.yes = true
 			}


### PR DESCRIPTION
reader.ReadString() includes the delimiter in the returned text, so we need to strip that out.