### PR TITLE
add tmp/ to default .dockerignore for Ruby

### DIFF
--- a/packs/ruby/.dockerignore
+++ b/packs/ruby/.dockerignore
@@ -2,3 +2,4 @@ Dockerfile
 draft.toml
 chart/
 NOTICE
+tmp/


### PR DESCRIPTION
tmp/ is commonly known as a temporary directory that should not be added
to the Docker image for Rails apps.

closes #337