### PR TITLE
Add environment selection flag to connect command

### DIFF
--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -20,27 +20,29 @@ type connectCmd struct {
 }
 
 func newConnectCmd(out io.Writer) *cobra.Command {
-	cc := &connectCmd{
-		out: out,
-	}
+	var (
+		cc          = &connectCmd{out: out}
+		environment string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "connect",
 		Short: "connect to your application locally",
 		Long:  connectDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cc.run()
+			return cc.run(environment)
 		},
 	}
+
 	f := cmd.Flags()
 	f.Int64Var(&cc.logLines, "tail", 5, "lines of recent log lines to display")
+	f.StringVarP(&environment, "environment", "e", defaultDraftEnvironment(), "the environment (development, staging, qa, etc) that draft will run under")
 
 	return cmd
 }
 
-func (cn *connectCmd) run() (err error) {
-
-	deployedApp, err := local.DeployedApplication(draftToml, defaultDraftEnvironment())
+func (cn *connectCmd) run(environment string) (err error) {
+	deployedApp, err := local.DeployedApplication(draftToml, environment)
 	if err != nil {
 		return err
 	}

--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -21,8 +21,8 @@ type connectCmd struct {
 
 func newConnectCmd(out io.Writer) *cobra.Command {
 	var (
-		cc          = &connectCmd{out: out}
-		environment string
+		cc                 = &connectCmd{out: out}
+		runningEnvironment string
 	)
 
 	cmd := &cobra.Command{
@@ -30,19 +30,19 @@ func newConnectCmd(out io.Writer) *cobra.Command {
 		Short: "connect to your application locally",
 		Long:  connectDesc,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cc.run(environment)
+			return cc.run(runningEnvironment)
 		},
 	}
 
 	f := cmd.Flags()
 	f.Int64Var(&cc.logLines, "tail", 5, "lines of recent log lines to display")
-	f.StringVarP(&environment, "environment", "e", defaultDraftEnvironment(), "the environment (development, staging, qa, etc) that draft will run under")
+	f.StringVarP(&runningEnvironment, environmentFlagName, environmentFlagShorthand, defaultDraftEnvironment(), environmentFlagUsage)
 
 	return cmd
 }
 
-func (cn *connectCmd) run(environment string) (err error) {
-	deployedApp, err := local.DeployedApplication(draftToml, environment)
+func (cn *connectCmd) run(runningEnvironment string) (err error) {
+	deployedApp, err := local.DeployedApplication(draftToml, runningEnvironment)
 	if err != nil {
 		return err
 	}

--- a/cmd/draft/delete.go
+++ b/cmd/draft/delete.go
@@ -48,7 +48,7 @@ func (d *deleteCmd) run() error {
 	} else {
 		deployedApp, err := local.DeployedApplication(draftToml, defaultDraftEnvironment())
 		if err != nil {
-			return errors.New("Unable to detect app name\nPlesae pass in the name of the application")
+			return errors.New("Unable to detect app name\nPlease pass in the name of the application")
 
 		}
 

--- a/cmd/draft/environment.go
+++ b/cmd/draft/environment.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+
+	"github.com/Azure/draft/pkg/draft/manifest"
+)
+
+const (
+	environmentEnvVar        = "DRAFT_ENV"
+	environmentFlagName      = "environment"
+	environmentFlagShorthand = "e"
+	environmentFlagUsage     = "the environment (development, staging, qa, etc) that draft will run under"
+)
+
+func defaultDraftEnvironment() string {
+	env := os.Getenv(environmentEnvVar)
+	if env == "" {
+		env = manifest.DefaultEnvironmentName
+	}
+	return env
+}

--- a/cmd/draft/environment_test.go
+++ b/cmd/draft/environment_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestDefaultEnvironment(t *testing.T) {
+
+	testCases := []struct {
+		envVar   string
+		expected string
+	}{
+		{envVar: "", expected: "development"},
+		{envVar: "something", expected: "something"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("env-%s", tc.envVar), func(t *testing.T) {
+			_ = os.Setenv(environmentEnvVar, tc.envVar)
+
+			if result := defaultDraftEnvironment(); result != tc.expected {
+				t.Errorf("Expected default environment %s, got %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/cmd/draft/environment_test.go
+++ b/cmd/draft/environment_test.go
@@ -21,7 +21,7 @@ func TestDefaultEnvironment(t *testing.T) {
 			_ = os.Setenv(environmentEnvVar, tc.envVar)
 
 			if result := defaultDraftEnvironment(); result != tc.expected {
-				t.Errorf("Expected default environment %s, got %v", tc.expected, result)
+				t.Errorf("Expected default environment %s, got %s", tc.expected, result)
 			}
 		})
 	}

--- a/cmd/draft/up.go
+++ b/cmd/draft/up.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Azure/draft/pkg/build"
 	"github.com/Azure/draft/pkg/cmdline"
 	"github.com/Azure/draft/pkg/draft"
-	"github.com/Azure/draft/pkg/draft/manifest"
 )
 
 const upDesc = `
@@ -25,8 +24,7 @@ that changes have stopped before uploading, but that can be altered by the
 `
 
 const (
-	environmentEnvVar = "DRAFT_ENV"
-	ignoreFileName    = ".draftignore"
+	ignoreFileName = ".draftignore"
 )
 
 type upCmd struct {
@@ -61,7 +59,7 @@ func newUpCmd(out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVarP(&runningEnvironment, "environment", "e", defaultDraftEnvironment(), "the environment (development, staging, qa, etc) that draft will run under")
+	f.StringVarP(&runningEnvironment, environmentFlagName, environmentFlagShorthand, defaultDraftEnvironment(), environmentFlagUsage)
 
 	return cmd
 }
@@ -82,12 +80,4 @@ func (u *upCmd) run(environment string) (err error) {
 	}()
 	cmdline.Display(ctx, buildctx.Env.Name, u.client.Results())
 	return <-errc
-}
-
-func defaultDraftEnvironment() string {
-	env := os.Getenv(environmentEnvVar)
-	if env == "" {
-		env = manifest.DefaultEnvironmentName
-	}
-	return env
 }

--- a/pkg/draft/local/local.go
+++ b/pkg/draft/local/local.go
@@ -46,7 +46,11 @@ func DeployedApplication(draftTomlPath, draftEnvironment string) (*App, error) {
 	if _, err := toml.DecodeFile(draftTomlPath, &draftConfig); err != nil {
 		return nil, err
 	}
-	appConfig := draftConfig.Environments[draftEnvironment]
+
+	appConfig, found := draftConfig.Environments[draftEnvironment]
+	if !found {
+		return nil, fmt.Errorf("Environment %v not found", draftEnvironment)
+	}
 
 	return &App{Name: appConfig.Name, Namespace: appConfig.Namespace}, nil
 }


### PR DESCRIPTION
This PR adds the possibility to choose the environment through the --environment / -e flag in connect.
Since this is possible with "up", i would expect this from connect as well.

There are two issues with the current implementation:
- Not having the default "development" environment in the .toml config results in a panic when calling "draft connect", because draft falls back to the default "development" and reads it from the map - and afterwards accesses the nil return value. See here https://github.com/birdayz/draft/commit/22fbcaa020f2bdae3351f83c82bd212b265274d1#diff-19de32b90b575e618c86ae2c9c8a80d6L49
Fixed by this PR. 
- It is only possible to choose the environment in connect by setting the environment variable DRAFT_ENV. Since up allows the -e param, i added this to connect as well.

Since i was already touching that code, i moved the environment stuff to its own file, because i feel that it  does not fit into up.go anymore because it is used not only by up but also by connect now (and possibly more commands in the future).
I also added a test to cover the "environment variable" vs default selection.

Remark: i guess there is more room for improvement for the environment handling - at least from my point of view. if there is interest, we can further discuss this. For me it is not really clear and there are open questions - for example different environments with the same app name are literally the same (correct me if i am wrong here), unless they use a different namespace. I am not sure if this is clear for the user.

Relates to #467