### PR TITLE
select storage driver as overlay

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         image: docker:17.05.0-ce-dind
         args:
         - --insecure-registry=10.0.0.0/24
+        env:
+        - name: DOCKER_DRIVER
+          value: overlay
         securityContext:
             privileged: true
         volumeMounts:

--- a/cmd/draft/installer/install.go
+++ b/cmd/draft/installer/install.go
@@ -122,6 +122,9 @@ spec:
         image: docker:17.05.0-ce-dind
         args:
         - --insecure-registry=10.0.0.0/24
+        env:
+        - name: DOCKER_DRIVER
+          value: overlay
         securityContext:
             privileged: true
         volumeMounts:


### PR DESCRIPTION
this significantly increases performance and fixes the issue where vfs on overlayfs was causing the disk to fill up rapidly on minikube.

closes #181 
closes #182 