### PR TITLE
 Add override-ports flag and use dashes instead of underscores in draft.toml

### DIFF
--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -63,7 +63,17 @@ func (cn *connectCmd) run(runningEnvironment string) (err error) {
 		return err
 	}
 
-	connection, err := deployedApp.Connect(client, config, targetContainer, overridePorts)
+	var ports []string
+	if len(deployedApp.OverridePorts) != 0 {
+		ports = deployedApp.OverridePorts
+	}
+
+	// --override-port takes precedence
+	if len(overridePorts) != 0 {
+		ports = overridePorts
+	}
+
+	connection, err := deployedApp.Connect(client, config, targetContainer, ports)
 	if err != nil {
 		return err
 	}

--- a/cmd/draft/testdata/create/generated/empty/draft.toml
+++ b/cmd/draft/testdata/create/generated/empty/draft.toml
@@ -4,4 +4,4 @@
     namespace = "default"
     wait = false
     watch = false
-    watch_delay = 2
+    watch-delay = 2

--- a/cmd/draft/testdata/create/generated/html-but-actually-go/draft.toml
+++ b/cmd/draft/testdata/create/generated/html-but-actually-go/draft.toml
@@ -4,4 +4,4 @@
     namespace = "default"
     wait = false
     watch = false
-    watch_delay = 2
+    watch-delay = 2

--- a/cmd/draft/testdata/create/generated/simple-go-with-draftignore/draft.toml
+++ b/cmd/draft/testdata/create/generated/simple-go-with-draftignore/draft.toml
@@ -4,4 +4,4 @@
     namespace = "default"
     wait = false
     watch = false
-    watch_delay = 2
+    watch-delay = 2

--- a/cmd/draft/testdata/create/generated/simple-go/draft.toml
+++ b/cmd/draft/testdata/create/generated/simple-go/draft.toml
@@ -4,4 +4,4 @@
     namespace = "default"
     wait = false
     watch = false
-    watch_delay = 2
+    watch-delay = 2

--- a/cmd/draft/up.go
+++ b/cmd/draft/up.go
@@ -20,7 +20,7 @@ the draft server.
 Adding the "watch" option to draft.toml makes draft automatically archive and
 upload whenever local files are saved. Draft delays a couple seconds to ensure
 that changes have stopped before uploading, but that can be altered by the
-"watch_delay" option.
+"watch-delay" option.
 `
 
 const (

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ $ cat draft.toml
     namespace = "default"
     wait = false
     watch = false
-    watch_delay = 2
+    watch-delay = 2
 ```
 
 See [DEP 6](reference/dep-006.md) for more information and available configuration on the `draft.toml`.

--- a/docs/reference/dep-006.md
+++ b/docs/reference/dep-006.md
@@ -23,13 +23,13 @@ The format of this file is as follows:
     name = "draft-dev"
     set = ["foo=bar", "car=star"]
     watch = true
-    watch_delay = 1
+    watch-delay = 1
 
     [environments.staging]
     name = "draft-dev"
     namespace = "kube-system"
-    build_tar = "build.tar.gz"
-    chart_tar = "chart.tar.gz"
+    build-tar = "build.tar.gz"
+    chart-tar = "chart.tar.gz"
 ```
 
 Let's break it down by section:
@@ -53,24 +53,24 @@ name at runtime using `draft up --environment=staging`.
 ```toml
     name = "draft"
     namespace = "kube-system"
-    build_tar = "build.tar.gz"
-    chart_tar = "chart.tar.gz"
+    build-tar = "build.tar.gz"
+    chart-tar = "chart.tar.gz"
     set = ["foo=bar", "car=star"]
     wait = false
     watch = false
