### PR TITLE
drop Windows support from install guide

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -33,7 +33,6 @@ Canary releases of the Draft client can be found at the following links:
 
  - [Linux amd64](https://azuredraft.blob.core.windows.net/draft/draft-canary-linux-amd64.tar.gz)
  - [macOS amd64](https://azuredraft.blob.core.windows.net/draft/draft-canary-darwin-amd64.tar.gz)
- - [Windows amd64](https://azuredraft.blob.core.windows.net/draft/draft-canary-darwin-amd64.tar.gz)
 
 It can also be installed with
 


### PR DESCRIPTION
due to #406 we should drop Windows from the install guide. We'll continue to build and release Windows binaries, but given its current state we shouldn't "support" it until we can fix these showstoppers.