### PR TITLE
use CircleCI's Workflow feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,3 +30,11 @@ jobs:
       - run:
           name: Deploy to Azure
           command: .circleci/deploy-azure.sh
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+        filters:
+          tags:
+            only: /.*/

--- a/docs/contributing/release-checklist.md
+++ b/docs/contributing/release-checklist.md
@@ -207,25 +207,9 @@ git tag $RELEASE_NAME-rc1
 git push upstream $RELEASE_NAME-rc1
 ```
 
-~~Jenkins will automatically create a tagged release image and client binary to test with.~~
+CircleCI will automatically create a tagged release image and client binary to test with.
 
-At the present time, [Jenkins does not support](https://issues.jenkins-ci.org/browse/JENKINS-34395)
-building releases from tags, so it is up to the release maintainer to create the release candidate
-binaries themselves and upload the docker image to DockerHub. This can be done by running
-
-```
-make clean
-make bootstrap
-make build-cross
-VERSION=$RELEASE_NAME-rc1 make dist checksum
-DOCKER_REGISTRY=docker.io IMAGE_PREFIX=microsoft VERSION=$RELEASE_NAME-rc1 make docker-binary docker-build docker-push
-```
-
-Afterwards, the release maintainer will need to upload the binaries and checksums to Azure Blob
-Storage. If the release maintainer does not have access to the container, PM @bacongobbler for
-more information.
-
-For testers, the process to start testing after Jenkins finishes building the artifacts involves
+For testers, the process to start testing after CircleCI finishes building the artifacts involves
 the following steps to grab the client from Azure Blob Storage:
 
 linux/amd64, using /bin/bash:


### PR DESCRIPTION
CircleCI recently changed how tags are being triggered and have now switched over to shutting off tag builds by default.

As per https://circleci.com/docs/2.0/configuration-reference/#tags

> 1. For a branch push unaffected by any filters, CircleCI runs the job.
> 2. For a tag push unaffected by any filters, CircleCI skips the job.

> Item two above means that a job must have a `filters` `tags` section to run as a part of a tag push and all its transitively dependent jobs must also have a `filters` `tags` section.