### PR TITLE
Adding some clarifications about the requirements of the application.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,8 @@ There are multiple example applications included within the [examples directory]
 $ cd examples/example-python
 ```
 
+When creating your own application, note that your entrypoint python file MUST be named app.py and be present in the root directory. Any additional packages that the project requires should be specified in requirements.txt (also at the root of the project). The container expects the application to serve on port 8080, however it is not required to implement an endpoint to use the tool.
+
 ## Draft Create
 
 We need some "scaffolding" to deploy our app into a [Kubernetes](https://kubernetes.io/) cluster. Draft can create a [Helm](https://helm.sh/) chart, a `Dockerfile` and a `draft.toml` with `draft create`:


### PR DESCRIPTION
Problem Statement:
I attempted to use draft on a personal project and ran into several roadblocks that led me down a hole trying to debug. Had I just had this paragraph, I would have saved hours of debug time (since I believed the error was in my app).

Adding a small chunk of text clarifying the requirements for a Python application.

Ideally, it would be great for the help text to dynamically print depending on the application since the error messages were a little mystic, but that's down the line.