### PR TITLE
fix dirty git tree state in circle builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       AZURE_CONTAINER: "draft"
       AZURE_STORAGE_ACCOUNT: "azuredraft"
       DOCKER_USERNAME: "bacongobbler"
+      GLIDE_HOME: /root/.glide
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
In circle builds, glide is detecting GLIDE_HOME as the current workspace instead of /root/.glide. Hardcoding $GLIDE_HOME makes it such that glide respects $HOME.

Running a circle build with SSH enabled showed the following:

```
root@bd257551223a:/go/src/github.com/Azure/draft# glide | grep GLIDE_HOME
   --home value            The location of Glide files (default: "/go/src/github.com/Azure/draft/.glide") [$GLIDE_HOME]
root@bd257551223a:/go/src/github.com/Azure/draft# git status
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.glide/

nothing added to commit but untracked files present (use "git add" to track)
```

This is causing release candidates to be released with a dirty git tree state.

```
><> draft version
Client: &version.Version{SemVer:"v0.8.0-rc3", GitCommit:"0bf3ac95279e7df78a01cf2d8f04834a70958214", GitTreeState:"dirty"}
Server: &version.Version{SemVer:"v0.8.0-rc3", GitCommit:"0bf3ac95279e7df78a01cf2d8f04834a70958214", GitTreeState:"dirty"}
```