### PR TITLE
add global flag `--draft-namespace`

### DIFF
--- a/cmd/draft/delete.go
+++ b/cmd/draft/delete.go
@@ -78,7 +78,7 @@ func Delete(app string) error {
 		return fmt.Errorf("Could not retrieve client config from the kube client: %s", err)
 	}
 
-	helmClient, err := setupHelm(client, restClientConfig)
+	helmClient, err := setupHelm(client, restClientConfig, draftNamespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/draft/init.go
+++ b/cmd/draft/init.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/helm/portforwarder"
 	"k8s.io/helm/pkg/kube"
-	"k8s.io/helm/pkg/tiller/environment"
 
 	"github.com/Azure/draft/cmd/draft/installer"
 	installerConfig "github.com/Azure/draft/cmd/draft/installer/config"
@@ -108,7 +107,7 @@ func (i *initCmd) run() error {
 			return fmt.Errorf("Could not retrieve client config from the kube client: %s", err)
 		}
 
-		i.helmClient, err = setupHelm(client, restClientConfig)
+		i.helmClient, err = setupHelm(client, restClientConfig, draftNamespace)
 		if err != nil {
 			return err
 		}
@@ -158,7 +157,7 @@ func (i *initCmd) run() error {
 		if err := installer.Uninstall(i.helmClient); err != nil {
 			log.Debugf("error uninstalling Draft: %s", err)
 		}
-		if err := installer.Install(i.helmClient, rawChartConfig); err != nil {
+		if err := installer.Install(i.helmClient, draftNamespace, rawChartConfig); err != nil {
 			return fmt.Errorf("error installing Draft: %s", err)
 		}
 		fmt.Fprintln(i.out, "Draft has been installed into your Kubernetes Cluster.")
@@ -304,8 +303,8 @@ func (i *initCmd) setupDraftHome() error {
 	return nil
 }
 
-func setupTillerConnection(client kubernetes.Interface, restClientConfig *restclient.Config) (*kube.Tunnel, error) {
-	tunnel, err := portforwarder.New(environment.DefaultTillerNamespace, client, restClientConfig)
+func setupTillerConnection(client kubernetes.Interface, restClientConfig *restclient.Config, namespace string) (*kube.Tunnel, error) {
+	tunnel, err := portforwarder.New(namespace, client, restClientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("Could not get a connection to tiller: %s\nPlease ensure you have run `helm init`", err)
 	}
@@ -328,8 +327,8 @@ func setupBasedomain(out io.Writer, reader *bufio.Reader, ingress bool, draftCon
 	return nil
 }
 
-func setupHelm(kubeClient *kubernetes.Clientset, restClientConfig *restclient.Config) (*helm.Client, error) {
-	tunnel, err := setupTillerConnection(kubeClient, restClientConfig)
+func setupHelm(kubeClient *kubernetes.Clientset, restClientConfig *restclient.Config, namespace string) (*helm.Client, error) {
+	tunnel, err := setupTillerConnection(kubeClient, restClientConfig, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/draft/installer/install.go
+++ b/cmd/draft/installer/install.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 
 	"github.com/Azure/draft/pkg/version"
-	"k8s.io/helm/pkg/tiller/environment"
 )
 
 // ReleaseName is the name of the release used when installing/uninstalling draft via helm.
@@ -207,14 +206,14 @@ var DefaultChartFiles = []*chartutil.BufferedFile{
 // Install uses the helm client to install Draftd with the given config.
 //
 // Returns an error if the command failed.
-func Install(client *helm.Client, rawChartConfig string) error {
+func Install(client *helm.Client, namespace string, rawChartConfig string) error {
 	chart, err := chartutil.LoadFiles(DefaultChartFiles)
 	if err != nil {
 		return err
 	}
 	_, err = client.InstallReleaseFromChart(
 		chart,
-		environment.DefaultTillerNamespace,
+		namespace,
 		helm.ReleaseName(ReleaseName),
 		helm.ValueOverrides([]byte(rawChartConfig)))
 	return prettyError(err)


### PR DESCRIPTION
This allows `draft` to communicate with Draftd installed in a different namespace than kube-system. This will also install Draftd in that same namespace so it may be installed with Tiller in that same namespace. Users can use `export DRAFT_NAMESPACE=foo` so they don't have to always specify it every time.

closes #357 