### PR TITLE
Fix for ipv6 lookup error

### DIFF
--- a/cmd/draft/draft.go
+++ b/cmd/draft/draft.go
@@ -120,7 +120,7 @@ func setupConnection(c *cobra.Command, args []string) error {
 			return err
 		}
 
-		draftHost = fmt.Sprintf("localhost:%d", tunnel.Local)
+		draftHost = fmt.Sprintf("127.0.0.1:%d", tunnel.Local)
 		log.Debugf("Created tunnel using local port: '%d'", tunnel.Local)
 	}
 
@@ -263,7 +263,7 @@ func setupHelm(kubeClient kubernetes.Interface, config *rest.Config, namespace s
 		return nil, err
 	}
 
-	return helm.NewClient(helm.Host(fmt.Sprintf("localhost:%d", tunnel.Local))), nil
+	return helm.NewClient(helm.Host(fmt.Sprintf("127.0.0.1:%d", tunnel.Local))), nil
 }
 
 func setupTillerConnection(client kubernetes.Interface, config *rest.Config, namespace string) (*kube.Tunnel, error) {


### PR DESCRIPTION
Per PR #3082 which closed helm issue#2658., we should use 127.0.0.1 instead of localhost to fix ipv6 lookup error: grpc: addrConn.resetTransport failed to create client transport: connection error: desc = “transport: dial tcp [::1]:56463: getsockopt: connection refused”; Reconnecting to {localhost:56463 <nil>}