### PR TITLE
add insecure registry to dind

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -43,6 +43,8 @@ spec:
             port: {{ .Values.service.http.internalPort }}
       - name: dind
         image: docker:17.05.0-ce-dind
+        args:
+        - --insecure-registry=10.0.0.0/24
         securityContext:
             privileged: true
         volumeMounts:

--- a/cmd/draft/installer/install.go
+++ b/cmd/draft/installer/install.go
@@ -120,6 +120,8 @@ spec:
             port: {{ .Values.service.http.internalPort }}
       - name: dind
         image: docker:17.05.0-ce-dind
+        args:
+        - --insecure-registry=10.0.0.0/24
         securityContext:
             privileged: true
         volumeMounts:


### PR DESCRIPTION
fixes docker push to minikube local registry

should be applied to `v0.5.0` as well