### PR TITLE
use draft.toml's environment for `draft logs`

### DIFF
--- a/cmd/draft/logs.go
+++ b/cmd/draft/logs.go
@@ -2,31 +2,35 @@ package main
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/Azure/draft/pkg/draft"
+	"github.com/Azure/draft/pkg/draft/local"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
-	"io"
 )
 
 const logsDesc = `This command outputs logs from the draft server to help debug builds.`
 
 type logsCmd struct {
-	client   *draft.Client
-	out      io.Writer
-	appName  string
-	buildID  string
-	logLines int64
-	args     []string
+	client             *draft.Client
+	out                io.Writer
+	appName            string
+	buildID            string
+	logLines           int64
+	args               []string
+	runningEnvironment string
 }
 
 func newLogsCmd(out io.Writer) *cobra.Command {
+
 	lc := &logsCmd{
 		out:  out,
-		args: []string{"app-name", "build-id"},
+		args: []string{"build-id"},
 	}
 
 	cmd := &cobra.Command{
-		Use:   "logs <app-name> <build-id>",
+		Use:   "logs <build-id>",
 		Short: logsDesc,
 		Long:  logsDesc,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -43,6 +47,7 @@ func newLogsCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 	f.Int64Var(&lc.logLines, "tail", 100, "lines of recent log lines to display")
+	f.StringVarP(&lc.runningEnvironment, environmentFlagName, environmentFlagShorthand, defaultDraftEnvironment(), environmentFlagUsage)
 
 	return cmd
 }
@@ -51,13 +56,17 @@ func (l *logsCmd) complete(args []string) error {
 	if err := validateArgs(args, l.args); err != nil {
 		return err
 	}
-	l.appName = args[0]
-	l.buildID = args[1]
+	l.buildID = args[0]
 	return nil
 }
 
 func (l *logsCmd) run() error {
-	b, err := l.client.GetLogs(context.Background(), l.appName, l.buildID, draft.WithLogsLimit(l.logLines))
+	deployedApp, err := local.DeployedApplication(draftToml, l.runningEnvironment)
+	if err != nil {
+		return err
+	}
+
+	b, err := l.client.GetLogs(context.Background(), deployedApp.Name, l.buildID, draft.WithLogsLimit(l.logLines))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows us to remove the need for supplying the application name to `draft logs`.