-    watch_delay = 2
+    watch-delay = 2
 ```
 
 Here is a run-down on each of the fields:
 
 - `name`: name of the application. This will map directly with the name of the Helm release.
 - `namespace`: the kubernetes namespace where the application will be deployed.
-- `build_tar`: path to a gzipped build tarball. `chart_tar` must also be set.
-- `chart_tar`: path to a gzipped chart tarball. `build_tar` must also be set.
+- `build-tar`: path to a gzipped build tarball. `chart-tar` must also be set.
+- `chart-tar`: path to a gzipped chart tarball. `build-tar` must also be set.
 - `set`: set custom Helm values.
 - `wait`: specifies whether or not to wait for all resources to be ready when Helm installs the chart.
 - `watch`: whether or not to deploy the app automatically when local files change.
-- `watch_delay`: the delay for local file changes to have stopped before deploying again (in seconds).
+- `watch-delay`: the delay for local file changes to have stopped before deploying again (in seconds).
 
 Note: All updates to the `draft.toml` will take effect the next time `draft up --environment=<affected environment>` is invoked _except_ the `namespace` key/value pair. Once a deployment has occurred in the original namespace, it won't be transferred over to another.
 

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -63,9 +63,9 @@ func LoadWithEnv(appdir, whichenv string) (*Context, error) {
 	}
 	// load the chart and the build archive; if a chart directory is present
 	// this will be given priority over the chart archive specified by the
-	// `chart_tar` field in the draft.toml. If this is the case, then build_tar
-	// is built from scratch. If no chart directory exists but a chart_tar and
-	// build_tar exist, then these will be used for values extraction.
+	// `chart-tar` field in the draft.toml. If this is the case, then build-tar
+	// is built from scratch. If no chart directory exists but a chart-tar and
+	// build-tar exist, then these will be used for values extraction.
 	if err := loadArchive(ctx); err != nil {
 		return nil, fmt.Errorf("failed to load chart: %v", err)
 	}
@@ -77,7 +77,7 @@ func LoadWithEnv(appdir, whichenv string) (*Context, error) {
 }
 
 // loadArchive loads the chart package and build archive.
-// Precedence is given to the `build_tar` and `chart_tar`
+// Precedence is given to the `build-tar` and `chart-tar`
 // indicated in the `draft.toml` if present. Otherwise,
 // loadArchive loads the chart directory and archives the
 // app directory to send to the draft server.

--- a/pkg/draft/local/local.go
+++ b/pkg/draft/local/local.go
@@ -28,9 +28,10 @@ const DraftLabelKey = "draft"
 //  Namespace is the Kubernetes namespace it is deployed in
 //  Container is the name the name of the application container to connect to
 type App struct {
-	Name      string
-	Namespace string
-	Container string
+	Name          string
+	Namespace     string
+	Container     string
+	OverridePorts []string
 }
 
 // Connection encapsulated information to connect to an application
@@ -60,7 +61,10 @@ func DeployedApplication(draftTomlPath, draftEnvironment string) (*App, error) {
 		return nil, fmt.Errorf("Environment %v not found", draftEnvironment)
 	}
 
-	return &App{Name: appConfig.Name, Namespace: appConfig.Namespace}, nil
+	return &App{
+		Name:          appConfig.Name,
+		Namespace:     appConfig.Namespace,
+		OverridePorts: appConfig.OverridePorts}, nil
 }
 
 // Connect tunnels to a Kubernetes pod running the application and returns the connection information

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -26,13 +26,13 @@ type Manifest struct {
 // Environment represents the environment for a given app at build time
 type Environment struct {
 	Name         string   `toml:"name,omitempty"`
-	BuildTarPath string   `toml:"build_tar,omitempty"`
-	ChartTarPath string   `toml:"chart_tar,omitempty"`
+	BuildTarPath string   `toml:"build-tar,omitempty"`
+	ChartTarPath string   `toml:"chart-tar,omitempty"`
 	Namespace    string   `toml:"namespace,omitempty"`
 	Values       []string `toml:"set,omitempty"`
 	Wait         bool     `toml:"wait"`
 	Watch        bool     `toml:"watch"`
-	WatchDelay   int      `toml:"watch_delay,omitempty"`
+	WatchDelay   int      `toml:"watch-delay,omitempty"`
 }
 
 // New creates a new manifest with the Environments intialized.

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -25,14 +25,15 @@ type Manifest struct {
 
 // Environment represents the environment for a given app at build time
 type Environment struct {
-	Name         string   `toml:"name,omitempty"`
-	BuildTarPath string   `toml:"build-tar,omitempty"`
-	ChartTarPath string   `toml:"chart-tar,omitempty"`
-	Namespace    string   `toml:"namespace,omitempty"`
-	Values       []string `toml:"set,omitempty"`
-	Wait         bool     `toml:"wait"`
-	Watch        bool     `toml:"watch"`
-	WatchDelay   int      `toml:"watch-delay,omitempty"`
+	Name          string   `toml:"name,omitempty"`
+	BuildTarPath  string   `toml:"build-tar,omitempty"`
+	ChartTarPath  string   `toml:"chart-tar,omitempty"`
+	Namespace     string   `toml:"namespace,omitempty"`
+	Values        []string `toml:"set,omitempty"`
+	Wait          bool     `toml:"wait"`
+	Watch         bool     `toml:"watch"`
+	WatchDelay    int      `toml:"watch-delay,omitempty"`
+	OverridePorts []string `toml:"override-ports,omitempty"`
 }
 
 // New creates a new manifest with the Environments intialized.

--- a/pkg/draft/manifest/manifest_test.go
+++ b/pkg/draft/manifest/manifest_test.go
@@ -8,7 +8,7 @@ import (
 func TestNew(t *testing.T) {
 	m := New()
 	m.Environments[DefaultEnvironmentName].Name = "foobar"
-	expected := "&{foobar   default [] false false 2}"
+	expected := "&{foobar   default [] false false 2 []}"
 	actual := fmt.Sprintf("%v", m.Environments[DefaultEnvironmentName])
 	if expected != actual {
 		t.Errorf("wanted %s, got %s", expected, actual)

--- a/pkg/draft/testdata/app/draft.toml
+++ b/pkg/draft/testdata/app/draft.toml
@@ -4,4 +4,4 @@
     namespace = "example-namespace"
     wait = false
     watch = false
-    watch_delay = 2
+    watch-delay = 2


### PR DESCRIPTION
This PR:

- switches underscores for dashes for `draft.toml`, as discussed in Slack
- adds an `override-ports` flag in `draft.toml`

Thanks!