### PR TITLE
update inputs-digest

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1199,6 +1199,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6a494ae6b3b1cd15b552e01be096cefd9d1268107fb6fde105098c91bbf15fa6"
+  inputs-digest = "d4a356e270ec480b87d32abd3109ed70e01431319a7e529a058031a22176ff5f"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
this was updated when I called `make bootstrap` from master. This might be why `v0.12.0-rc2` is in a dirty git tree state.

```
><> draft version
&version.Version{SemVer:"v0.12.0-rc2", GitCommit:"b66329c163c67dc8c7f9a3560573f0c9d42ce560", GitTreeState:"dirty"}
```