### PR TITLE
Fix pack-repo add on Windows

### DIFF
--- a/pkg/draft/pack/repo/installer/vcs_installer.go
+++ b/pkg/draft/pack/repo/installer/vcs_installer.go
@@ -3,7 +3,6 @@ package installer
 import (
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 
@@ -77,7 +76,7 @@ func (i *VCSInstaller) Install() error {
 		return repo.ErrHomeMissing
 	}
 
-	if err := os.MkdirAll(path.Dir(i.Path()), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(i.Path()), 0755); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Should fix #587 - tested in Windows and WSL

In order to test you need to:

- clone https://github.com/Azure/draft-pack-repo
- `dep ensure` and delete `vendor/github.com/Azure/draft` so it uses the one in the GOPATH (so this branch)
- `go build` 
- copy the executable in `$DRAFT_HOME/packs/draft-pack-repo/bin`

- `draft pack-repo add <pack-repo-url>` should successfully work (both in user and admin)

Please test this also with macOS and regular Linux.

On with #396!