### PR TITLE
Add local port forwarding for draft connect

### DIFF
--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -18,7 +18,10 @@ const (
 `
 )
 
-var containerName string
+var (
+	targetContainer string
+	overridePorts   []string
+)
 
 type connectCmd struct {
 	out      io.Writer
@@ -43,7 +46,8 @@ func newConnectCmd(out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.Int64Var(&cc.logLines, "tail", 5, "lines of recent log lines to display")
 	f.StringVarP(&runningEnvironment, environmentFlagName, environmentFlagShorthand, defaultDraftEnvironment(), environmentFlagUsage)
-	f.StringVarP(&containerName, "container", "c", "", "name of the container to connect to")
+	f.StringVarP(&targetContainer, "container", "c", "", "name of the container to connect to")
+	f.StringSliceVarP(&overridePorts, "override-port", "p", []string{}, "specify a local port to connect to, in the form <local>:<remote>")
 
 	return cmd
 }
@@ -59,7 +63,7 @@ func (cn *connectCmd) run(runningEnvironment string) (err error) {
 		return err
 	}
 
-	connection, err := deployedApp.Connect(client, config, containerName)
+	connection, err := deployedApp.Connect(client, config, targetContainer, overridePorts)
 	if err != nil {
 		return err
 	}

--- a/pkg/draft/local/local.go
+++ b/pkg/draft/local/local.go
@@ -3,6 +3,8 @@ package local
 import (
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"k8s.io/api/core/v1"
@@ -10,9 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/helm/pkg/kube"
 
 	"github.com/Azure/draft/pkg/draft/manifest"
+	"github.com/Azure/draft/pkg/draft/tunnel"
 	"github.com/Azure/draft/pkg/kube/podutil"
 )
 
@@ -40,7 +42,7 @@ type Connection struct {
 
 // ContainerConnection encapsulates a connection to a container in a pod
 type ContainerConnection struct {
-	Tunnels       []*kube.Tunnel
+	Tunnels       []*tunnel.Tunnel
 	ContainerName string
 }
 
@@ -62,21 +64,28 @@ func DeployedApplication(draftTomlPath, draftEnvironment string) (*App, error) {
 }
 
 // Connect tunnels to a Kubernetes pod running the application and returns the connection information
-func (a *App) Connect(clientset kubernetes.Interface, clientConfig *restclient.Config, containerName string) (*Connection, error) {
+func (a *App) Connect(clientset kubernetes.Interface, clientConfig *restclient.Config, targetContainer string, overridePorts []string) (*Connection, error) {
 	var cc []*ContainerConnection
 	pod, err := getPod(a.Namespace, a.Name, clientset)
 	if err != nil {
 		return nil, err
 	}
 
+	m, err := getPortMapping(overridePorts)
+	if err != nil {
+		return nil, err
+	}
+
 	// if no container was specified as flag, return tunnels to all containers in pod
-	if containerName == "" {
+	if targetContainer == "" {
 		for _, c := range pod.Spec.Containers {
-			var tt []*kube.Tunnel
+			var tt []*tunnel.Tunnel
 
 			// iterate through all ports of the contaier and create tunnels
 			for _, p := range c.Ports {
-				t := kube.NewTunnel(clientset.CoreV1().RESTClient(), clientConfig, a.Namespace, pod.Name, int(p.ContainerPort))
+				remote := int(p.ContainerPort)
+				local := m[remote]
+				t := tunnel.NewWithLocalTunnel(clientset.CoreV1().RESTClient(), clientConfig, a.Namespace, pod.Name, remote, local)
 				tt = append(tt, t)
 			}
 			cc = append(cc, &ContainerConnection{
@@ -91,22 +100,23 @@ func (a *App) Connect(clientset kubernetes.Interface, clientConfig *restclient.C
 			Clientset:            clientset,
 		}, nil
 	}
-	var tt []*kube.Tunnel
+	var tt []*tunnel.Tunnel
 
 	// a container was specified - return tunnel to specified container
-	ports, err := getTargetContainerPorts(pod.Spec.Containers, containerName)
+	ports, err := getTargetContainerPorts(pod.Spec.Containers, targetContainer)
 	if err != nil {
 		return nil, err
 	}
 
 	// iterate through all ports of the container and create tunnels
 	for _, p := range ports {
-		t := kube.NewTunnel(clientset.CoreV1().RESTClient(), clientConfig, a.Namespace, pod.Name, p)
+		local := m[p]
+		t := tunnel.NewWithLocalTunnel(clientset.CoreV1().RESTClient(), clientConfig, a.Namespace, pod.Name, p, local)
 		tt = append(tt, t)
 	}
 
 	cc = append(cc, &ContainerConnection{
-		ContainerName: containerName,
+		ContainerName: targetContainer,
 		Tunnels:       tt,
 	})
 
@@ -115,6 +125,40 @@ func (a *App) Connect(clientset kubernetes.Interface, clientConfig *restclient.C
 		PodName:              pod.Name,
 		Clientset:            clientset,
 	}, nil
+}
+
+func getPortMapping(overridePorts []string) (map[int]int, error) {
+	var portMapping = make(map[int]int, len(overridePorts))
+
+	for _, p := range overridePorts {
+		m := strings.Split(p, ":")
+		local, err := strconv.Atoi(m[0])
+		if err != nil {
+			return nil, fmt.Errorf("cannot get port mapping: %v", err)
+		}
+
+		remote, err := strconv.Atoi(m[1])
+		if err != nil {
+			return nil, fmt.Errorf("cannot get port mapping: %v", err)
+		}
+
+		// check if remote port already exists in port mapping
+		_, exists := portMapping[remote]
+		if exists {
+			return nil, fmt.Errorf("remote port %v already mapped", remote)
+		}
+
+		// check if local port already exists in port mapping
+		for _, l := range portMapping {
+			if local == l {
+				return nil, fmt.Errorf("local port %v already mapped", local)
+			}
+		}
+
+		portMapping[remote] = local
+	}
+
+	return portMapping, nil
 }
 
 // RequestLogStream returns a stream of the application pod's logs

--- a/pkg/draft/local/local_test.go
+++ b/pkg/draft/local/local_test.go
@@ -56,6 +56,34 @@ func TestGetTargetContainerPort(t *testing.T) {
 	}
 }
 
+func TestGetPortMapping(t *testing.T) {
+	testCases := []struct {
+		description     string
+		portMapping     []string
+		expectedMapping map[int]int
+		expectedErr     bool
+	}{
+		{"single port mapping", []string{"8080:8080"}, map[int]int{8080: 8080}, false},
+		{"multiple port mappings", []string{"8080:80", "8081:81"}, map[int]int{80: 8080, 81: 8081}, false},
+		{"multiple port mappings, same local port", []string{"8080:8080", "8080:8081"}, map[int]int{}, true},
+		{"multiple port mappings, same remote port", []string{"8081:8081", "8080:8081"}, map[int]int{}, true},
+	}
+
+	for _, tc := range testCases {
+		m, err := getPortMapping(tc.portMapping)
+
+		if tc.expectedErr {
+			if err == nil {
+				t.Errorf("Expected err but did not get one for test case: %s", tc.description)
+			}
+		} else {
+			if !reflect.DeepEqual(m, tc.expectedMapping) {
+				t.Errorf("For scenario %v - expected: %v, actual: %v", tc.description, tc.expectedMapping, m)
+			}
+		}
+	}
+}
+
 func areEqual(a, b []int) bool {
 
 	if a == nil && b == nil {

--- a/pkg/draft/tunnel/tunnel.go
+++ b/pkg/draft/tunnel/tunnel.go
@@ -1,0 +1,139 @@
+// Initial license from Helm
+/*
+Copyright 2016 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tunnel
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// Tunnel describes a ssh-like tunnel to a kubernetes pod
+type Tunnel struct {
+	Local     int
+	Remote    int
+	Namespace string
+	PodName   string
+	Out       io.Writer
+	stopChan  chan struct{}
+	readyChan chan struct{}
+	config    *rest.Config
+	client    rest.Interface
+}
+
+// NewTunnel creates a new tunnel
+func NewTunnel(client rest.Interface, config *rest.Config, namespace, podName string, remote int) *Tunnel {
+	return &Tunnel{
+		config:    config,
+		client:    client,
+		Namespace: namespace,
+		PodName:   podName,
+		Remote:    remote,
+		stopChan:  make(chan struct{}, 1),
+		readyChan: make(chan struct{}, 1),
+		Out:       ioutil.Discard,
+	}
+}
+
+// NewWithLocalTunnel creates a new tunnel on a specified local port
+func NewWithLocalTunnel(client rest.Interface, config *rest.Config, namespace, podName string, remote, local int) *Tunnel {
+	return &Tunnel{
+		config:    config,
+		client:    client,
+		Namespace: namespace,
+		PodName:   podName,
+		Remote:    remote,
+		Local:     local,
+		stopChan:  make(chan struct{}, 1),
+		readyChan: make(chan struct{}, 1),
+		Out:       ioutil.Discard,
+	}
+}
+
+// Close disconnects a tunnel connection
+func (t *Tunnel) Close() {
+	close(t.stopChan)
+	close(t.readyChan)
+}
+
+// ForwardPort opens a tunnel to a kubernetes pod
+func (t *Tunnel) ForwardPort() error {
+	// Build a url to the portforward endpoint
+	// example: http://localhost:8080/api/v1/namespaces/helm/pods/tiller-deploy-9itlq/portforward
+	u := t.client.Post().
+		Resource("pods").
+		Namespace(t.Namespace).
+		Name(t.PodName).
+		SubResource("portforward").URL()
+
+	transport, upgrader, err := spdy.RoundTripperFor(t.config)
+	if err != nil {
+		return err
+	}
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", u)
+
+	local, err := getAvailablePort(t.Local)
+	if err != nil {
+		return fmt.Errorf("could not find an available port: %s", err)
+	}
+	t.Local = local
+
+	ports := []string{fmt.Sprintf("%d:%d", t.Local, t.Remote)}
+
+	pf, err := portforward.New(dialer, ports, t.stopChan, t.readyChan, t.Out, t.Out)
+	if err != nil {
+		return err
+	}
+
+	errChan := make(chan error)
+	go func() {
+		errChan <- pf.ForwardPorts()
+	}()
+
+	select {
+	case err = <-errChan:
+		return fmt.Errorf("forwarding ports: %v", err)
+	case <-pf.Ready:
+		return nil
+	}
+}
+
+func getAvailablePort(localPort int) (int, error) {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", localPort))
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+
+	_, p, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		return 0, err
+	}
+	port, err := strconv.Atoi(p)
+	if err != nil {
+		return 0, err
+	}
+	return port, err
+}

--- a/pkg/draftd/portforwarder/portforwarder.go
+++ b/pkg/draftd/portforwarder/portforwarder.go
@@ -3,6 +3,7 @@ package portforwarder
 import (
 	"fmt"
 
+	"github.com/Azure/draft/pkg/draft/tunnel"
 	"github.com/Azure/draft/pkg/kube/podutil"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,7 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/helm/pkg/kube"
 	"k8s.io/helm/pkg/tiller/environment"
 )
 
@@ -20,13 +20,13 @@ const (
 )
 
 // New returns a tunnel to the Draft pod.
-func New(client kubernetes.Interface, config *restclient.Config, namespace string) (*kube.Tunnel, error) {
+func New(client kubernetes.Interface, config *restclient.Config, namespace string) (*tunnel.Tunnel, error) {
 	podName, err := getDraftPodName(client.CoreV1(), namespace)
 	if err != nil {
 		return nil, err
 	}
 	const draftPort = 44135
-	t := kube.NewTunnel(client.Core().RESTClient(), config, namespace, podName, draftPort)
+	t := tunnel.NewTunnel(client.Core().RESTClient(), config, namespace, podName, draftPort)
 	return t, t.ForwardPort()
 }
 


### PR DESCRIPTION
This PR adds the ability to specify local ports, by doing  `draft connect -p <local>:<remote> -p <local>:remote`