### PR TITLE
Add swift support

### DIFF
--- a/examples/example-swift/.gitattributes
+++ b/examples/example-swift/.gitattributes
@@ -1,0 +1,2 @@
+*.swift linguist-language=Swift
+Package.pins linguist-language=Swift

--- a/examples/example-swift/Package.pins
+++ b/examples/example-swift/Package.pins
@@ -1,0 +1,108 @@
+{
+  "autoPin": true,
+  "pins": [
+    {
+      "package": "CLibreSSL",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/clibressl.git",
+      "version": "1.0.0"
+    },
+    {
+      "package": "Console",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/console.git",
+      "version": "1.0.2"
+    },
+    {
+      "package": "Core",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/core.git",
+      "version": "1.1.2"
+    },
+    {
+      "package": "Crypto",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/crypto.git",
+      "version": "1.1.0"
+    },
+    {
+      "package": "Engine",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/engine.git",
+      "version": "1.3.13"
+    },
+    {
+      "package": "Fluent",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/fluent.git",
+      "version": "1.4.3"
+    },
+    {
+      "package": "JSON",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/json.git",
+      "version": "1.0.6"
+    },
+    {
+      "package": "Jay",
+      "reason": null,
+      "repositoryURL": "https://github.com/DanToml/Jay.git",
+      "version": "1.0.1"
+    },
+    {
+      "package": "Leaf",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/leaf.git",
+      "version": "1.0.7"
+    },
+    {
+      "package": "Node",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/node.git",
+      "version": "1.0.1"
+    },
+    {
+      "package": "PathIndexable",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/path-indexable.git",
+      "version": "1.0.0"
+    },
+    {
+      "package": "Polymorphic",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/polymorphic.git",
+      "version": "1.0.1"
+    },
+    {
+      "package": "Routing",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/routing.git",
+      "version": "1.1.0"
+    },
+    {
+      "package": "Socks",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/socks.git",
+      "version": "1.2.7"
+    },
+    {
+      "package": "TLS",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/tls.git",
+      "version": "1.1.2"
+    },
+    {
+      "package": "Turnstile",
+      "reason": null,
+      "repositoryURL": "https://github.com/stormpath/Turnstile.git",
+      "version": "1.0.6"
+    },
+    {
+      "package": "Vapor",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/vapor.git",
+      "version": "1.1.13"
+    }
+  ],
+  "version": 1
+}

--- a/examples/example-swift/Package.swift
+++ b/examples/example-swift/Package.swift
@@ -1,0 +1,10 @@
+// swift-tools-version:3.1
+
+import PackageDescription
+
+let package = Package(
+    name: "swifthw",
+    dependencies: [
+        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 1)
+    ]
+)

--- a/examples/example-swift/Sources/main.swift
+++ b/examples/example-swift/Sources/main.swift
@@ -1,0 +1,8 @@
+import Vapor
+
+let drop = Droplet()
+drop.get("/") { _ in
+  return "Hello from Swift"
+}
+drop.run()
+

--- a/packs/swift/.dockerignore
+++ b/packs/swift/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+draft.toml
+chart/
+NOTICE

--- a/packs/swift/Dockerfile
+++ b/packs/swift/Dockerfile
@@ -1,0 +1,10 @@
+FROM swift
+
+WORKDIR /src
+ONBUILD COPY . /src
+ONBUILD RUN swift build -c release
+
+ENV PORT 8080
+EXPOSE 8080
+
+CMD ["/bin/bash", "-c", "find .build -executable -type f -not -name '*.so'| swift package describe | grep "Type: executable" | head | bash"]

--- a/packs/swift/chart/.helmignore
+++ b/packs/swift/chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/packs/swift/chart/Chart.yaml
+++ b/packs/swift/chart/Chart.yaml
@@ -1,0 +1,4 @@
+name: swift
+description: A Helm chart for Kubernetes
+apiVersion: v1
+version: v0.1.0

--- a/packs/swift/chart/templates/NOTES.txt
+++ b/packs/swift/chart/templates/NOTES.txt
@@ -1,0 +1,15 @@
+
+{{- if contains "NodePort" .Values.service.type }}
+  Get the application URL by running these commands:
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  Get the application URL by running these commands:
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else }}
+  http://{{ .Release.Name }}.{{ .Values.basedomain }} to access your application
+{{- end }}

--- a/packs/swift/chart/templates/_helpers.tpl
+++ b/packs/swift/chart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/packs/swift/chart/templates/deployment.yaml
+++ b/packs/swift/chart/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    draft: {{ default "draft-app" .Values.draft }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        draft: {{ default "draft-app" .Values.draft }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/packs/swift/chart/templates/ingress.yaml
+++ b/packs/swift/chart/templates/ingress.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  rules:
+  - host: {{ .Release.Name }}.{{ .Values.basedomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: {{ .Values.service.externalPort }}
+{{- end -}}

--- a/packs/swift/chart/templates/service.yaml
+++ b/packs/swift/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/packs/swift/chart/values.yaml
+++ b/packs/swift/chart/values.yaml
@@ -1,0 +1,20 @@
+# Default values for Swift.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 2
+image:
+  repository: swift
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  name: swift
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8080
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
supercedes #155
closes #96

blocked until #344 is merged, as without it the example swift app is improperly determined as a different programming language.