### PR TITLE
feat(cmd/draft): implement draft delete

### DIFF
--- a/cmd/draft/delete.go
+++ b/cmd/draft/delete.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	"github.com/Azure/draft/pkg/draft/local"
+)
+
+const deleteDesc = `This command deletes an application from your Kubernetes environment.`
+
+type deleteCmd struct {
+	appName string
+	out     io.Writer
+}
+
+func newDeleteCmd(out io.Writer) *cobra.Command {
+	dc := &deleteCmd{
+		out: out,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete [app]",
+		Short: "delete an application",
+		Long:  deleteDesc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				dc.appName = args[0]
+			}
+			return dc.run()
+		},
+	}
+
+	return cmd
+}
+
+func (d *deleteCmd) run() error {
+
+	var name string
+
+	if d.appName != "" {
+		name = d.appName
+	} else {
+		deployedApp, err := local.DeployedApplication(draftToml, defaultDraftEnvironment())
+		if err != nil {
+			return errors.New("Unable to detect app name\nPlesae pass in the name of the application")
+
+		}
+
+		name = deployedApp.Name
+	}
+
+	//TODO: replace with serverside call
+	if err := Delete(name); err != nil {
+		return err
+	}
+
+	msg := "app '" + name + "' deleted"
+	fmt.Fprintln(d.out, msg)
+	return nil
+}
+
+// Delete uses the helm client to delete an app with the given name
+//
+// Returns an error if the command failed.
+func Delete(app string) error {
+	// set up helm client
+	client, clientConfig, err := getKubeClient(kubeContext)
+	if err != nil {
+		return fmt.Errorf("Could not get a kube client: %s", err)
+	}
+	restClientConfig, err := clientConfig.ClientConfig()
+	if err != nil {
+		return fmt.Errorf("Could not retrieve client config from the kube client: %s", err)
+	}
+
+	helmClient, err := setupHelm(client, restClientConfig)
+	if err != nil {
+		return err
+	}
+
+	// delete helm release
+	_, err = helmClient.DeleteRelease(app)
+	if err != nil {
+		return errors.New(grpc.ErrorDesc(err))
+	}
+
+	return nil
+}

--- a/cmd/draft/delete_test.go
+++ b/cmd/draft/delete_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestDelete(t *testing.T) {
+
+	testCases := []struct {
+		src     string
+		wantErr bool
+	}{
+		{"testdata/delete/src/simple-go-error", true},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("delete", tc.src), func(t *testing.T) {
+			delete := &deleteCmd{
+				appName: "",
+				out:     os.Stdout,
+			}
+			err := delete.run()
+
+			// Error checking
+			if err != nil != tc.wantErr {
+				t.Errorf("draft delete error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+
+		})
+	}
+}

--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -72,6 +72,7 @@ func newRootCmd(out io.Writer, in io.Reader) *cobra.Command {
 		newVersionCmd(out),
 		newPluginCmd(out),
 		newConnectCmd(out),
+		newDeleteCmd(out),
 	)
 
 	// Find and add plugins

--- a/cmd/draft/testdata/delete/src/simple-go-error/main.go
+++ b/cmd/draft/testdata/delete/src/simple-go-error/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello World, I'm Golang!")
+}
+
+func main() {
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
This implementation of `draft delete` calls helm from the draft client. We should really be calling delete from the server, so this is a temporary implementation. The interface/experience should not change but it makes more sense to call delete from server after #379 is in place which gives us the ability to query if an application exists.