### PR TITLE
Output CircleCI test results to a JUnit XML files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ jobs:
       - run:
           name: Test
           command: .circleci/test.sh
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: raw-test-output
+      - store_test_results:
+          path: /tmp/test-results
       - run:
           name: Deploy to DockerHub
           command: .circleci/deploy-dockerhub.sh

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -8,7 +8,9 @@ cd "$DRAFT_ROOT"
 
 run_unit_test() {
   echo "Running unit tests"
-  make test-unit
+  go get -u github.com/jstemmer/go-junit-report
+  trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
+  make test-unit | tee ${TEST_RESULTS}/go-test.out
 }
 
 run_style_check() {

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -9,8 +9,8 @@ cd "$DRAFT_ROOT"
 run_unit_test() {
   echo "Running unit tests"
   go get -u github.com/jstemmer/go-junit-report
-  trap "go-junit-report <${TEST_RESULTS}/go-test.out > ${TEST_RESULTS}/go-test-report.xml" EXIT
-  make test-unit | tee ${TEST_RESULTS}/go-test.out
+  trap "go-junit-report </tmp/test-results/go-test.out > /tmp/test-results/go-test-report.xml" EXIT
+  make test-unit | tee /tmp/test-results/go-test.out
 }
 
 run_style_check() {

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -9,6 +9,7 @@ cd "$DRAFT_ROOT"
 run_unit_test() {
   echo "Running unit tests"
   go get -u github.com/jstemmer/go-junit-report
+  mkdir -p /tmp/test-results
   trap "go-junit-report </tmp/test-results/go-test.out > /tmp/test-results/go-test-report.xml" EXIT
   make test-unit | tee /tmp/test-results/go-test.out
 }


### PR DESCRIPTION
This provides a nicer build experience when something fails.
Now there's no need to dig into the build logs anymore.