### PR TITLE
java pack: `mvn` invocation should be non interactive (`--batch-mode`). Fix  #524

### DIFF
--- a/packs/java/Dockerfile
+++ b/packs/java/Dockerfile
@@ -1,7 +1,7 @@
 FROM maven:3.5-jdk-8-alpine as BUILD
 
 COPY . /usr/src/app
-RUN mvn -f /usr/src/app/pom.xml clean package
+RUN mvn --batch-mode -f /usr/src/app/pom.xml clean package
 
 FROM openjdk:8-jdk-alpine
 ENV PORT 4567


### PR DESCRIPTION
`mvn` invocation should be non interactive (`--batch-mode`). Fix  #524