### PR TITLE
Avoid panic for draft connect and logs when there is no build in logs

### DIFF
--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -141,5 +141,9 @@ func getLatestBuildID() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return files[len(files)-1].Name(), nil
+	n := len(files)
+	if n == 0 {
+		return "", fmt.Errorf("could not find the latest build ID of your application. Try `draft up` first")
+	}
+	return files[n-1].Name(), nil
 }


### PR DESCRIPTION
How to test this:

- delete logs in `~/.draft/logs`
- try running `draft connect` or `draft logs`

Instead of a panic, you should now get an error.