### PR TITLE
Use the Debian based Docker image instead of the Alpine image

### DIFF
--- a/packs/gradle/Dockerfile
+++ b/packs/gradle/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:3.5-jdk8-alpine as BUILD
+FROM gradle:3.5-jdk8 as BUILD
 
 COPY . /project
 RUN gradle -b /project/build.gradle clean build
 
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jdk
 ENV PORT 4567
 EXPOSE 4567
 COPY --from=BUILD /project/target/app.jar /opt/app.jar

--- a/packs/java/Dockerfile
+++ b/packs/java/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3.5-jdk-8-alpine as BUILD
+FROM maven:3.5-jdk-8 as BUILD
 
 COPY . /usr/src/app
 RUN mvn --batch-mode -f /usr/src/app/pom.xml clean package
 
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jdk
 ENV PORT 4567
 EXPOSE 4567
 COPY --from=BUILD /usr/src/app/target/helloworld-jar-with-dependencies.jar /opt/app.jar


### PR DESCRIPTION
Use the Debian based Docker image instead of the Alpine image due to bugs with the JDK on Alpine. Fix #526