### PR TITLE
Fix make rpc target by adding local protobuf include in vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,5 +137,6 @@ ifndef HAS_BINDATA
 endif
 	dep ensure -v
 	scripts/setup-apimachinery.sh
+	scripts/setup-protobuf-include.sh
 
 include versioning.mk

--- a/pkg/rpc/Makefile
+++ b/pkg/rpc/Makefile
@@ -1,6 +1,6 @@
 google_deps = Mgoogle/protobuf/empty.proto=github.com/golang/protobuf/ptypes/empty
 helm_deps = Mhapi/chart/config.proto=k8s.io/helm/pkg/proto/hapi/chart,Mhapi/chart/chart.proto=k8s.io/helm/pkg/proto/hapi/chart
-includes = $(HOME)/src/protobuf/include:../../vendor/k8s.io/helm/_proto
+includes = ../../vendor/protobuf-include/include/:../../vendor/k8s.io/helm/_proto
 plugins = grpc
 target = go
 deps = $(google_deps),$(helm_deps)
@@ -8,10 +8,8 @@ dst = .
 
 .PHONY: rpc
 rpc:
-	PATH=../../bin:$(PATH) protoc -I=$(includes):. --$(target)_out=plugins=$(plugins),$(deps):$(dst) *.proto
+	protoc -I=$(includes):. --$(target)_out=plugins=$(plugins),$(deps):$(dst) *.proto
 
 .PHONY: clean
 clean:
 	rm *.pb.go
-
-

--- a/scripts/setup-protobuf-include.sh
+++ b/scripts/setup-protobuf-include.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+mkdir vendor/protobuf && cd vendor/protobuf
+curl -LO https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
+unzip protoc-3.5.1-linux-x86_64.zip
+cd .. && mkdir protobuf-include
+cp -R protobuf/include protobuf-include/
+rm -rf protobuf


### PR DESCRIPTION
Fixes #555 

(It first needs a `make bootstrap` to execute `scripts/setup-protobuf-include.sh`, which brings the `include` directory from protobuf in `vendor`)