### PR TITLE
Fixed Java pack Jar file error

### DIFF
--- a/packs/maven/Dockerfile
+++ b/packs/maven/Dockerfile
@@ -5,6 +5,6 @@ RUN mvn -f /usr/src/app/pom.xml clean package
 
 FROM openjdk:8-jdk-alpine
 EXPOSE 4567
-COPY --from=BUILD /usr/src/app/target/app.jar /opt/app.jar
+COPY --from=BUILD /usr/src/app/target/helloworld.jar /opt/app.jar
 WORKDIR /opt
 CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
The artifact name built was helloworld.jar but the copy command was referring to different name hence build is failing:

```
Step 6/8 : COPY --from=BUILD /usr/src/app/target/app.jar /opt/app.jar
lstat usr/src/app/target/app.jar: no such file or directory
```