### PR TITLE
Bump docker image to node 8.8 to support async etc

### DIFF
--- a/packs/javascript/Dockerfile
+++ b/packs/javascript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6-onbuild
+FROM node:8-onbuild
 ENV PORT 8080
 EXPOSE 8080
 RUN npm install


### PR DESCRIPTION
I am not sure if this has to be default pack or e.g. `javascript-edge`