### PR TITLE
document container registry setup for Minikube and AKS

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,31 +10,6 @@ There are multiple example applications included within the [examples directory]
 $ cd examples/example-python
 ```
 
-## Draft Setup
-
-### Minikube
-
-For minikube environments, the recommended way to get started is by talking to minikube's Docker daemon. To do this, we run
-
-```shell
-$ eval $(minikube docker-env)
-$ draft config set disable-push-warning 1
-```
-
-Draft will pick up on this and build Docker images using Minikube's in-cluster Docker daemon, making the build process quick and speedy.
-
-The second command disables a warning that `draft up` outputs when no registry has been configured to push images to. Since docker builds on Minikube are immediately picked up by the Kubelet, we can safely disable this warning.
-
-### Other environments
-
-If we're using a cloud-provided solution like [Azure Container Service](https://azure.microsoft.com/en-us/services/container-service/), we need to configure a registry where we will be pushing all of our images to, so all nodes in the Kubernetes cluster can pull the images we build using Draft. for this example, we want to push images to our registry sitting at `myregistry.com`, and pull those images down to the Kubernetes cluster from that same registry. To do that, we run
-
-```shell
-$ draft config set registry myregistry.com
-```
-
-This command tells Draft to push images to this Docker registry, and for Kubernetes to pull images from this Docker registry.
-
 ## Draft Create
 
 We need some "scaffolding" to deploy our app into a [Kubernetes](https://kubernetes.io/) cluster. Draft can create a [Helm](https://helm.sh/) chart, a `Dockerfile` and a `draft.toml` with `draft create`:

--- a/docs/install-advanced.md
+++ b/docs/install-advanced.md
@@ -7,6 +7,26 @@ In certain situations, users are given a Kubernetes cluster with tighter securit
 
 This document explains some of these situations as well as how it can be handled using draft.
 
+## Drafting in the Cloud
+
+When using Draft with cloud-provided Kubernetes solutions like [Azure Container Service](https://azure.microsoft.com/en-us/services/container-service/), we need a way to distribute the built image across the cluster. A container registry allows all nodes in the Kubernetes cluster to pull the images we build using Draft, and we have a way for our local Docker daemon to distribute the built image.
+
+For this example, we want to push images to our registry sitting at `myregistry.azurecr.io`, and pull those images down to the Kubernetes cluster from that same registry. To do that, we run
+
+```shell
+$ draft config set registry myregistry.azurecr.io
+```
+
+This command tells Draft to push images to this container registry as well as to tell Kubernetes to pull images from this container registry.
+
+We'll also need to log into the cluster to push images from our local docker daemon to the container registry:
+
+```
+$ az acr login -n myregistry -g myresourcegroup
+```
+
+NOTE: Kubernetes distributions like Azure Container Service are automatically authorized to pull from container registries in the same resource group. If this is not the case, then you'll need to [add a container registry secret to your chart](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry) to pull the private image.
+
 ## Running Tiller with RBAC enabled
 
 To install Tiller in a cluster with RBAC enabled, a few additional steps are required to grant tiller access to deploy in namespaces.

--- a/docs/install.md
+++ b/docs/install.md
@@ -92,6 +92,17 @@ $ helm init
 
 Wait for Helm to come up and be in a `Ready` state. You can use `kubectl -n kube-system get deploy tiller-deploy --watch` to wait for tiller to come up.
 
+## Configure Docker
+
+For minikube environments, it's best to get started by telling Draft to build images directly using Minikube's Docker daemon, making the build process quick and speedy. To do this, we run
+
+```shell
+$ eval $(minikube docker-env)
+$ draft config set disable-push-warning 1
+```
+
+The second command disables a warning that `draft up` outputs when no registry has been configured to push images to. Since docker builds on Minikube are immediately picked up by the Kubelet, we don't require a container registry and thus can safely disable this warning.
+
 ## Take Draft for a Spin
 
 Once you've completed the above steps, you're ready to climb aboard and explore the [Getting Started Guide][Getting Started] - you'll soon be sailing!


### PR DESCRIPTION
This documents the new-and-improved setup process to use Draft with and without a container registry.