### PR TITLE
use test-unit target

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,9 +84,6 @@ node('linux') {
 
     stage('Test') {
       sh 'make test'
-      withCredentials(wrapId('CODECOV_TOKEN', codecovToken)) {
-        sh 'curl -s https://codecov.io/bash | bash -s - -t $CODECOV_TOKEN'
-      }
     }
 
     stage('Build') {

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ clean:
 
 .PHONY: test
 test: TESTFLAGS += -race -v
-test: test-lint test-cover
+test: test-lint test-unit
 
 test-cover:
 	scripts/cover.sh


### PR DESCRIPTION
`make test-cover` takes over 17 minutes on #269. Removing it will help unblock some CI builds.

```
><> time ./scripts/cover.sh
ok  	github.com/Azure/draft/cmd/draft	6.222s	coverage: 37.2% of statements
ok  	github.com/Azure/draft/cmd/draft/installer	1.642s	coverage: 0.0% of statements
?   	github.com/Azure/draft/cmd/draft/installer/config	[no test files]
?   	github.com/Azure/draft/cmd/draftd	[no test files]
?   	github.com/Azure/draft/examples/go	[no test files]
?   	github.com/Azure/draft/pkg/build	[no test files]
?   	github.com/Azure/draft/pkg/cmdline	[no test files]
ok  	github.com/Azure/draft/pkg/draft	1.860s	coverage: 6.4% of statements
ok  	github.com/Azure/draft/pkg/draft/draftpath	1.019s	coverage: 50.0% of statements
ok  	github.com/Azure/draft/pkg/draft/local	1.658s	coverage: 10.8% of statements
ok  	github.com/Azure/draft/pkg/draft/manifest	1.013s	coverage: 100.0% of statements
ok  	github.com/Azure/draft/pkg/draft/pack	1.086s	coverage: 83.1% of statements
?   	github.com/Azure/draft/pkg/draft/pack/generated	[no test files]
?   	github.com/Azure/draft/pkg/draftd/portforwarder	[no test files]
?   	github.com/Azure/draft/pkg/kube	[no test files]
?   	github.com/Azure/draft/pkg/kube/podutil	[no test files]
ok  	github.com/Azure/draft/pkg/linguist	1.170s	coverage: 40.3% of statements
ok  	github.com/Azure/draft/pkg/osutil	1.019s	coverage: 83.3% of statements
ok  	github.com/Azure/draft/pkg/plugin/installer	1.713s	coverage: 77.0% of statements
?   	github.com/Azure/draft/pkg/rpc	[no test files]
?   	github.com/Azure/draft/pkg/testing/helpers	[no test files]
ok  	github.com/Azure/draft/pkg/version	1.016s	coverage: 100.0% of statements

real	5m22.533s
user	17m37.082s
sys	1m55.250s
><> time make test-unit
go test  -cover -run . ./cmd/... ./examples/... ./pkg/...
ok  	github.com/Azure/draft/cmd/draft	2.046s	coverage: 37.2% of statements
ok  	github.com/Azure/draft/cmd/draft/installer	0.139s	coverage: 0.0% of statements
?   	github.com/Azure/draft/cmd/draft/installer/config	[no test files]
?   	github.com/Azure/draft/cmd/draftd	[no test files]
?   	github.com/Azure/draft/examples/go	[no test files]
?   	github.com/Azure/draft/pkg/build	[no test files]
?   	github.com/Azure/draft/pkg/cmdline	[no test files]
ok  	github.com/Azure/draft/pkg/draft	0.194s	coverage: 6.4% of statements
ok  	github.com/Azure/draft/pkg/draft/draftpath	0.008s	coverage: 50.0% of statements
ok  	github.com/Azure/draft/pkg/draft/local	0.110s	coverage: 10.8% of statements
ok  	github.com/Azure/draft/pkg/draft/manifest	0.016s	coverage: 100.0% of statements
ok  	github.com/Azure/draft/pkg/draft/pack	0.027s	coverage: 83.1% of statements
?   	github.com/Azure/draft/pkg/draft/pack/generated	[no test files]
?   	github.com/Azure/draft/pkg/draftd/portforwarder	[no test files]
?   	github.com/Azure/draft/pkg/kube	[no test files]
?   	github.com/Azure/draft/pkg/kube/podutil	[no test files]
ok  	github.com/Azure/draft/pkg/linguist	0.021s	coverage: 39.5% of statements
ok  	github.com/Azure/draft/pkg/osutil	0.012s	coverage: 83.3% of statements
ok  	github.com/Azure/draft/pkg/plugin/installer	1.643s	coverage: 77.0% of statements
?   	github.com/Azure/draft/pkg/rpc	[no test files]
?   	github.com/Azure/draft/pkg/testing/helpers	[no test files]
ok  	github.com/Azure/draft/pkg/version	0.006s	coverage: 100.0% of statements

real	0m39.130s
user	2m37.338s
sys	0m21.592s
```