### PR TITLE
add rootCmd variable

### DIFF
--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -45,6 +45,10 @@ var (
 	draftHost string
 	// draftNamespace depicts which namespace the Draftd server is running in. This is used when Draftd was installed in a different namespace than kube-system.
 	draftNamespace string
+
+	//rootCmd is the root command handling `draft`. It's used in other parts of package cmd to add/search the command tree.
+	rootCmd *cobra.Command
+
 	// tls flags, options, and defaults
 	tlsCaCertFile string // path to TLS CA certificate file
 	tlsCertFile   string // path to TLS certificate file
@@ -59,6 +63,10 @@ var (
 
 var globalUsage = `The application deployment tool for Kubernetes.
 `
+
+func init() {
+	rootCmd = newRootCmd(os.Stdout, os.Stdin)
+}
 
 func newRootCmd(out io.Writer, in io.Reader) *cobra.Command {
 	cmd := &cobra.Command{
@@ -218,8 +226,7 @@ func getKubeClient(context string) (kubernetes.Interface, *rest.Config, error) {
 }
 
 func main() {
-	cmd := newRootCmd(os.Stdout, os.Stdin)
-	if err := cmd.Execute(); err != nil {
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/draft/ensure.go
+++ b/cmd/draft/ensure.go
@@ -70,7 +70,7 @@ func (i *initCmd) ensurePack(builtin *repo.Builtin, existingRepos []repo.Reposit
 		fmt.Sprintf("--debug=%v", flagDebug),
 	}
 
-	packRepoCmd, _, err := newRootCmd(i.out, i.in).Find([]string{"pack-repo"})
+	packRepoCmd, _, err := rootCmd.Find([]string{"pack-repo"})
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (i *initCmd) ensurePlugin(builtin *plugin.Builtin, existingPlugins []*plugi
 		fmt.Sprintf("--debug=%v", flagDebug),
 	}
 
-	plugInstallCmd, _, err := newRootCmd(i.out, i.in).Find([]string{"plugin", "install"})
+	plugInstallCmd, _, err := rootCmd.Find([]string{"plugin", "install"})
 	if err != nil {
 		return err
 	}
@@ -154,6 +154,9 @@ func (i *initCmd) ensurePlugin(builtin *plugin.Builtin, existingPlugins []*plugi
 	if err := plugInstallCmd.RunE(plugInstallCmd, installArgs); err != nil {
 		return err
 	}
+
+	// reload plugins
+	loadPlugins(rootCmd, i.home, i.out, i.in)
 
 	debug("Successfully installed %v %v from %v",
 		builtin.Name, builtin.Version, builtin.URL)


### PR DESCRIPTION
This way, draft commands can use the same rootCmd when adding plugins to the command tree, performing command lookups or re-loading rootCmd after `draft init`.