### PR TITLE
Fix root command's pre run not being called

### DIFF
--- a/cmd/draft/up.go
+++ b/cmd/draft/up.go
@@ -86,7 +86,8 @@ func newUpCmd(out io.Writer) *cobra.Command {
 		Use:   "up [path]",
 		Short: "upload the current directory to the draft server for deployment",
 		Long:  upDesc,
-		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+		PersistentPreRun: func(c *cobra.Command, args []string) {
+			rootCmd.PersistentPreRunE(c, args)
 			up.dockerClientOptions.Common.SetDefaultOptions(f)
 			dockerPreRun(up.dockerClientOptions)
 		},


### PR DESCRIPTION
Because of https://github.com/spf13/cobra/issues/216, since `draft up` has its own  `PersistentPreRun`, the `rootCmd` `PersistentPreRunE` from `draft.go` is no longer called - which means (among others) that the global config is not loaded.

This adds a call to the  the `rootCmd` `PersistentPreRunE`.

cc @bacongobbler 