### PR TITLE
Fix ruby example: Wrong port in app.rb

### DIFF
--- a/examples/example-ruby/app.rb
+++ b/examples/example-ruby/app.rb
@@ -1,7 +1,7 @@
 require 'sinatra'
 
 set :bind, '0.0.0.0'
-set :port, 8080
+set :port, 3000
 
 get '/' do
   'Hello World, I\'m Ruby!'


### PR DESCRIPTION
Hello,

i noticed that the port set in the ruby example is not aligned with the port in the ruby pack.

The connection gets refused out of the box
![image](https://user-images.githubusercontent.com/4410553/32979419-45308b26-cc55-11e7-8840-cf81dbe54aba.png)

I adjusted the file `app.rb` to reflect the port set in the dockerfile https://github.com/Azure/draft/blob/10065c94086dca145a7b0e2ffcc37e93a0ba0d36/packs/ruby/Dockerfile#L3

With the change it works
![image](https://user-images.githubusercontent.com/4410553/32979441-9c402fc0-cc55-11e7-8fd7-70d85a71d683.png)