### PR TITLE
implement `draft pack-repo`

### DIFF
--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -70,6 +70,7 @@ func newRootCmd(out io.Writer, in io.Reader) *cobra.Command {
 		newInitCmd(out, in),
 		newUpCmd(out),
 		newVersionCmd(out),
+		newPackManCmd(out),
 		newPluginCmd(out),
 		newConnectCmd(out),
 	)

--- a/cmd/draft/pack_man.go
+++ b/cmd/draft/pack_man.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+var packManHelp = `The Draft Pack Manager.
+`
+
+func newPackManCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pack-man",
+		Short: "manage Draft Packs",
+		Long:  packManHelp,
+	}
+	cmd.AddCommand(
+		newPackManAddCmd(out),
+		newPackManListCmd(out),
+		// newPackManRemoveCmd(out),
+		newPackManUpdateCmd(out),
+	)
+	return cmd
+}

--- a/cmd/draft/pack_man_add.go
+++ b/cmd/draft/pack_man_add.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/draft/pack/repo"
+	"github.com/Azure/draft/pkg/draft/pack/repo/installer"
+)
+
+type packManAddCmd struct {
+	out    io.Writer
+	err    io.Writer
+	source string
+	home   draftpath.Home
+}
+
+func newPackManAddCmd(out io.Writer) *cobra.Command {
+	add := &packManAddCmd{out: out}
+
+	cmd := &cobra.Command{
+		Use:   "add [flags] <path|url>",
+		Short: "Add a Pack repository",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return add.complete(args)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return add.run()
+		},
+	}
+	return cmd
+}
+
+func (a *packManAddCmd) complete(args []string) error {
+	if err := validateArgs(args, []string{"path|url"}); err != nil {
+		return err
+	}
+	a.source = args[0]
+	a.home = draftpath.Home(homePath())
+	return nil
+}
+
+func (a *packManAddCmd) run() error {
+	i, err := installer.New(a.source, "", a.home)
+	if err != nil {
+		return err
+	}
+
+	debug("installing pack repo from %s", a.source)
+	if err := installer.Install(i); err != nil {
+		return err
+	}
+
+	p := repo.Repository{
+		Name: filepath.Base(i.Path()),
+		Dir:  filepath.Dir(i.Path()),
+	}
+
+	fmt.Fprintf(a.out, "Installed pack repository %s\n", p.Name)
+	return nil
+}

--- a/cmd/draft/pack_man_list.go
+++ b/cmd/draft/pack_man_list.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/gosuri/uitable"
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/draft/pkg/draft/pack/repo"
+)
+
+type packManListCmd struct {
+	out  io.Writer
+	home draftpath.Home
+}
+
+func newPackManListCmd(out io.Writer) *cobra.Command {
+	list := &packManListCmd{out: out}
+
+	cmd := &cobra.Command{
+		Use:   "list [flags]",
+		Short: "List all installed pack repositories.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			list.home = draftpath.Home(homePath())
+			return list.run()
+		},
+	}
+	return cmd
+}
+
+func (l *packManListCmd) run() error {
+	repos := repo.FindRepositories(l.home.Packs())
+	if len(repos) == 0 {
+		return errors.New("no pack repositories to show")
+	}
+	table := uitable.New()
+	table.AddRow("NAME", "PATH")
+	for i := range repos {
+		table.AddRow(repos[i].Name, repos[i].Dir)
+	}
+	fmt.Fprintln(l.out, table)
+	return nil
+}

--- a/cmd/draft/pack_man_update.go
+++ b/cmd/draft/pack_man_update.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/draft/pack/repo"
+	"github.com/Azure/draft/pkg/draft/pack/repo/installer"
+)
+
+type packManUpdateCmd struct {
+	out    io.Writer
+	err    io.Writer
+	source string
+	home   draftpath.Home
+}
+
+func newPackManUpdateCmd(out io.Writer) *cobra.Command {
+	upd := &packManUpdateCmd{out: out}
+
+	cmd := &cobra.Command{
+		Use:   "update [flags]",
+		Short: "Fetch the newest version of all packs using git.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			upd.home = draftpath.Home(homePath())
+			return upd.run()
+		},
+	}
+	return cmd
+}
+
+func (upd *packManUpdateCmd) run() error {
+
+	repos := repo.FindRepositories(upd.home.Packs())
+	if len(repos) == 0 {
+		fmt.Fprintf(upd.out, "No pack repositories found to update. All up to date!")
+		return nil
+	}
+	var updatedRepoNames []string
+	for i := range repos {
+		exactLocation, err := filepath.EvalSymlinks(repos[i].Dir)
+		if err != nil {
+			return err
+		}
+		absExactLocation, err := filepath.Abs(exactLocation)
+		if err != nil {
+			return err
+		}
+
+		i, err := installer.FindSource(absExactLocation, upd.home)
+		if err != nil {
+			return err
+		}
+		if err := installer.Update(i); err != nil {
+			return err
+		}
+		updatedRepoNames = append(updatedRepoNames, filepath.Base(i.Path()))
+	}
+	repoMsg := "Updated %d pack repository %v\n"
+	if len(repos) > 1 {
+		repoMsg = "Updated %d pack repositories %v\n"
+	}
+	fmt.Fprintf(upd.out, repoMsg, len(repos), updatedRepoNames)
+	return nil
+}

