### PR TITLE
ignore common java work directories

### DIFF
--- a/packs/java/.dockerignore
+++ b/packs/java/.dockerignore
@@ -2,3 +2,6 @@ Dockerfile
 draft.toml
 chart/
 NOTICE
+target/
+work/
+.git/


### PR DESCRIPTION
to reduce the amount of data tarred up and POSTed to docker when building the docker image via the  command