### PR TITLE
Connect to every containerPort in pod

### DIFF
--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -66,11 +66,13 @@ func (cn *connectCmd) run(runningEnvironment string) (err error) {
 
 	// output all local ports first - easier to spot
 	for _, cc := range connection.ContainerConnections {
-		err = cc.Tunnel.ForwardPort()
-		if err != nil {
-			return err
+		for _, t := range cc.Tunnels {
+			err = t.ForwardPort()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cn.out, "Connect to %v:%v on localhost:%#v\n", cc.ContainerName, t.Remote, t.Local)
 		}
-		fmt.Fprintf(cn.out, "Connect to %v on localhost:%#v\n", cc.ContainerName, cc.Tunnel.Local)
 	}
 
 	for _, cc := range connection.ContainerConnections {

--- a/pkg/draft/local/local_test.go
+++ b/pkg/draft/local/local_test.go
@@ -27,27 +27,54 @@ func TestGetTargetContainerPort(t *testing.T) {
 	containersTest1 := []v1.Container{
 		{Name: "anothercontainer", Ports: []v1.ContainerPort{{ContainerPort: 3000}}},
 		{Name: "mycontainer", Ports: []v1.ContainerPort{{ContainerPort: 4000}}},
+		{Name: "multi-port", Ports: []v1.ContainerPort{{ContainerPort: 80}, {ContainerPort: 81}}},
+		{Name: "no-port", Ports: []v1.ContainerPort{{}}},
 	}
 
 	testCases := []struct {
 		description     string
 		containers      []v1.Container
 		targetContainer string
-		expectedPort    int
+		expectedPorts   []int
 		expectErr       bool
 	}{
-		{"test correct container and port found", containersTest1, "mycontainer", 4000, false},
-		{"test container not found error", containersTest1, "randomcontainer", 0, true},
+		{"test correct container and port found", containersTest1, "mycontainer", []int{4000}, false},
+		{"test container not found error", containersTest1, "randomcontainer", []int{0}, true},
+		{"container found, multiple ports", containersTest1, "multi-port", []int{80, 81}, false},
+		{"container found, no ports", containersTest1, "no-port", []int{0}, false},
 	}
 
 	for _, tc := range testCases {
-		port, err := getTargetContainerPort(tc.containers, tc.targetContainer)
+		ports, err := getTargetContainerPorts(tc.containers, tc.targetContainer)
 		if tc.expectErr && err == nil {
 			t.Errorf("Expected err but did not get one for case: %s", tc.description)
 		}
 
-		if tc.expectedPort != 0 && (tc.expectedPort != port) {
-			t.Errorf("Expected port %v, got %v for scenario: %s", tc.expectedPort, port, tc.description)
+		if (!areEqual(tc.expectedPorts, []int{0})) && (!areEqual(tc.expectedPorts, ports)) {
+			t.Errorf("Expected port %v, got %v for scenario: %v", tc.expectedPorts, ports, tc.description)
 		}
 	}
+}
+
+func areEqual(a, b []int) bool {
+
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
- fixes #535 
- starts tunnel to every `containerPort` in pod spec

Essentially, when doing `draft connect` with the deployment below, you get:

```
<tunnels to all ports of all containers>

Connect to multi-port:80 on localhost:53010
Connect to multi-port:81 on localhost:53012
Connect to go:8080 on localhost:53014

<logs from all containers, including ones without ports>
``` 

The `--container/-c` flag works as expected, creating tunnels only for all the ports of the selected container.

Best tried with the following deployment template, which has containers with 0, 1 or 2 defined `containerPort`

```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: {{ template "fullname" . }}
  labels:
    draft: {{ default "draft-app" .Values.draft }}
    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
spec:
  replicas: {{ .Values.replicaCount }}
  template:
    metadata:
      labels:
        draft: {{ default "draft-app" .Values.draft }}
        app: {{ template "fullname" . }}
    spec:
      containers:

      - name: multi-port
        image: radumatei/multi-port
        ports:
        - containerPort: 80
        - containerPort: 81

      - name: no-port
        image: ubuntu
        command: ["/bin/sh"]
        args: ["-c", "while true; do echo hello; sleep 1;done"]
        
      - name: {{ .Chart.Name }}
        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
        imagePullPolicy: {{ .Values.image.pullPolicy }}
        ports:
        - containerPort: {{ .Values.service.internalPort }}
        resources:
{{ toYaml .Values.resources | indent 12 }}

```