--- a/pkg/draft/draftpath/home.go
+++ b/pkg/draft/draftpath/home.go
@@ -1,6 +1,7 @@
 package draftpath
 
 import (
+	"os"
 	"path/filepath"
 )
 
@@ -9,9 +10,11 @@ import (
 // This helper builds paths relative to a Draft Home directory.
 type Home string
 
-// Packs returns the path to the Draft starter packs.
-func (h Home) Packs() string {
-	return filepath.Join(string(h), "packs")
+// String returns Home as a string.
+//
+// Implements fmt.Stringer.
+func (h Home) String() string {
+	return os.ExpandEnv(string(h))
 }
 
 // Path returns Home with elements appended.
@@ -21,14 +24,12 @@ func (h Home) Path(elem ...string) string {
 	return filepath.Join(p...)
 }
 
-// Plugins returns the path to the Draft plugins.
-func (h Home) Plugins() string {
-	return filepath.Join(string(h), "plugins")
+// Packs returns the path to the Draft starter packs.
+func (h Home) Packs() string {
+	return h.Path("packs")
 }
 
-// String returns Home as a string.
-//
-// Implements fmt.Stringer.
-func (h Home) String() string {
-	return string(h)
+// Plugins returns the path to the Draft plugins.
+func (h Home) Plugins() string {
+	return h.Path("plugins")
 }

--- a/pkg/draft/pack/repo/installer/installer.go
+++ b/pkg/draft/pack/repo/installer/installer.go
@@ -1,0 +1,94 @@
+package installer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/plugin/installer"
+)
+
+// ErrMissingPackDir indicates that the packs dir is missing.
+var ErrMissingPackDir = errors.New("packs dir missing or not found")
+
+type base struct {
+	// Source is the reference to a pack repo
+	Source string
+
+	// DraftHome is the $DRAFT_HOME directory
+	DraftHome draftpath.Home
+}
+
+func newBase(source string, home draftpath.Home) base {
+	return base{source, home}
+}
+
+// link creates a symlink from the pack repo source to $DRAFT_HOME
+func (b *base) link(from string) error {
+	//debug("symlinking %s to %s", from, b.Path())
+	return os.Symlink(from, b.Path())
+}
+
+// Path is where the pack repo will be symlinked to.
+func (b *base) Path() string {
+	if b.Source == "" {
+		return ""
+	}
+	return filepath.Join(b.DraftHome.Packs(), filepath.Base(b.Source))
+}
+
+// isPackRepo checks if the directory contains a packs directory.
+func isPackRepo(dirname string) bool {
+	fi, err := os.Stat(filepath.Join(dirname, "packs"))
+	return err == nil && fi.IsDir()
+}
+
+// isLocalReference checks if the source exists on the filesystem.
+func isLocalReference(source string) bool {
+	_, err := os.Stat(source)
+	return err == nil
+}
+
+// Install installs a pack repo to $DRAFT_HOME
+func Install(i installer.Installer) error {
+	if _, pathErr := os.Stat(path.Dir(i.Path())); os.IsNotExist(pathErr) {
+
+		return fmt.Errorf("pack home %s does not exist", path.Dir(i.Path()))
+	}
+
+	if _, pathErr := os.Stat(i.Path()); !os.IsNotExist(pathErr) {
+		return errors.New("pack repo already exists")
+	}
+
+	return i.Install()
+}
+
+// Update updates a pack repo in $DRAFT_HOME.
+func Update(i installer.Installer) error {
+	if _, pathErr := os.Stat(i.Path()); os.IsNotExist(pathErr) {
+		return errors.New("pack repo does not exist")
+	}
+
+	return i.Update()
+}
+
+// FindSource determines the correct Installer for the given source.
+func FindSource(location string, home draftpath.Home) (installer.Installer, error) {
+	installer, err := existingVCSRepo(location, home)
+	if err != nil && err.Error() == "Cannot detect VCS" {
+		return installer, errors.New("cannot get information about pack repo source")
+	}
+	return installer, err
+}
+
+// New determines and returns the correct Installer for the given source
+func New(source, version string, home draftpath.Home) (installer.Installer, error) {
+	if isLocalReference(source) {
+		return NewLocalInstaller(source, home)
+	}
+
+	return NewVCSInstaller(source, version, home)
+}

--- a/pkg/draft/pack/repo/installer/local_installer.go
+++ b/pkg/draft/pack/repo/installer/local_installer.go
@@ -1,0 +1,41 @@
+package installer
+
+import (
+	"path/filepath"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+)
+
+// LocalInstaller installs pack repos from the filesystem
+type LocalInstaller struct {
+	base
+}
+
+// NewLocalInstaller creates a new LocalInstaller
+func NewLocalInstaller(source string, home draftpath.Home) (*LocalInstaller, error) {
+
+	i := &LocalInstaller{
+		base: newBase(source, home),
+	}
+
+	return i, nil
+}
+
+// Install creates a symlink to the pack repo directory in $DRAFT_HOME
+func (i *LocalInstaller) Install() error {
+	if !isPackRepo(i.Source) {
+		return ErrMissingPackDir
+	}
+
+	src, err := filepath.Abs(i.Source)
+	if err != nil {
+		return err
+	}
+
+	return i.link(src)
+}
+
+// Update updates a local repository
+func (i *LocalInstaller) Update() error {
+	return nil
+}

--- a/pkg/draft/pack/repo/installer/local_installer_test.go
+++ b/pkg/draft/pack/repo/installer/local_installer_test.go
@@ -1,0 +1,47 @@
+package installer
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/plugin/installer"
+)
+
+var _ installer.Installer = new(LocalInstaller)
+
+func TestLocalInstaller(t *testing.T) {
+	dh, err := ioutil.TempDir("", "draft-home-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dh)
+
+	home := draftpath.Home(dh)
+	if err := os.MkdirAll(home.Packs(), 0755); err != nil {
+		t.Fatalf("Could not create %s: %s", home.Packs(), err)
+	}
+
+	// Make a temp dir
+	tdir, err := ioutil.TempDir("", "draft-installer-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(tdir)
+
+	source := "../testdata/packdir/defaultpacks"
+	i, err := New(source, "", home)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	if err := Install(i); err != nil {
+		t.Error(err)
+	}
+
+	if i.Path() != home.Path("packs", "defaultpacks") {
+		t.Errorf("expected path '$DRAFT_HOME/packs/defaultpacks', got %q", i.Path())
+	}
+}

--- a/pkg/draft/pack/repo/installer/vcs_installer.go
+++ b/pkg/draft/pack/repo/installer/vcs_installer.go
@@ -1,0 +1,158 @@
+package installer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/Masterminds/semver"
+	"github.com/Masterminds/vcs"
+	"k8s.io/helm/pkg/plugin/cache"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/plugin/installer"
+)
+
+//VCSInstaller installs packs from a remote repository
+type VCSInstaller struct {
+	Repo    vcs.Repo
+	Version string
+	base
+}
+
+// NewVCSInstaller creates a new VCSInstaller.
+func NewVCSInstaller(source, version string, home draftpath.Home) (*VCSInstaller, error) {
+	// create a system safe cache key
+	key, err := cache.Key(source)
+	if err != nil {
+		return nil, err
+	}
+	cachedpath := home.Path("cache", "packs", key)
+	repo, err := vcs.NewRepo(source, cachedpath)
+	if err != nil {
+		return nil, err
+	}
+
+	i := &VCSInstaller{
+		Repo:    repo,
+		Version: version,
+		base:    newBase(source, home),
+	}
+	return i, err
+}
+
+// Install clones a remote repository and creates a symlink to the pack repo directory in DRAFT_HOME
+//
+// Implements Installer
+func (i *VCSInstaller) Install() error {
+	if err := i.sync(i.Repo); err != nil {
+		return err
+	}
+
+	ref, err := i.solveVersion(i.Repo)
+	if err != nil {
+		return err
+	}
+
+	if err := i.setVersion(i.Repo, ref); err != nil {
+		return err
+	}
+
+	if !isPackRepo(i.Repo.LocalPath()) {
+		return ErrMissingPackDir
+	}
+
+	return i.link(i.Repo.LocalPath())
+}
+
+// Update updates a remote repository
+func (i *VCSInstaller) Update() error {
+	if i.Repo.IsDirty() {
+		return errors.New("pack repo was modified")
+	}
+	if err := i.Repo.Update(); err != nil {
+		return err
+	}
+	if !isPackRepo(i.Repo.LocalPath()) {
+		return ErrMissingPackDir
+	}
+	return nil
+}
+
+func existingVCSRepo(location string, home draftpath.Home) (installer.Installer, error) {
+	repo, err := vcs.NewRepo("", location)
+	if err != nil {
+		return nil, err
+	}
+	i := &VCSInstaller{
+		Repo: repo,
+		base: newBase(repo.Remote(), home),
+	}
+
+	return i, err
+}
+
+// Filter a list of versions to only included semantic versions. The response
+// is a mapping of the original version to the semantic version.
+func getSemVers(refs []string) []*semver.Version {
+	var sv []*semver.Version
+	for _, r := range refs {
+		if v, err := semver.NewVersion(r); err == nil {
+			sv = append(sv, v)
+		}
+	}
+	return sv
+}
+
+// setVersion attempts to checkout the version
+func (i *VCSInstaller) setVersion(repo vcs.Repo, ref string) error {
+	return repo.UpdateVersion(ref)
+}
+
+func (i *VCSInstaller) solveVersion(repo vcs.Repo) (string, error) {
+	if i.Version == "" {
+		return "", nil
+	}
+
+	if repo.IsReference(i.Version) {
+		return i.Version, nil
+	}
+
+	// Create the constraint first to make sure it's valid before
+	// working on the repo.
+	constraint, err := semver.NewConstraint(i.Version)
+	if err != nil {
+		return "", err
+	}
+
+	// Get the tags
+	refs, err := repo.Tags()
+	if err != nil {
+		return "", err
+	}
+
+	// Convert and filter the list to semver.Version instances
+	semvers := getSemVers(refs)
+
+	// Sort semver list
+	sort.Sort(sort.Reverse(semver.Collection(semvers)))
+	for _, v := range semvers {
+		if constraint.Check(v) {
+			// If the constrint passes get the original reference
+			ver := v.Original()
+			return ver, nil
+		}
+	}
+
+	return "", fmt.Errorf("requested version %q does not exist for pack repo %q", i.Version, i.Repo.Remote())
+}
+
+// sync will clone or update a remote repo.
+func (i *VCSInstaller) sync(repo vcs.Repo) error {
+
+	if _, err := os.Stat(repo.LocalPath()); os.IsNotExist(err) {
+		return repo.Get()
+	}
+	return repo.Update()
+}

--- a/pkg/draft/pack/repo/installer/vcs_installer_test.go
+++ b/pkg/draft/pack/repo/installer/vcs_installer_test.go
@@ -1,0 +1,149 @@
+package installer
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Masterminds/vcs"
+
+	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/plugin/installer"
+)
+
+var _ installer.Installer = new(VCSInstaller)
+
+type testRepo struct {
+	local, remote, current string
+	tags, branches         []string
+	err                    error
+	vcs.Repo
+}
+
+func (r *testRepo) LocalPath() string           { return r.local }
+func (r *testRepo) Remote() string              { return r.remote }
+func (r *testRepo) Update() error               { return r.err }
+func (r *testRepo) Get() error                  { return r.err }
+func (r *testRepo) IsReference(string) bool     { return false }
+func (r *testRepo) Tags() ([]string, error)     { return r.tags, r.err }
+func (r *testRepo) Branches() ([]string, error) { return r.branches, r.err }
+func (r *testRepo) UpdateVersion(version string) error {
+	r.current = version
+	return r.err
+}
+
+func TestVCSInstallerSuccess(t *testing.T) {
+	dh, err := ioutil.TempDir("", "draft-home-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dh)
+
+	home := draftpath.Home(dh)
+	if err := os.MkdirAll(home.Packs(), 0755); err != nil {
+		t.Fatalf("Could not create %s: %s", home.Packs(), err)
+	}
+
+	source := "https://github.com/org/defaultpacks"
+	testRepoPath, _ := filepath.Abs("../testdata/packdir/defaultpacks")
+	repo := &testRepo{
+		local: testRepoPath,
+		tags:  []string{"0.1.0", "0.1.1"},
+	}
+
+	i, err := New(source, "~0.1.0", home)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// ensure a VCSInstaller was returned
+	vcsInstaller, ok := i.(*VCSInstaller)
+	if !ok {
+		t.Error("expected a VCSInstaller")
+	}
+
+	// set the testRepo in the VCSInstaller
+	vcsInstaller.Repo = repo
+
+	if err := Install(i); err != nil {
+		t.Error(err)
+	}
+	if repo.current != "0.1.1" {
+		t.Errorf("expected version '0.1.1', got %q", repo.current)
+	}
+	if i.Path() != home.Path("packs", "defaultpacks") {
+		t.Errorf("expected path '$DRAFT_HOME/packs/defaultpacks', got %q", i.Path())
+	}
+
+	// Install again to test pack repo exists error
+	if err := Install(i); err == nil {
+		t.Error("expected error for pack repo exists, got none")
+	} else if err.Error() != "pack repo already exists" {
+		t.Errorf("expected error for pack repo exists, got (%v)", err)
+	}
+}
+
+func TestVCSInstallerUpdate(t *testing.T) {
+
+	dh, err := ioutil.TempDir("", "draft-home-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dh)
+
+	home := draftpath.Home(dh)
+	if err := os.MkdirAll(home.Packs(), 0755); err != nil {
+		t.Fatalf("Could not create %s: %s", home.Packs(), err)
+	}
+
+	// Draft can install itself. Pretty neat eh?
+	source := "https://github.com/Azure/draft"
+	i, err := New(source, "0.6.0", home)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// ensure a VCSInstaller was returned
+	_, ok := i.(*VCSInstaller)
+	if !ok {
+		t.Error("expected a VCSInstaller")
+	}
+
+	if err := Update(i); err == nil {
+		t.Error("expected error for pack repo does not exist, got none")
+	} else if err.Error() != "pack repo does not exist" {
+		t.Errorf("expected error for pack repo does not exist, got (%v)", err)
+	}
+
+	// Install pack repo before update
+	if err := Install(i); err != nil {
+		t.Error(err)
+	}
+
+	// Test FindSource method for positive result
+	packInfo, err := FindSource(i.Path(), home)
+	if err != nil {
+		t.Error(err)
+	}
+
+	repoRemote := packInfo.(*VCSInstaller).Repo.Remote()
+	if repoRemote != source {
+		t.Errorf("invalid source found, expected %q got %q", source, repoRemote)
+	}
+
+	// Update pack repo
+	if err := Update(i); err != nil {
+		t.Error(err)
+	}
+
+	// Test update failure
+	os.Remove(filepath.Join(i.Path(), "README.md"))
+	// Testing update for error
+	if err := Update(i); err == nil {
+		t.Error("expected error for pack repo modified, got none")
+	} else if err.Error() != "pack repo was modified" {
+		t.Errorf("expected error for pack repo modified, got (%v)", err)
+	}
+
+}

--- a/pkg/draft/pack/repo/repo.go
+++ b/pkg/draft/pack/repo/repo.go
@@ -1,0 +1,31 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Repository represents a pack repository.
+type Repository struct {
+	Name string
+	Dir  string
+}
+
+// FindRepositories takes a given path and returns a list of repositories.
+//
+// Repositories are defined as directories with a "packs" directory present.
+func FindRepositories(path string) []Repository {
+	var repos []Repository
+	filepath.Walk(path, func(walkPath string, f os.FileInfo, err error) error {
+		// find all directories in walkPath that have a child directory called "packs"
+		if f.IsDir() && f.Name() == "packs" && walkPath != path {
+			repos = append(repos, Repository{
+				Name: filepath.Base(filepath.Dir(walkPath)),
+				Dir:  strings.TrimSuffix(walkPath, "/"+f.Name()),
+			})
+		}
+		return nil
+	})
+	return repos
+}


### PR DESCRIPTION
closes #2

TODO:

- [x] implement `draft pack-repo remove`
- [ ] install the default packs into `~/.draft/packs/default/packs` on `draft init`
- [x] ~~figure out pack detection when multiple packs support the same language type (will require further discussion)~~ deferred to https://github.com/Azure/draft/issues/308
- [x] rip out into its own plugin
- [x] call it `draft pack-repo`