### PR TITLE
feat(*): install remote and local plugins

### DIFF
--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -70,6 +70,7 @@ func newRootCmd(out io.Writer, in io.Reader) *cobra.Command {
 		newInitCmd(out, in),
 		newUpCmd(out),
 		newVersionCmd(out),
+		newPluginCmd(out),
 	)
 
 	// Find and add plugins

--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -168,3 +168,10 @@ func debug(format string, args ...interface{}) {
 		fmt.Printf(format, args...)
 	}
 }
+
+func validateArgs(args, expectedArgs []string) error {
+	if len(args) != len(expectedArgs) {
+		return fmt.Errorf("This command needs %v argument(s): %v", len(expectedArgs), expectedArgs)
+	}
+	return nil
+}

--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -161,3 +161,10 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+func debug(format string, args ...interface{}) {
+	if flagDebug {
+		format = fmt.Sprintf("[debug] %s\n", format)
+		fmt.Printf(format, args...)
+	}
+}

--- a/cmd/draft/plugin.go
+++ b/cmd/draft/plugin.go
@@ -166,7 +166,7 @@ func runHook(p *plugin.Plugin, event string) error {
 	// I think its ... ¯\_(ツ)_/¯
 	// prog := exec.Command("cmd", "/C", p.Metadata.Hooks.Install())
 
-	//TODO: debug("running %s hook: %s", event, prog)
+	debug("running %s hook: %s", event, prog)
 
 	home := draftpath.Home(homePath())
 	setupEnv(p.Metadata.Name, p.Dir, home.Plugins(), home)

--- a/cmd/draft/plugin.go
+++ b/cmd/draft/plugin.go
@@ -85,7 +85,7 @@ func loadPlugins(baseCmd *cobra.Command, home draftpath.Home, out io.Writer, in 
 				// Call setupEnv before PrepareCommand because
 				// PrepareCommand uses os.ExpandEnv and expects the
 				// setupEnv vars.
-				setupEnv(md.Name, plug.Dir, plugdirs, draftpath.Home(homePath()))
+				setupPluginEnv(md.Name, plug.Dir, plugdirs, draftpath.Home(homePath()))
 				main, argv := plug.PrepareCommand(u)
 
 				prog := exec.Command(main, argv...)
@@ -169,7 +169,7 @@ func runHook(p *plugin.Plugin, event string) error {
 	debug("running %s hook: %s", event, prog)
 
 	home := draftpath.Home(homePath())
-	setupEnv(p.Metadata.Name, p.Dir, home.Plugins(), home)
+	setupPluginEnv(p.Metadata.Name, p.Dir, home.Plugins(), home)
 	prog.Stdout, prog.Stderr = os.Stdout, os.Stderr
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
@@ -181,11 +181,10 @@ func runHook(p *plugin.Plugin, event string) error {
 	return nil
 }
 
-// setupEnv prepares os.Env for plugins. It operates on os.Env because
+// setupPluginEnv prepares os.Env for plugins. It operates on os.Env because
 // the plugin subsystem itself needs access to the environment variables
 // created here.
-// TODO: change setupEnv to setupPluginEnv
-func setupEnv(shortname, base, plugdirs string, home draftpath.Home) {
+func setupPluginEnv(shortname, base, plugdirs string, home draftpath.Home) {
 	// Set extra env vars:
 	for key, val := range map[string]string{
 		"DRAFT_PLUGIN_NAME": shortname,

--- a/cmd/draft/plugin_install.go
+++ b/cmd/draft/plugin_install.go
@@ -57,16 +57,19 @@ func (pcmd *pluginInstallCmd) run() error {
 	if err != nil {
 		return err
 	}
+
+	debug("installing plugin from %s", pcmd.source)
 	if err := installer.Install(i); err != nil {
 		return err
 	}
 
-	//TODO: debug("loading plugin from %s", i.Path())
+	debug("loading plugin from %s", i.Path())
 	p, err := plugin.LoadDir(i.Path())
 	if err != nil {
 		return err
 	}
 
+	debug("running any install instructions for plugin: %s", p.Metadata.Name)
 	if err := runHook(p, plugin.Install); err != nil {
 		return err
 	}

--- a/cmd/draft/plugin_install.go
+++ b/cmd/draft/plugin_install.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"k8s.io/helm/pkg/plugin"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/plugin/installer"
+)
+
+type pluginInstallCmd struct {
+	source  string
+	version string
+	home    draftpath.Home
+	out     io.Writer
+	args    []string
+}
+
+func newPluginInstallCmd(out io.Writer) *cobra.Command {
+	pcmd := &pluginInstallCmd{
+		out:  out,
+		args: []string{"plugin"},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "install [options] <path|url>...",
+		Short: "install one or more Draft plugins",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return pcmd.complete(args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pcmd.run()
+		},
+	}
+	cmd.Flags().StringVar(&pcmd.version, "version", "", "specify a version constraint. If this is not specified, the latest version is installed")
+	return cmd
+}
+
+func (pcmd *pluginInstallCmd) complete(args []string) error {
+	if len(args) != len(pcmd.args) {
+		//TODO: pull this out into helper func like checkArgsLength but better
+		//TODO: standardize error
+		return fmt.Errorf("This command needs %v argument(s): %v", len(pcmd.args), pcmd.args)
+	}
+	pcmd.source = args[0]
+	pcmd.home = draftpath.Home(homePath())
+	return nil
+}
+
+func (pcmd *pluginInstallCmd) run() error {
+	installer.Debug = flagDebug
+
+	i, err := installer.New(pcmd.source, pcmd.version, pcmd.home)
+	if err != nil {
+		return err
+	}
+	if err := installer.Install(i); err != nil {
+		return err
+	}
+
+	//TODO: debug("loading plugin from %s", i.Path())
+	p, err := plugin.LoadDir(i.Path())
+	if err != nil {
+		return err
+	}
+
+	if err := runHook(p, plugin.Install); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(pcmd.out, "Installed plugin: %s\n", p.Metadata.Name)
+	return nil
+}

--- a/cmd/draft/plugin_install.go
+++ b/cmd/draft/plugin_install.go
@@ -40,10 +40,8 @@ func newPluginInstallCmd(out io.Writer) *cobra.Command {
 }
 
 func (pcmd *pluginInstallCmd) complete(args []string) error {
-	if len(args) != len(pcmd.args) {
-		//TODO: pull this out into helper func like checkArgsLength but better
-		//TODO: standardize error
-		return fmt.Errorf("This command needs %v argument(s): %v", len(pcmd.args), pcmd.args)
+	if err := validateArgs(args, pcmd.args); err != nil {
+		return err
 	}
 	pcmd.source = args[0]
 	pcmd.home = draftpath.Home(homePath())

--- a/cmd/draft/plugin_install_test.go
+++ b/cmd/draft/plugin_install_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+type pluginTest struct {
+	name   string
+	plugin string
+	path   string
+	output string
+	fail   bool
+	flags  []string
+}
+
+func TestPluginInstallCmd(t *testing.T) {
+	// set up draft home
+	old := draftHome
+	defer func() {
+		draftHome = old
+	}()
+
+	dir, err := ioutil.TempDir("", "draft_home-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	draftHome = dir
+	home := draftpath.Home(draftHome)
+
+	if err := os.Mkdir(home.Plugins(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []pluginTest{
+		{
+			name:   "install plugin",
+			plugin: "echo",
+			path:   "testdata/plugins/echo",
+			output: "Installed plugin: echo",
+			fail:   false,
+		},
+		{
+			name:   "error installing nonexistent plugin",
+			plugin: "dummy",
+			path:   "testdata/plugins/dummy",
+			output: "",
+			fail:   true,
+		},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	for _, tt := range tests {
+		cmd := newPluginInstallCmd(buf)
+
+		if err := cmd.PreRunE(cmd, []string{tt.path}); err != nil {
+			t.Errorf("%q reported error: %s", tt.name, err)
+		}
+
+		if err := cmd.RunE(cmd, []string{tt.path}); err != nil && !tt.fail {
+			t.Errorf("%q reported error: %s", tt.name, err)
+		}
+
+		if !tt.fail {
+			result := buf.String()
+			if !strings.Contains(result, tt.output) {
+				t.Errorf("Expected %v, got %v", tt.output, result)
+			}
+
+			if _, err = os.Stat(filepath.Join(home.Plugins(), tt.plugin)); err != nil && os.IsNotExist(err) {
+				t.Errorf("Installed plugin not found: %v", err)
+			}
+
+		}
+
+		buf.Reset()
+	}
+}

--- a/cmd/draft/plugin_install_test.go
+++ b/cmd/draft/plugin_install_test.go
@@ -82,4 +82,10 @@ func TestPluginInstallCmd(t *testing.T) {
 
 		buf.Reset()
 	}
+
+	cmd := newPluginInstallCmd(buf)
+	if err := cmd.PreRunE(cmd, []string{"arg1", "extra arg"}); err == nil {
+		t.Error("Expected failure due to incorrect number of arguments for plugin install command")
+	}
+
 }

--- a/cmd/draft/plugin_list.go
+++ b/cmd/draft/plugin_list.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/gosuri/uitable"
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+type pluginListCmd struct {
+	home draftpath.Home
+	out  io.Writer
+}
+
+func newPluginListCmd(out io.Writer) *cobra.Command {
+	pcmd := &pluginListCmd{out: out}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "list installed Draft plugins",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pcmd.home = draftpath.Home(homePath())
+			return pcmd.run()
+		},
+	}
+	return cmd
+}
+
+func (pcmd *pluginListCmd) run() error {
+	pluginDirs := pluginDirPath(pcmd.home)
+
+	debug("looking for plugins at: %s", pluginDirs)
+	plugins, err := findPlugins(pluginDirs)
+	if err != nil {
+		return err
+	}
+
+	if len(plugins) == 0 {
+		fmt.Fprintln(pcmd.out, "No plugins found")
+		return nil
+	}
+
+	table := uitable.New()
+	table.AddRow("NAME", "VERSION", "DESCRIPTION")
+	for _, p := range plugins {
+		table.AddRow(p.Metadata.Name, p.Metadata.Version, p.Metadata.Description)
+	}
+	fmt.Fprintln(pcmd.out, table)
+	return nil
+}

--- a/cmd/draft/plugin_list_test.go
+++ b/cmd/draft/plugin_list_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+func TestPluginListCmd(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+
+	list := &pluginListCmd{
+		home: draftpath.Home("testdata/drafthome/"),
+		out:  buf,
+	}
+
+	if err := list.run(); err != nil {
+		t.Errorf("draft plugin list error: %v", err)
+	}
+
+	expectedOutput := "NAME   \tVERSION\tDESCRIPTION      \nargs   \t       \tThis echos args  \necho   \t       \tThis echos stuff \nfullenv\t       \tshow all env vars\nhome   \t       \tshow DRAFT_HOME  \n"
+
+	actual := buf.String()
+	if !strings.Contains(actual, expectedOutput) {
+		t.Errorf("Expected %q, Got %q", expectedOutput, actual)
+	}
+}
+
+func TestEmptyResultsOnPluginListCmd(t *testing.T) {
+	target, err := newTestPluginEnv("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	old, err := setupTestPluginEnv(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer teardownTestPluginEnv(target, old)
+
+	buf := bytes.NewBuffer(nil)
+	list := &pluginListCmd{
+		home: draftpath.Home(homePath()),
+		out:  buf,
+	}
+
+	if err := list.run(); err != nil {
+		t.Errorf("draft plugin list error: %v", err)
+	}
+
+	expectedOutput := "No plugins found"
+	actual := buf.String()
+	if !strings.Contains(actual, expectedOutput) {
+		t.Errorf("Expected %s, got %s", expectedOutput, actual)
+	}
+
+}

--- a/cmd/draft/plugin_test.go
+++ b/cmd/draft/plugin_test.go
@@ -149,7 +149,7 @@ func TestSetupEnv(t *testing.T) {
 		flagDebug = false
 	}()
 
-	setupEnv(name, base, plugdirs, ph)
+	setupPluginEnv(name, base, plugdirs, ph)
 	for _, tt := range []struct {
 		name   string
 		expect string

--- a/cmd/draft/plugin_test.go
+++ b/cmd/draft/plugin_test.go
@@ -49,9 +49,12 @@ func TestManuallyProcessArgs(t *testing.T) {
 func TestLoadPlugins(t *testing.T) {
 	// Set draft home to point to testdata
 	old := draftHome
+	oldEnv := os.Getenv(pluginEnvVar)
 	draftHome = "testdata/drafthome"
+	os.Unsetenv(pluginEnvVar)
 	defer func() {
 		draftHome = old
+		os.Setenv(pluginEnvVar, oldEnv)
 	}()
 	ph := draftpath.Home(homePath())
 

--- a/cmd/draft/plugin_test.go
+++ b/cmd/draft/plugin_test.go
@@ -49,12 +49,9 @@ func TestManuallyProcessArgs(t *testing.T) {
 func TestLoadPlugins(t *testing.T) {
 	// Set draft home to point to testdata
 	old := draftHome
-	oldEnv := os.Getenv(pluginEnvVar)
 	draftHome = "testdata/drafthome"
-	os.Unsetenv(pluginEnvVar)
 	defer func() {
 		draftHome = old
-		os.Setenv(pluginEnvVar, oldEnv)
 	}()
 	ph := draftpath.Home(homePath())
 

--- a/cmd/draft/testdata/plugins/echo/plugin.yaml
+++ b/cmd/draft/testdata/plugins/echo/plugin.yaml
@@ -1,0 +1,6 @@
+name: echo
+usage: "echo stuff"
+description: "This echos stuff"
+command: "echo hello"
+hooks:
+    install: "echo installing"

--- a/docs/design.md
+++ b/docs/design.md
@@ -41,7 +41,7 @@ following domains:
 
 - installation of the server (through `draft init`)
 - interacting with the Draft server
-- interacting with [plugins](plugins.md)
+- interacting with [plugins](plugins-guide.md)
 
 The Draft client interacts with the Draft server through the Kubernetes API server, using
 HTTP/Websockets as the communication protocol.

--- a/docs/plugins-guide.md
+++ b/docs/plugins-guide.md
@@ -3,11 +3,12 @@
 A plugin is a tool that can be accessed through the `draft` CLI, but which is not part of the
 built-in Draft codebase. This guide explains how to use and create plugins.
 
+Exisiting plugins can be found on the [draft plugins](#draft-plugins) section of this page or by searching [Github](https://github.com/search?q=topic%3Adraft-plugin&type=Repositories)
+
 ## An Overview
 
 Draft plugins are add-on tools that integrate seamlessly with Draft. They provide a way to extend
-the core feature set of Draft, but without requiring every new feature to be written in Go and added
-to the core tool.
+the core feature set of Draft, but without requiring every new feature to be written in Go and added to the core tool.
 
 Draft plugins have the following features:
 
@@ -18,22 +19,23 @@ Draft plugins have the following features:
 
 Draft plugins live in `$DRAFT_HOME/plugins`.
 
-The Draft plugin model is partially modeled on Git's plugin model. To that end, you may sometimes
-hear `draft` referred to as the _porcelain_ layer, with plugins being the _plumbing_. This is a
-shorthand way of suggesting that Draft provides the user experience and top level processing logic,
-while the plugins do the "detail work" of performing a desired action.
+The Draft plugin model is partially modeled on Git's plugin model. To that end, you may sometimes hear `draft` referred to as the _porcelain_ layer, with plugins being the _plumbing_. This is a shorthand way of suggesting that Draft provides the user experience and top level processing logic, while the plugins do the "detail work" of performing a desired action.
 
 ## Installing a Plugin
 
-A Draft plugin management system is in the works. But in the short term, plugins are installed by
-copying the plugin directory into `$(draft home)/plugins`.
+Plugins are installed using `$draft plugin install <plugin url/path>`. You can pass in a url to a git repository which contains the plugin or you can opt to pass in a local path to a plugin on your machine.
+```console
+$ draft plugin install https://github.com/michelleN/draft-server
+Installed plugin: server
+$ draft plugin list
+NAME  	VERSION	DESCRIPTION
+server	0.1.0  	Helpers for working with in-cluster draftd
+```
 
+Alternatively, you can also copy the plugin directory into `$(draft home)/plugins` by hand which is what the `$draft plugin install <plugin path/url>` command does under the hood.
 ```console
 $ cp -a myplugin/ $(draft home)/plugins/
 ```
-
-If you have a plugin tar distribution, simply untar the plugin into the `$(draft home)/plugins`
-directory.
 
 ## Building Plugins
 
@@ -158,3 +160,8 @@ _not_ passed on to the plugin.
 
 Plugins _should_ display help text and then exit for `-h` and `--help`. In all other cases, plugins
 may use flags as appropriate.
+
+## Draft Plugins
+- [draft-server](https://github.com/michelleN/draft-server) - Additional commands to work with and manage draftd
+
+_Notes: We also encourage Github authors to use the [draft-plugin](https://github.com/search?q=topic%3Adraft-plugin&type=Repositories) tag on their plugin repositories._

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f5a7f23585502f42141b89cfdc8a5c3881f1a308bfc2cea96e37c43b40068524
-updated: 2017-07-26T12:00:22.25440202-04:00
+hash: 8cbb1ca6a2b874649647a8acea3d6a23bd0c0fe57814ea6ee12f6fd6c0067442
+updated: 2017-07-26T15:10:38.787789948-04:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -199,6 +199,8 @@ imports:
   version: 3f0ab6d4ab4bed1c61caf056b63a6e62190c7801
 - name: github.com/Masterminds/sprig
   version: 9526be0327b26ad31aa70296a7b10704883976d5
+- name: github.com/Masterminds/vcs
+  version: 3084677c2c188840777bff30054f2b553729d329
 - name: github.com/Microsoft/go-winio
   version: 8f9387ea7efabb228a981b9c381142be7667967f
 - name: github.com/mitchellh/go-wordwrap
@@ -475,6 +477,7 @@ imports:
   - pkg/ignore
   - pkg/kube
   - pkg/plugin
+  - pkg/plugin/cache
   - pkg/proto/hapi/chart
   - pkg/proto/hapi/release
   - pkg/proto/hapi/services

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8cbb1ca6a2b874649647a8acea3d6a23bd0c0fe57814ea6ee12f6fd6c0067442
-updated: 2017-07-26T15:10:38.787789948-04:00
+hash: 010f114cb7f72ad6b5d106bc3ddb2ceabde6ab724d3f47c43b09d20101cb1b76
+updated: 2017-07-26T15:54:32.289598056-04:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -171,6 +171,11 @@ imports:
   version: 7fe3183ee95b29153898356cc2c6026a8cb7afe5
   repo: https://github.com/bacongobbler/websocket
   vcs: git
+- name: github.com/gosuri/uitable
+  version: 36ee7e946282a3fb1cfecd476ddc9b35d8847e42
+  subpackages:
+  - util/strutil
+  - util/wordwrap
 - name: github.com/hashicorp/golang-lru
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
@@ -201,6 +206,8 @@ imports:
   version: 9526be0327b26ad31aa70296a7b10704883976d5
 - name: github.com/Masterminds/vcs
   version: 3084677c2c188840777bff30054f2b553729d329
+- name: github.com/mattn/go-runewidth
+  version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/Microsoft/go-winio
   version: 8f9387ea7efabb228a981b9c381142be7667967f
 - name: github.com/mitchellh/go-wordwrap

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,3 +35,4 @@ import:
   version: ~0.8.0
 - package: github.com/Masterminds/vcs
   version: ^1.11.1
+- package: github.com/gosuri/uitable

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,6 @@
 package: github.com/Azure/draft
 import:
 - package: github.com/BurntSushi/toml
-
 - package: github.com/Azure/go-ansiterm
   version: 388960b655244e76e24c75f48631564eaefade62
 - package: github.com/docker/distribution
@@ -12,7 +11,6 @@ import:
   version: v17.05.0-ce
 - package: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
-
 - package: github.com/emicklei/go-restful
   version: v1.2
 - package: github.com/ghodss/yaml
@@ -35,3 +33,5 @@ import:
   version: ~0.11.5
 - package: github.com/pkg/errors
   version: ~0.8.0
+- package: github.com/Masterminds/vcs
+  version: ^1.11.1

--- a/pkg/draft/draftpath/home.go
+++ b/pkg/draft/draftpath/home.go
@@ -9,19 +9,26 @@ import (
 // This helper builds paths relative to a Draft Home directory.
 type Home string
 
-// String returns Home as a string.
-//
-// Implements fmt.Stringer.
-func (h Home) String() string {
-	return string(h)
-}
-
 // Packs returns the path to the Draft starter packs.
 func (h Home) Packs() string {
 	return filepath.Join(string(h), "packs")
 }
 
+// Path returns Home with elements appended.
+func (h Home) Path(elem ...string) string {
+	p := []string{h.String()}
+	p = append(p, elem...)
+	return filepath.Join(p...)
+}
+
 // Plugins returns the path to the Draft plugins.
 func (h Home) Plugins() string {
 	return filepath.Join(string(h), "plugins")
+}
+
+// String returns Home as a string.
+//
+// Implements fmt.Stringer.
+func (h Home) String() string {
+	return string(h)
 }

--- a/pkg/plugin/installer/base.go
+++ b/pkg/plugin/installer/base.go
@@ -1,0 +1,37 @@
+package installer // import "github.com/Azure/draft/pkg/plugin/installer"
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+type base struct {
+	// Source is the reference to a plugin
+	Source string
+
+	//TODO: change DraftHome to ProjectHome or something more generic
+	// or add ProjectHomeEnv as an attribute
+
+	// DraftHome is the $DRAFT_HOME directory
+	DraftHome draftpath.Home
+}
+
+func newBase(source string, home draftpath.Home) base {
+	return base{source, home}
+}
+
+// link creates a symlink from the plugin source to $DRAFT_HOME
+func (b *base) link(from string) error {
+	//debug("symlinking %s to %s", from, b.Path())
+	return os.Symlink(from, b.Path())
+}
+
+// Path is where the plugin will be symlinked to.
+func (b *base) Path() string {
+	if b.Source == "" {
+		return ""
+	}
+	return filepath.Join(b.DraftHome.Plugins(), filepath.Base(b.Source))
+}

--- a/pkg/plugin/installer/base.go
+++ b/pkg/plugin/installer/base.go
@@ -11,9 +11,6 @@ type base struct {
 	// Source is the reference to a plugin
 	Source string
 
-	//TODO: change DraftHome to ProjectHome or something more generic
-	// or add ProjectHomeEnv as an attribute
-
 	// DraftHome is the $DRAFT_HOME directory
 	DraftHome draftpath.Home
 }

--- a/pkg/plugin/installer/installer.go
+++ b/pkg/plugin/installer/installer.go
@@ -58,7 +58,6 @@ func debug(format string, args ...interface{}) {
 
 // isLocalReference checks if the source exists on the filesystem.
 func isLocalReference(source string) bool {
-	//TODO: can user install a local plugin using "."?
 	_, err := os.Stat(source)
 	return err == nil
 }

--- a/pkg/plugin/installer/installer.go
+++ b/pkg/plugin/installer/installer.go
@@ -1,0 +1,70 @@
+package installer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+// special thanks to the Kubernets Helm plugin installer pkg
+
+// ErrMissingMetadata indicates that plugin.yaml is missing.
+var ErrMissingMetadata = errors.New("plugin metadata (plugin.yaml) missing")
+
+// Debug enables verbose output.
+var Debug bool
+
+// Installer provides an interface for installing client plugins.
+type Installer interface {
+	// Install adds a plugin to a path
+	Install() error
+	// Path is the directory of the installed plugin.
+	Path() string
+}
+
+// Install installs a plugin to $DRAFT_HOME
+func Install(i Installer) error {
+	if _, pathErr := os.Stat(path.Dir(i.Path())); os.IsNotExist(pathErr) {
+
+		return errors.New(`plugin home "$DRAFT_HOME/plugins" does not exist`)
+	}
+
+	if _, pathErr := os.Stat(i.Path()); !os.IsNotExist(pathErr) {
+		return errors.New("plugin already exists")
+	}
+
+	return i.Install()
+}
+
+// New determines and returns the correct Installer for the given source
+func New(source, version string, home draftpath.Home) (Installer, error) {
+	if isLocalReference(source) {
+		return NewLocalInstaller(source, home)
+	}
+
+	return NewVCSInstaller(source, version, home)
+}
+
+func debug(format string, args ...interface{}) {
+	if Debug {
+		format = fmt.Sprintf("[debug] %s\n", format)
+		fmt.Printf(format, args...)
+	}
+}
+
+// isLocalReference checks if the source exists on the filesystem.
+func isLocalReference(source string) bool {
+	//TODO: can user install a local plugin using "."?
+	_, err := os.Stat(source)
+	return err == nil
+}
+
+// isPlugin checks if the directory contains a plugin.yaml file.
+func isPlugin(dirname string) bool {
+	_, err := os.Stat(filepath.Join(dirname, "plugin.yaml"))
+	return err == nil
+}

--- a/pkg/plugin/installer/local_installer.go
+++ b/pkg/plugin/installer/local_installer.go
@@ -1,0 +1,36 @@
+package installer
+
+import (
+	"path/filepath"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+// LocalInstaller installs plugins from the filesystem
+type LocalInstaller struct {
+	base
+}
+
+// NewLocalInstaller creates a new LocalInstaller
+func NewLocalInstaller(source string, home draftpath.Home) (*LocalInstaller, error) {
+
+	i := &LocalInstaller{
+		base: newBase(source, home),
+	}
+
+	return i, nil
+}
+
+// Install creates a symlink to the plugin directory in $HELM_HOME
+func (i *LocalInstaller) Install() error {
+	if !isPlugin(i.Source) {
+		return ErrMissingMetadata
+	}
+
+	src, err := filepath.Abs(i.Source)
+	if err != nil {
+		return err
+	}
+
+	return i.link(src)
+}

--- a/pkg/plugin/installer/local_installer_test.go
+++ b/pkg/plugin/installer/local_installer_test.go
@@ -1,0 +1,51 @@
+package installer
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+var _ Installer = new(LocalInstaller)
+
+func TestLocalInstaller(t *testing.T) {
+	dh, err := ioutil.TempDir("", "draft-home-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dh)
+
+	home := draftpath.Home(dh)
+	if err := os.MkdirAll(home.Plugins(), 0755); err != nil {
+		t.Fatalf("Could not create %s: %s", home.Plugins(), err)
+	}
+
+	// Make a temp dir
+	tdir, err := ioutil.TempDir("", "draft-installer-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(tdir)
+
+	if err := ioutil.WriteFile(filepath.Join(tdir, "plugin.yaml"), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	source := "../testdata/plugdir/echo"
+	i, err := New(source, "", home)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if err := Install(i); err != nil {
+		t.Error(err)
+	}
+
+	if i.Path() != home.Path("plugins", "echo") {
+		t.Errorf("expected path '$DRAFT_HOME/plugins/draft-env', got %q", i.Path())
+	}
+}

--- a/pkg/plugin/installer/vcs_installer.go
+++ b/pkg/plugin/installer/vcs_installer.go
@@ -1,0 +1,133 @@
+package installer
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/Masterminds/semver"
+	"github.com/Masterminds/vcs"
+	"k8s.io/helm/pkg/plugin/cache"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+//VCSInstaller installs plugins from a remote repository
+type VCSInstaller struct {
+	Repo    vcs.Repo
+	Version string
+	base
+}
+
+// NewVCSInstaller creates a new VCSInstaller.
+func NewVCSInstaller(source, version string, home draftpath.Home) (*VCSInstaller, error) {
+	// create a system safe cache key
+	key, err := cache.Key(source)
+	if err != nil {
+		return nil, err
+	}
+	cachedpath := home.Path("cache", "plugins", key)
+	repo, err := vcs.NewRepo(source, cachedpath)
+	if err != nil {
+		return nil, err
+	}
+	i := &VCSInstaller{
+		Repo:    repo,
+		Version: version,
+		base:    newBase(source, home),
+	}
+	return i, err
+}
+
+// Install clones a remote repository and creates a symlink to the plugin directory in DRAFT_HOME
+//
+// Implements Installer
+func (i *VCSInstaller) Install() error {
+	if err := i.sync(i.Repo); err != nil {
+		return err
+	}
+
+	ref, err := i.solveVersion(i.Repo)
+	if err != nil {
+		return err
+	}
+
+	if err := i.setVersion(i.Repo, ref); err != nil {
+		return err
+	}
+
+	if !isPlugin(i.Repo.LocalPath()) {
+		return ErrMissingMetadata
+	}
+
+	return i.link(i.Repo.LocalPath())
+}
+
+// Filter a list of versions to only included semantic versions. The response
+// is a mapping of the original version to the semantic version.
+func getSemVers(refs []string) []*semver.Version {
+	var sv []*semver.Version
+	for _, r := range refs {
+		if v, err := semver.NewVersion(r); err == nil {
+			sv = append(sv, v)
+		}
+	}
+	return sv
+}
+
+// setVersion attempts to checkout the version
+func (i *VCSInstaller) setVersion(repo vcs.Repo, ref string) error {
+	debug("setting version to %q", i.Version)
+	return repo.UpdateVersion(ref)
+}
+
+func (i *VCSInstaller) solveVersion(repo vcs.Repo) (string, error) {
+	if i.Version == "" {
+		return "", nil
+	}
+
+	if repo.IsReference(i.Version) {
+		return i.Version, nil
+	}
+
+	// Create the constraint first to make sure it's valid before
+	// working on the repo.
+	constraint, err := semver.NewConstraint(i.Version)
+	if err != nil {
+		return "", err
+	}
+
+	// Get the tags
+	refs, err := repo.Tags()
+	if err != nil {
+		return "", err
+	}
+	debug("found refs: %s", refs)
+
+	// Convert and filter the list to semver.Version instances
+	semvers := getSemVers(refs)
+
+	// Sort semver list
+	sort.Sort(sort.Reverse(semver.Collection(semvers)))
+	for _, v := range semvers {
+		if constraint.Check(v) {
+			// If the constrint passes get the original reference
+			ver := v.Original()
+			debug("setting to %s", ver)
+			return ver, nil
+		}
+	}
+
+	return "", fmt.Errorf("requested version %q does not exist for plugin %q", i.Version, i.Repo.Remote())
+}
+
+// sync will clone or update a remote repo.
+func (i *VCSInstaller) sync(repo vcs.Repo) error {
+
+	if _, err := os.Stat(repo.LocalPath()); os.IsNotExist(err) {
+		debug("cloning %s to %s", repo.Remote(), repo.LocalPath())
+		return repo.Get()
+	}
+	debug("updating %s", repo.Remote())
+	return repo.Update()
+}

--- a/pkg/plugin/installer/vcs_installer_test.go
+++ b/pkg/plugin/installer/vcs_installer_test.go
@@ -1,0 +1,84 @@
+package installer
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Masterminds/vcs"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+var _ Installer = new(VCSInstaller)
+
+type testRepo struct {
+	local, remote, current string
+	tags, branches         []string
+	err                    error
+	vcs.Repo
+}
+
+func (r *testRepo) LocalPath() string           { return r.local }
+func (r *testRepo) Remote() string              { return r.remote }
+func (r *testRepo) Update() error               { return r.err }
+func (r *testRepo) Get() error                  { return r.err }
+func (r *testRepo) IsReference(string) bool     { return false }
+func (r *testRepo) Tags() ([]string, error)     { return r.tags, r.err }
+func (r *testRepo) Branches() ([]string, error) { return r.branches, r.err }
+func (r *testRepo) UpdateVersion(version string) error {
+	r.current = version
+	return r.err
+}
+
+func TestVCSInstallerSuccess(t *testing.T) {
+	dh, err := ioutil.TempDir("", "draft-home-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dh)
+
+	home := draftpath.Home(dh)
+	if err := os.MkdirAll(home.Plugins(), 0755); err != nil {
+		t.Fatalf("Could not create %s: %s", home.Plugins(), err)
+	}
+
+	source := "https://github.com/org/draft-env"
+	testRepoPath, _ := filepath.Abs("../testdata/plugdir/echo")
+	repo := &testRepo{
+		local: testRepoPath,
+		tags:  []string{"0.1.0", "0.1.1"},
+	}
+
+	i, err := New(source, "~0.1.0", home)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// ensure a VCSInstaller was returned
+	vcsInstaller, ok := i.(*VCSInstaller)
+	if !ok {
+		t.Error("expected a VCSInstaller")
+	}
+
+	// set the testRepo in the VCSInstaller
+	vcsInstaller.Repo = repo
+
+	if err := Install(i); err != nil {
+		t.Error(err)
+	}
+	if repo.current != "0.1.1" {
+		t.Errorf("expected version '0.1.1', got %q", repo.current)
+	}
+	if i.Path() != home.Path("plugins", "draft-env") {
+		t.Errorf("expected path '$DRAFT_HOME/plugins/draft-env', got %q", i.Path())
+	}
+
+	// Install again to test plugin exists error
+	if err := Install(i); err == nil {
+		t.Error("expected error for plugin exists, got none")
+	} else if err.Error() != "plugin already exists" {
+		t.Errorf("expected error for plugin exists, got (%v)", err)
+	}
+}

--- a/pkg/plugin/testdata/plugdir/echo/plugin.yaml
+++ b/pkg/plugin/testdata/plugdir/echo/plugin.yaml
@@ -1,0 +1,8 @@
+name: "echo"
+version: "1.2.3"
+usage: "echo something"
+description: |-
+  This is a testing fixture. Thank you Helm.
+command: "echo Hello"
+hooks:
+  install: "echo Installing"


### PR DESCRIPTION
This implements the plugin install command. The bulk of this
creates a plugin installer specific for the Draft environment and
it creates the plugin install command with the proper setup.
Addresses #185 by creating a framework for a plugin manager.