### PR TITLE
ref(pkg/plugin): remove 'v' from pack-repo ver

### DIFF
--- a/pkg/plugin/builtins.go
+++ b/pkg/plugin/builtins.go
@@ -14,7 +14,7 @@ func Builtins() []*Builtin {
 	var packRepoVersion string
 	// canary draft releases should always test the latest version of the plugin.
 	if version.Release != "canary" {
-		packRepoVersion = "v0.3.1"
+		packRepoVersion = "0.3.1"
 	}
 	return []*Builtin{
 		{


### PR DESCRIPTION
Fixes issue where we keep downloading pack-repo even if we have right version.