### PR TITLE
do not log requests from kubernetes liveness/readiness probes for python/ruby apps

### DIFF
--- a/examples/python/app.py
+++ b/examples/python/app.py
@@ -1,9 +1,45 @@
-from flask import Flask
-app = Flask(__name__)
+import logging
+import logging.config
+import os
+import sys
+import time
 
-@app.route('/')
+from flask import Flask, request
+
+RUNNING_IN_KUBERNETES = 'KUBERNETES_SERVICE_HOST' in os.environ
+
+app = Flask(__name__)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.INFO)
+app.logger.addHandler(handler)
+
+# disable flask's default request logger
+werkzeug_logger = logging.getLogger('werkzeug')
+werkzeug_logger.setLevel(logging.ERROR)
+
+logging.getLogger().setLevel(logging.INFO)
+
+@app.route('/', methods=['GET'])
 def hello_world():
     return "Hello, World!\n"
 
+@app.after_request
+def log_after(response):
+    # check if the request was made from a kubernetes liveness/readiness probe
+    if RUNNING_IN_KUBERNETES:
+        if request.headers.get('User-Agent') == 'Go-http-client/1.1':
+            return response
+    app.logger.info('%s %s %s %s %s %s',
+        time.strftime('[%Y-%b-%d %H:%M]'),
+        request.remote_addr,
+        request.method,
+        request.scheme,
+        request.full_path,
+        response.status)
+    return response
+
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8080)
+    host = '0.0.0.0'
+    port = int(os.environ.get('PORT', '8080'))
+    app.logger.info('Serving on http://%s:%d', host, port)
+    app.run(host=host, port=port)

--- a/examples/ruby/Gemfile
+++ b/examples/ruby/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'sinatra'
+gem 'thin'

--- a/examples/ruby/Gemfile.lock
+++ b/examples/ruby/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    daemons (1.2.4)
+    eventmachine (1.2.5)
     mustermann (1.0.0)
     rack (2.0.3)
     rack-protection (2.0.0)
@@ -10,6 +12,10 @@ GEM
       rack (~> 2.0)
       rack-protection (= 2.0.0)
       tilt (~> 2.0)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     tilt (2.0.7)
 
 PLATFORMS
@@ -17,6 +23,7 @@ PLATFORMS
 
 DEPENDENCIES
   sinatra
+  thin
 
 BUNDLED WITH
    1.15.0

--- a/examples/ruby/app.rb
+++ b/examples/ruby/app.rb
@@ -1,8 +1,26 @@
 require 'sinatra'
+require 'logger'
 
-set :bind, '0.0.0.0'
-set :port, 8080
+configure do
+  set :bind, '0.0.0.0'
+  set :port, 8080
+  disable :logging
+  logger = Logger.new STDOUT
+  logger.level = Logger::INFO
+  logger.datetime_format = '%a %d-%m-%Y %H%M '
+  set :logger, logger
+end
 
 get '/' do
   'Hello World, I\'m Ruby!'
+end
+
+after do
+  # disable logging for kubernetes liveness/readiness probes
+  if ENV.has_key? "KUBERNETES_SERVICE_HOST"
+    if request.user_agent == 'Go-http-client/1.1'
+      return
+    end
+  end
+  settings.logger.info "#{response.status} #{response.body}"
 end


### PR DESCRIPTION
This PR took WAY longer than it needed to. Basically it looks to see if we $KUBERNETES_SERVICE_HOST is present, and if so, disable logging from any requests coming from Kubernetes that is identified with the user agent `Go-http-client/1.1`.

I wish we could be more specific on the incoming requests, but it doesn't seem like that's possible.

closes https://github.com/Azure/draft/issues/328