### PR TITLE
Add 'http://' prefix to output message

### DIFF
--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -60,7 +60,7 @@ func (cn *connectCmd) run() (err error) {
 		return err
 	}
 
-	detail := fmt.Sprintf("localhost:%#v", connection.Tunnel.Local)
+	detail := fmt.Sprintf("http://localhost:%#v", connection.Tunnel.Local)
 	fmt.Fprintln(cn.out, "SUCCESS...Connect to your app on "+detail)
 
 	fmt.Fprintln(cn.out, "Starting log streaming...")


### PR DESCRIPTION
Add `http://` prefix when outputting the localhost address with `draft connect`. This makes the link clickable in bash to make it even easier to get to browsing the application