### PR TITLE
lower replica count to 1

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 basedomain: example.com
-replicaCount: 3
+replicaCount: 1
 image:
   registry: docker.io
   org: microsoft

--- a/cmd/draft/installer/install.go
+++ b/cmd/draft/installer/install.go
@@ -21,7 +21,7 @@ apiVersion: v1
 const draftValues = `# Default values for Draftd.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 3
+replicaCount: 1
 basedomain: example.com
 image:
   registry: docker.io


### PR DESCRIPTION
On clusters like minikube (the large majority of users), resources are limited.
We should make the default replica count as 1, then under `draft init` if a cloud
provider (*cough* Azure *wheeze*) wants to have more replicas running for
redundancy purposes, they can.