### PR TITLE
Revert "add vendor to `make clean`"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ clean:
 	-rm bin/*
 	-rm rootfs/bin/*
 	-rm -rf _dist/
-	-rm -rf vendor/
 
 .PHONY: test
 test: TESTFLAGS += -race -v


### PR DESCRIPTION
This caused CI to fail to release v0.12.0-rc1 due to the workflow of `make clean build-cross` as part of [`.circleci/deploy-azure.sh`](https://github.com/Azure/draft/blob/c7c7d08721328cf84a792b23affb1476080f510e/.circleci/deploy-azure.sh#L34-L36).

Reverts Azure/draft#596