### PR TITLE
Support packs with multiple files and multiple chart folders - fixes …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ examples/**/.draftignore
 pkg/linguist/data/classifier
 pkg/linguist/data/linguist
 pkg/linguist/data/*.yml
+.idea/

--- a/cmd/draft/testdata/create/generated/empty/.dockerignore
+++ b/cmd/draft/testdata/create/generated/empty/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+draft.toml
+chart/
+NOTICE

--- a/cmd/draft/testdata/create/generated/empty/NOTICE
+++ b/cmd/draft/testdata/create/generated/empty/NOTICE
@@ -1,0 +1,9 @@
+MIT License:
+
+Copyright (C) 2011-2015 Heroku, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cmd/draft/testdata/create/generated/html-but-actually-go/.dockerignore
+++ b/cmd/draft/testdata/create/generated/html-but-actually-go/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+draft.toml
+chart/
+NOTICE

--- a/cmd/draft/testdata/create/generated/html-but-actually-go/NOTICE
+++ b/cmd/draft/testdata/create/generated/html-but-actually-go/NOTICE
@@ -1,0 +1,9 @@
+MIT License:
+
+Copyright (C) 2011-2015 Heroku, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cmd/draft/testdata/create/generated/simple-go-with-draftignore/.dockerignore
+++ b/cmd/draft/testdata/create/generated/simple-go-with-draftignore/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+draft.toml
+chart/
+NOTICE

--- a/cmd/draft/testdata/create/generated/simple-go-with-draftignore/NOTICE
+++ b/cmd/draft/testdata/create/generated/simple-go-with-draftignore/NOTICE
@@ -1,0 +1,9 @@
+MIT License:
+
+Copyright (C) 2011-2015 Heroku, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/cmd/draft/testdata/create/generated/simple-go/.dockerignore
+++ b/cmd/draft/testdata/create/generated/simple-go/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+draft.toml
+chart/
+NOTICE

--- a/cmd/draft/testdata/create/generated/simple-go/NOTICE
+++ b/cmd/draft/testdata/create/generated/simple-go/NOTICE
@@ -1,0 +1,9 @@
+MIT License:
+
+Copyright (C) 2011-2015 Heroku, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pkg/draft/pack/load.go
+++ b/pkg/draft/pack/load.go
@@ -20,15 +20,32 @@ func FromDir(dir string) (*Pack, error) {
 		return nil, err
 	}
 
-	pack.Chart, err = chartutil.LoadDir(filepath.Join(topdir, ChartsDir))
+	files, err := ioutil.ReadDir(topdir)
 	if err != nil {
 		return nil, err
 	}
+	for _, file := range files {
+		if file.IsDir() {
+			chart, err := chartutil.LoadDir(filepath.Join(topdir, file.Name()))
+			if err != nil {
+				return nil, err
+			}
+			pack.Charts = append(pack.Charts, chart)
+		} else {
+			var rootFile ChartRootFiles
+			rootFile.Filename = file.Name()
 
-	dockerfile := filepath.Join(topdir, DockerfileName)
-	pack.Dockerfile, err = ioutil.ReadFile(dockerfile)
-	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %s", dockerfile, err)
+			rootFileName := filepath.Join(topdir, file.Name())
+			rootFile.File, err = ioutil.ReadFile(rootFileName)
+			if err != nil {
+				return nil, err
+			}
+			pack.Files = append(pack.Files, &rootFile)
+
+			if err != nil {
+				return nil, fmt.Errorf("error reading %s: %s", file.Name(), err)
+			}
+		}
 	}
 
 	return pack, nil

--- a/pkg/draft/pack/load_test.go
+++ b/pkg/draft/pack/load_test.go
@@ -22,12 +22,12 @@ func TestFromDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not load python pack: %v", err)
 	}
-	if pack.Chart == nil {
+	if pack.Charts == nil || len(pack.Charts) == 0 {
 		t.Errorf("expected chart to be non-nil")
 	}
 
-	if string(pack.Dockerfile) != expectedDockerfile {
-		t.Errorf("expected dockerfile == expected, got '%v'", pack.Dockerfile)
+	if string(pack.Files[0].File) != expectedDockerfile {
+		t.Errorf("expected dockerfile == expected, got '%v'", pack.Files[0].File)
 	}
 
 	if _, err := FromDir("dir-does-not-exist"); err == nil {

--- a/pkg/draft/pack/pack_test.go
+++ b/pkg/draft/pack/pack_test.go
@@ -14,13 +14,25 @@ const testDockerfile = `FROM nginx:latest
 `
 
 func TestSaveDir(t *testing.T) {
-	p := &Pack{
-		Chart: &chart.Chart{
+
+	charts := []*chart.Chart{
+		{
 			Metadata: &chart.Metadata{
 				Name: "chart-for-nigel-thornberry",
 			},
 		},
-		Dockerfile: []byte(testDockerfile),
+	}
+
+	file := ChartRootFiles{
+		Filename: "Dockerfile",
+		File:     []byte(testDockerfile),
+	}
+
+	files := []*ChartRootFiles{&file}
+
+	p := &Pack{
+		Charts: charts,
+		Files:  files,
 	}
 	dir, err := ioutil.TempDir("", "draft-pack-test")
 	if err != nil {
@@ -34,13 +46,24 @@ func TestSaveDir(t *testing.T) {
 }
 
 func TestSaveDirDockerfileExistsInAppDir(t *testing.T) {
-	p := &Pack{
-		Chart: &chart.Chart{
+	charts := []*chart.Chart{
+		{
 			Metadata: &chart.Metadata{
 				Name: "chart-for-nigel-thornberry",
 			},
 		},
-		Dockerfile: []byte(testDockerfile),
+	}
+
+	file := &ChartRootFiles{
+		Filename: "Dockerfile",
+		File:     []byte(testDockerfile),
+	}
+
+	files := []*ChartRootFiles{file}
+
+	p := &Pack{
+		Charts: charts,
+		Files:  files,
 	}
 	dir, err := ioutil.TempDir("", "draft-pack-test")
 	if err != nil {


### PR DESCRIPTION
…#549

Rather than just copying a Dockerfile and folder called charts it would be handy if we can add extra files and folders to our draft packs.

We've found that we add extra files such as a Jenkinsfile (for CI/CD pipelines) and extra chart folders used for deploying into different environments.