### PR TITLE
remove docker-in-docker container

### DIFF
--- a/charts/draftd/templates/deployment.yaml
+++ b/charts/draftd/templates/deployment.yaml
@@ -30,8 +30,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375 
         livenessProbe:
           httpGet:
             path: /ping
@@ -40,20 +38,12 @@ spec:
           httpGet:
             path: /ping
             port: {{ .Values.service.http.internalPort }}
-      - name: dind
-        image: docker:17.05.0-ce-dind
-        args:
-        - --insecure-registry=10.0.0.0/24
-        env:
-        - name: DOCKER_DRIVER
-          value: overlay
-        securityContext:
-            privileged: true
         volumeMounts:
-          - name: docker-graph-storage
-            mountPath: /var/lib/docker
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
       volumes:
-      - name: docker-graph-storage
-        emptyDir: {}
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
       nodeSelector:
         beta.kubernetes.io/os: linux

--- a/cmd/draft/installer/install.go
+++ b/cmd/draft/installer/install.go
@@ -114,8 +114,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: DOCKER_HOST
-          value: tcp://localhost:2375
         livenessProbe:
           httpGet:
             path: /ping
@@ -124,21 +122,13 @@ spec:
           httpGet:
             path: /ping
             port: 8080
-      - name: dind
-        image: docker:17.05.0-ce-dind
-        args:
-        - --insecure-registry=10.0.0.0/24
-        env:
-        - name: DOCKER_DRIVER
-          value: overlay
-        securityContext:
-            privileged: true
         volumeMounts:
-          - name: docker-graph-storage
-            mountPath: /var/lib/docker
+        - mountPath: /var/run/docker.sock
+          name: docker-socket
       volumes:
-      - name: docker-graph-storage
-        emptyDir: {}
+      - name: docker-socket
+        hostPath:
+          path: /var/run/docker.sock
       nodeSelector:
         beta.kubernetes.io/os: linux
 `


### PR DESCRIPTION
The latest version of minikube now supports Docker 17.06.0-ce which contains the multi-stage build feature in Docker, therefore removing the need to run a separate docker engine just for builds. #163 was introduced strictly for this feature, so it's no longer required.

As an added bonus, we get:

- automatic authentication to Azure Container Registries in the same resource group, and automatic authentication to the minikube docker registry (winner winner chicken dinner)
- free security updates to docker (big maintenance win)

closes #430 
closes #431 
closes #405 
partially addresses #213
#355 and #285 should be closed assuming that GKE/AWS clusters are automatically authenticated against GCR/ECR instances, but that needs verification.