### PR TITLE
attach os.Stdin to plugin's stdin

### DIFF
--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -73,7 +73,7 @@ func newRootCmd(out io.Writer, in io.Reader) *cobra.Command {
 	)
 
 	// Find and add plugins
-	loadPlugins(cmd, draftpath.Home(homePath()), out)
+	loadPlugins(cmd, draftpath.Home(homePath()), out, in)
 
 	return cmd
 }

--- a/cmd/draft/plugins.go
+++ b/cmd/draft/plugins.go
@@ -21,7 +21,7 @@ const pluginEnvVar = "DRAFT_PLUGIN"
 // This follows a different pattern than the other commands because it has
 // to inspect its environment and then add commands to the base command
 // as it finds them.
-func loadPlugins(baseCmd *cobra.Command, home draftpath.Home, out io.Writer) {
+func loadPlugins(baseCmd *cobra.Command, home draftpath.Home, out io.Writer, in io.Reader) {
 	plugdirs := os.Getenv(pluginEnvVar)
 	if plugdirs == "" {
 		plugdirs = home.Plugins()
@@ -62,6 +62,7 @@ func loadPlugins(baseCmd *cobra.Command, home draftpath.Home, out io.Writer) {
 				prog.Env = os.Environ()
 				prog.Stdout = out
 				prog.Stderr = os.Stderr
+				prog.Stdin = in
 				if err := prog.Run(); err != nil {
 					if eerr, ok := err.(*exec.ExitError); ok {
 						os.Stderr.Write(eerr.Stderr)

--- a/cmd/draft/plugins_test.go
+++ b/cmd/draft/plugins_test.go
@@ -56,13 +56,14 @@ func TestLoadPlugins(t *testing.T) {
 	ph := draftpath.Home(homePath())
 
 	out := bytes.NewBuffer(nil)
+	in := bytes.NewBuffer(nil)
 	cmd := &cobra.Command{}
 	// add `--home` flag to cmd (which is what cmd.Parent() resolves to for the loaded plugin)
 	// so that it can be overridden in tests below
 	p := cmd.PersistentFlags()
 	p.StringVar(&draftHome, "home", draftHome, "location of your Draft config. Overrides $DRAFT_HOME")
 
-	loadPlugins(cmd, ph, out)
+	loadPlugins(cmd, ph, out, in)
 
 	envs := strings.Join([]string{
 		"fullenv",


### PR DESCRIPTION
closes #206 

Manually tested using the example I provided in #206:

```
><> draft hi
What is your name?
Matt
Hi Matt!
```