### PR TITLE
Add draft connect --container/-c flag (#399)

### DIFF
--- a/cmd/draft/logs.go
+++ b/cmd/draft/logs.go
@@ -48,13 +48,13 @@ func (l *logsCmd) run() error {
 		Container: "draftd",
 	}
 
-	connection, err := draftApp.Connect(client, config)
+	connection, err := draftApp.Connect(client, config, draftApp.Container)
 	if err != nil {
 		return fmt.Errorf("Could not connect to draftd: %s", err)
 	}
 
 	fmt.Fprintf(l.out, "Starting a log stream from the draft server...\n")
-	readCloser, err := connection.RequestLogStream(draftApp, l.logLines)
+	readCloser, err := connection.RequestLogStream(draftApp.Namespace, draftApp.Container, l.logLines)
 	if err != nil {
 		return fmt.Errorf("Could not get log stream: %s", err)
 	}

--- a/pkg/draft/local/local_test.go
+++ b/pkg/draft/local/local_test.go
@@ -23,7 +23,7 @@ func TestDeployedApplication(t *testing.T) {
 	}
 }
 
-func TestGetContainerPort(t *testing.T) {
+func TestGetTargetContainerPort(t *testing.T) {
 	containersTest1 := []v1.Container{
 		{Name: "anothercontainer", Ports: []v1.ContainerPort{{ContainerPort: 3000}}},
 		{Name: "mycontainer", Ports: []v1.ContainerPort{{ContainerPort: 4000}}},
@@ -37,12 +37,11 @@ func TestGetContainerPort(t *testing.T) {
 		expectErr       bool
 	}{
 		{"test correct container and port found", containersTest1, "mycontainer", 4000, false},
-		{"test first container and port found", containersTest1, "", 3000, false},
 		{"test container not found error", containersTest1, "randomcontainer", 0, true},
 	}
 
 	for _, tc := range testCases {
-		port, err := getContainerPort(tc.containers, tc.targetContainer)
+		port, err := getTargetContainerPort(tc.containers, tc.targetContainer)
 		if tc.expectErr && err == nil {
 			t.Errorf("Expected err but did not get one for case: %s", tc.description)
 		}


### PR DESCRIPTION
What this does:
- adds `draft connect -c` flag

- if a container is specified, start a tunnel to the container's first port and get logs from that container
- if no container is specified, start tunnels to the first port of all containers in pod and get logs from all containers