### PR TITLE
remove redundant/confusing default values in packs

### DIFF
--- a/cmd/draft/testdata/create/generated/empty/charts/go/values.yaml
+++ b/cmd/draft/testdata/create/generated/empty/charts/go/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: golang
-  tag: onbuild
   pullPolicy: IfNotPresent
 service:
   name: golang

--- a/cmd/draft/testdata/create/generated/simple-go-with-draftignore/charts/go/values.yaml
+++ b/cmd/draft/testdata/create/generated/simple-go-with-draftignore/charts/go/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: golang
-  tag: onbuild
   pullPolicy: IfNotPresent
 service:
   name: golang

--- a/cmd/draft/testdata/create/generated/simple-go/charts/go/values.yaml
+++ b/cmd/draft/testdata/create/generated/simple-go/charts/go/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: golang
-  tag: onbuild
   pullPolicy: IfNotPresent
 service:
   name: golang

--- a/cmd/draft/testdata/drafthome/packs/github.com/Azure/draft/packs/go/charts/values.yaml
+++ b/cmd/draft/testdata/drafthome/packs/github.com/Azure/draft/packs/go/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: golang
-  tag: onbuild
   pullPolicy: IfNotPresent
 service:
   name: golang

--- a/packs/csharp/charts/values.yaml
+++ b/packs/csharp/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: microsoft/aspnetcore-build
-  tag: 1.1
   pullPolicy: IfNotPresent
 service:
   name: dotnetcore

--- a/packs/go/charts/values.yaml
+++ b/packs/go/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: golang
-  tag: onbuild
   pullPolicy: IfNotPresent
 service:
   name: golang

--- a/packs/gradle/charts/values.yaml
+++ b/packs/gradle/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: openjdk
-  tag: 8-jdk-alpine
   pullPolicy: IfNotPresent
 service:
   name: java

--- a/packs/java/charts/values.yaml
+++ b/packs/java/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: openjdk
-  tag: 8-jdk-alpine
   pullPolicy: IfNotPresent
 service:
   name: java

--- a/packs/javascript/charts/values.yaml
+++ b/packs/javascript/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: node
-  tag: onbuild
   pullPolicy: IfNotPresent
 service:
   name: node

--- a/packs/php/charts/values.yaml
+++ b/packs/php/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: php
-  tag: 7.1-apache
   pullPolicy: IfNotPresent
 service:
   name: php

--- a/packs/python/charts/values.yaml
+++ b/packs/python/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: python
-  tag: onbuild
   pullPolicy: IfNotPresent
 service:
   name: python

--- a/packs/ruby/charts/values.yaml
+++ b/packs/ruby/charts/values.yaml
@@ -3,8 +3,6 @@
 # Declare variables to be passed into your templates.
 replicaCount: 2
 image:
-  repository: ruby
-  tag: onbuild
   pullPolicy: IfNotPresent
 service:
   name: ruby


### PR DESCRIPTION
For the new pack developer, it's not known that these values are overwritten on `draft up`. Removing these will make it easier for new pack devs to approach pack development.