### PR TITLE
add another indentation level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,6 @@ workflows:
   build:
     jobs:
       - build:
-        filters:
-          tags:
-            only: /.*/
+          filters:
+            tags:
+              only: /.*/


### PR DESCRIPTION
without it, the `filters` field is being parsed at the jobs level.