### PR TITLE
use go fmt best practices for import statements

### DIFF
--- a/pkg/draft/context.go
+++ b/pkg/draft/context.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
-	"github.com/Azure/draft/pkg/rpc"
 	"io"
-)
 
-// helm imports
-import (
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/strvals"
+
+	"github.com/Azure/draft/pkg/rpc"
 )
 
 type AppContext struct {

--- a/pkg/draft/server.go
+++ b/pkg/draft/server.go
@@ -4,36 +4,26 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/draft/pkg/rpc"
-	"golang.org/x/net/context"
 	"net"
 	"net/http"
 	"os"
 	"strings"
 	"sync"
 	"time"
-)
 
-// kubernetes imports
-import (
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8s "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
-)
-
-// docker imports
-import (
 	"github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/term"
-)
-
-// helm imports
-import (
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/release"
+
+	"github.com/Azure/draft/pkg/rpc"
 )
 
 type (


### PR DESCRIPTION
Most of the codebase is of the form

    import (
        stdlib

        thirdparty

        firstparty
    )

This makes the import statements overall more readable. This is also
how `go fmt` formats import statements.