### PR TITLE
Auto connect for draft up

### DIFF
--- a/cmd/draft/testdata/create/generated/empty/draft.toml
+++ b/cmd/draft/testdata/create/generated/empty/draft.toml
@@ -5,3 +5,4 @@
     wait = false
     watch = false
     watch-delay = 2
+    auto-connect = false

--- a/cmd/draft/testdata/create/generated/html-but-actually-go/draft.toml
+++ b/cmd/draft/testdata/create/generated/html-but-actually-go/draft.toml
@@ -5,3 +5,4 @@
     wait = false
     watch = false
     watch-delay = 2
+    auto-connect = false

--- a/cmd/draft/testdata/create/generated/simple-go-with-draftignore/draft.toml
+++ b/cmd/draft/testdata/create/generated/simple-go-with-draftignore/draft.toml
@@ -5,3 +5,4 @@
     wait = false
     watch = false
     watch-delay = 2
+    auto-connect = false

--- a/cmd/draft/testdata/create/generated/simple-go/draft.toml
+++ b/cmd/draft/testdata/create/generated/simple-go/draft.toml
@@ -5,3 +5,4 @@
     wait = false
     watch = false
     watch-delay = 2
+    auto-connect = false

--- a/packs/clojure/charts/templates/deployment.yaml
+++ b/packs/clojure/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/clojure/charts/templates/deployment.yaml
+++ b/packs/clojure/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/csharp/charts/templates/deployment.yaml
+++ b/packs/csharp/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/csharp/charts/templates/deployment.yaml
+++ b/packs/csharp/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/go/charts/templates/deployment.yaml
+++ b/packs/go/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/go/charts/templates/deployment.yaml
+++ b/packs/go/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/gradle/charts/templates/deployment.yaml
+++ b/packs/gradle/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/gradle/charts/templates/deployment.yaml
+++ b/packs/gradle/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/java/charts/templates/deployment.yaml
+++ b/packs/java/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/java/charts/templates/deployment.yaml
+++ b/packs/java/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/javascript/charts/templates/deployment.yaml
+++ b/packs/javascript/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/javascript/charts/templates/deployment.yaml
+++ b/packs/javascript/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/php/charts/templates/deployment.yaml
+++ b/packs/php/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/php/charts/templates/deployment.yaml
+++ b/packs/php/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/python/charts/templates/deployment.yaml
+++ b/packs/python/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/python/charts/templates/deployment.yaml
+++ b/packs/python/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/ruby/charts/templates/deployment.yaml
+++ b/packs/ruby/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/ruby/charts/templates/deployment.yaml
+++ b/packs/ruby/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     draft: {{ default "draft-app" .Values.draft }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         draft: {{ default "draft-app" .Values.draft }}
         app: {{ template "fullname" . }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/swift/charts/templates/deployment.yaml
+++ b/packs/swift/charts/templates/deployment.yaml
@@ -5,15 +5,15 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     draft: {{ default "draft-app" .Values.draft }}
-    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
     metadata:
+      annotations:
+        buildID: {{ .Values.buildID }}
       labels:
         app: {{ template "fullname" . }}
         draft: {{ default "draft-app" .Values.draft }}
-        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/packs/swift/charts/templates/deployment.yaml
+++ b/packs/swift/charts/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     draft: {{ default "draft-app" .Values.draft }}
+    buildID: {{ .Values.buildID }}
 spec:
   replicas: {{ .Values.replicaCount }}
   template:
@@ -12,6 +13,7 @@ spec:
       labels:
         app: {{ template "fullname" . }}
         draft: {{ default "draft-app" .Values.draft }}
+        buildID: {{ .Values.buildID }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -86,10 +86,12 @@ func newAppContext(b *Builder, buildCtx *Context, out io.Writer) (*AppContext, e
 	imageRepository := strings.TrimLeft(fmt.Sprintf("%s/%s", buildCtx.Env.Registry, buildCtx.Env.Name), "/")
 	image := fmt.Sprintf("%s:%s", imageRepository, imgtag)
 
+	buildID := getulid()
+
 	// inject certain values into the chart such as the registry location,
-	// the application name, and the application version.
-	tplstr := "image.repository=%s,image.tag=%s,%s=%s"
-	inject := fmt.Sprintf(tplstr, imageRepository, imgtag, local.DraftLabelKey, buildCtx.Env.Name)
+	// the application name, buildID and the application version.
+	tplstr := "image.repository=%s,image.tag=%s,%s=%s,%s=%s"
+	inject := fmt.Sprintf(tplstr, imageRepository, imgtag, local.DraftLabelKey, buildCtx.Env.Name, local.BuildIDKey, buildID)
 
 	vals, err := chartutil.ReadValues([]byte(buildCtx.Values.Raw))
 	if err != nil {
@@ -98,7 +100,6 @@ func newAppContext(b *Builder, buildCtx *Context, out io.Writer) (*AppContext, e
 	if err := strvals.ParseInto(inject, vals); err != nil {
 		return nil, err
 	}
-	buildID := getulid()
 	return &AppContext{
 		obj:  &storage.Object{BuildID: buildID, ContextID: ctxtID},
 		id:   buildID,

--- a/pkg/draft/local/local.go
+++ b/pkg/draft/local/local.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 
@@ -76,9 +75,7 @@ func DeployedApplication(draftTomlPath, draftEnvironment string) (*App, error) {
 func (a *App) Connect(clientset kubernetes.Interface, clientConfig *restclient.Config, targetContainer string, overridePorts []string, buildID string) (*Connection, error) {
 	var cc []*ContainerConnection
 
-	label := labels.Set{DraftLabelKey: a.Name, BuildIDKey: buildID}
-
-	pod, err := podutil.GetPod(a.Namespace, label, clientset)
+	pod, err := podutil.GetPod(a.Namespace, DraftLabelKey, a.Name, BuildIDKey, buildID, clientset)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/draft/local/local.go
+++ b/pkg/draft/local/local.go
@@ -17,9 +17,15 @@ import (
 	"github.com/Azure/draft/pkg/kube/podutil"
 )
 
-// DraftLabelKey is the label selector key on a pod that allows
-//  us to identify which draft app a pod is associated with
-const DraftLabelKey = "draft"
+const (
+	// DraftLabelKey is the label selector key on a pod that allows
+	//  us to identify which draft app a pod is associated with
+	DraftLabelKey = "draft"
+
+	// BuildIDKey is the label selector key on a pod that specifies
+	// the build ID of the application
+	BuildIDKey = "buildID"
+)
 
 // App encapsulates information about an application to connect to
 //
@@ -67,9 +73,10 @@ func DeployedApplication(draftTomlPath, draftEnvironment string) (*App, error) {
 }
 
 // Connect tunnels to a Kubernetes pod running the application and returns the connection information
-func (a *App) Connect(clientset kubernetes.Interface, clientConfig *restclient.Config, targetContainer string, overridePorts []string) (*Connection, error) {
+func (a *App) Connect(clientset kubernetes.Interface, clientConfig *restclient.Config, targetContainer string, overridePorts []string, buildID string) (*Connection, error) {
 	var cc []*ContainerConnection
-	label := labels.Set{DraftLabelKey: a.Name}
+
+	label := labels.Set{DraftLabelKey: a.Name, BuildIDKey: buildID}
 
 	pod, err := podutil.GetPod(a.Namespace, label, clientset)
 	if err != nil {

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -35,6 +35,7 @@ type Environment struct {
 	Watch         bool     `toml:"watch"`
 	WatchDelay    int      `toml:"watch-delay,omitempty"`
 	OverridePorts []string `toml:"override-ports,omitempty"`
+	AutoConnect   bool     `toml:"auto-connect"`
 }
 
 // New creates a new manifest with the Environments intialized.
@@ -43,10 +44,11 @@ func New() *Manifest {
 		Environments: make(map[string]*Environment),
 	}
 	m.Environments[DefaultEnvironmentName] = &Environment{
-		Name:       generateName(),
-		Namespace:  DefaultNamespace,
-		Watch:      false,
-		WatchDelay: DefaultWatchDelaySeconds,
+		Name:        generateName(),
+		Namespace:   DefaultNamespace,
+		Watch:       false,
+		WatchDelay:  DefaultWatchDelaySeconds,
+		AutoConnect: false,
 	}
 	return &m
 }

--- a/pkg/draft/manifest/manifest_test.go
+++ b/pkg/draft/manifest/manifest_test.go
@@ -8,7 +8,7 @@ import (
 func TestNew(t *testing.T) {
 	m := New()
 	m.Environments[DefaultEnvironmentName].Name = "foobar"
-	expected := "&{foobar    default [] false false 2 []}"
+	expected := "&{foobar    default [] false false 2 [] false}"
 
 	actual := fmt.Sprintf("%v", m.Environments[DefaultEnvironmentName])
 	if expected != actual {


### PR DESCRIPTION
This PR adds the `draft up --auto-connect` flag and entry in manifest.

In order to ignore existing running pods with the previous version, this PR also injects the build ID as label on the pods and takes it into consideration when connecting.