### PR TITLE
Initial prep work for custom tags for drafted docker images

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1092,6 +1092,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "09d18ea0a7471f02dc11146d4b00bf98f305601fc7ec6f28c01e052a8c46f90d"
+  inputs-digest = "e598e395392d2ba1f7a23155fda00ea3ed10ed370e7b05b5bb2f98c2ef1c5219"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/draft/context.go
+++ b/pkg/draft/context.go
@@ -26,7 +26,7 @@ type AppContext struct {
 	req  *rpc.UpRequest
 	buf  *bytes.Buffer
 	tag  string
-	img  string
+	imgs []string
 	out  io.Writer
 	id   string
 	vals chartutil.Values
@@ -47,6 +47,7 @@ func newAppContext(s *Server, req *rpc.UpRequest, out io.Writer) (*AppContext, e
 	ctxtID := h.Sum(nil)
 	imgtag := fmt.Sprintf("%.20x", ctxtID)
 	image := fmt.Sprintf("%s/%s:%s", s.cfg.Registry.URL, req.AppName, imgtag)
+	imageLatest := fmt.Sprintf("%s/%s:latest", s.cfg.Registry.URL, req.AppName)
 
 	// inject certain values into the chart such as the registry location,
 	// the application name, and the application version.
@@ -68,7 +69,7 @@ func newAppContext(s *Server, req *rpc.UpRequest, out io.Writer) (*AppContext, e
 		req:  req,
 		buf:  b,
 		tag:  imgtag,
-		img:  image,
+		imgs: []string{image, imageLatest},
 		out:  out,
 		vals: vals,
 	}, nil


### PR DESCRIPTION
This PR adds the latest tag to the docker image. This is useful because latest is a floating tag and will allow users to reuse the image outside the context of a `draft up` invocation if needed.
This PR also makes image names a plural which is needed to fix #541.

Ref #541 but does not fix it yet.
