### PR TITLE
Update --insecure-registry CIDR range

### DIFF
--- a/charts/draftd/templates/deployment.yaml
+++ b/charts/draftd/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       - name: dind
         image: docker:17.05.0-ce-dind
         args:
-        - --insecure-registry=10.0.0.0/24
+        - --insecure-registry=10.96.0.0/12,10.0.0.0/24
         env:
         - name: DOCKER_DRIVER
           value: overlay

--- a/cmd/draft/installer/templates.go
+++ b/cmd/draft/installer/templates.go
@@ -125,7 +125,7 @@ spec:
       - name: dind
         image: docker:17.05.0-ce-dind
         args:
-        - --insecure-registry=10.0.0.0/24
+        - --insecure-registry=10.96.0.0/12,10.0.0.0/24
         env:
         - name: DOCKER_DRIVER
           value: overlay


### PR DESCRIPTION
https://github.com/kubernetes/minikube/pull/2077 changed the default service cluster IP range to 10.96.0.0/12 from 10.0.0.0/24.

Without this fix, `draft up` on minikube will fail with the following error:

> buildApp: pushImg error: Get https://10.107.109.2/v1/_ping: dial tcp 10.107.109.2:443: i/o timeout