### PR TITLE
implement SymlinkWithFallback

### DIFF
--- a/pkg/draft/pack/repo/installer/local_installer.go
+++ b/pkg/draft/pack/repo/installer/local_installer.go
@@ -1,11 +1,11 @@
 package installer
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/Azure/draft/pkg/draft/draftpath"
 	"github.com/Azure/draft/pkg/draft/pack/repo"
+	"github.com/Azure/draft/pkg/osutil"
 )
 
 // LocalInstaller installs pack repos from the filesystem
@@ -42,7 +42,7 @@ func (i *LocalInstaller) Install() error {
 		return err
 	}
 
-	return os.Symlink(src, i.Path())
+	return osutil.SymlinkWithFallback(src, i.Path())
 }
 
 // Update updates a local repository

--- a/pkg/draft/pack/repo/installer/vcs_installer.go
+++ b/pkg/draft/pack/repo/installer/vcs_installer.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/draft/pkg/draft/draftpath"
 	"github.com/Azure/draft/pkg/draft/pack/repo"
+	"github.com/Azure/draft/pkg/osutil"
 	"github.com/Azure/draft/pkg/plugin/installer"
 )
 
@@ -78,7 +79,7 @@ func (i *VCSInstaller) Install() error {
 		return err
 	}
 
-	return os.Symlink(i.Repo.LocalPath(), i.Path())
+	return osutil.SymlinkWithFallback(i.Repo.LocalPath(), i.Path())
 }
 
 // Update updates a remote repository

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -2,6 +2,8 @@ package osutil
 
 import (
 	"os"
+	"runtime"
+	"syscall"
 )
 
 // Exists returns whether the given file or directory exists or not.
@@ -14,4 +16,22 @@ func Exists(path string) (bool, error) {
 		return false, nil
 	}
 	return true, err
+}
+
+// SymlinkWithFallback attempts to symlink a file or directory, but falls back to a move operation
+// in the event of the user not having the required privileges to create the symlink.
+func SymlinkWithFallback(oldname, newname string) (err error) {
+	err = os.Symlink(oldname, newname)
+	if runtime.GOOS == "windows" {
+		// If creating the symlink fails on Windows because the user
+		// does not have the required privileges, ignore the error and
+		// fall back to renaming the file.
+		//
+		// ERROR_PRIVILEGE_NOT_HELD is 0x522:
+		// https://msdn.microsoft.com/en-us/library/windows/desktop/ms681385(v=vs.85).aspx
+		if lerr, ok := err.(*os.LinkError); ok && lerr.Err == syscall.Errno(0x522) {
+			err = os.Rename(oldname, newname)
+		}
+	}
+	return
 }

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -3,6 +3,8 @@ package osutil
 import (
 	"io/ioutil"
 	"os"
+	"path"
+	"runtime"
 	"testing"
 )
 
@@ -26,5 +28,47 @@ func TestExists(t *testing.T) {
 	}
 	if exists {
 		t.Error("expected tempfile to NOT exist")
+	}
+}
+
+func TestSymlinkWithFallback(t *testing.T) {
+	const (
+		oldFileName = "foo.txt"
+		newFileName = "bar.txt"
+	)
+	tmpDir, err := ioutil.TempDir("", "osutil")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	oldFileNamePath := path.Join(tmpDir, oldFileName)
+	newFileNamePath := path.Join(tmpDir, newFileName)
+
+	oldFile, err := os.Create(path.Join(tmpDir, oldFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldFile.Close()
+
+	if err := SymlinkWithFallback(oldFileNamePath, newFileNamePath); err != nil {
+		t.Errorf("expected no error when calling SymlinkWithFallback() on a file that exists, got %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		exists, err := Exists(oldFileNamePath)
+		if err != nil {
+			t.Errorf("expected no error when calling Exists() on a file that does not exist, got %v", err)
+		}
+		if exists {
+			// check that newFileName is a symlink. If this succeeds, then we are running this test as a
+			// user that has permission to create symbolic links, so the old file should still exist.
+			newFile, err := os.Lstat(newFileNamePath)
+			if err != nil {
+				t.Error(err)
+			}
+			if newFile.Mode() != os.ModeSymlink {
+				t.Errorf("expected %s to be removed when %s is not a symbolic link", oldFileNamePath, newFileNamePath)
+			}
+		}
 	}
 }

--- a/pkg/plugin/installer/base.go
+++ b/pkg/plugin/installer/base.go
@@ -1,10 +1,10 @@
 package installer // import "github.com/Azure/draft/pkg/plugin/installer"
 
 import (
-	"os"
 	"path/filepath"
 
 	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/osutil"
 )
 
 type base struct {
@@ -22,7 +22,7 @@ func newBase(source string, home draftpath.Home) base {
 // link creates a symlink from the plugin source to $DRAFT_HOME
 func (b *base) link(from string) error {
 	//debug("symlinking %s to %s", from, b.Path())
-	return os.Symlink(from, b.Path())
+	return osutil.SymlinkWithFallback(from, b.Path())
 }
 
 // Path is where the plugin will be symlinked to.


### PR DESCRIPTION
This function attempts to create a symbolic link, but falls back to os.Rename() when the user does not have permission to create symbolic links (e.g. Windows non-administrators).

closes #401