### PR TITLE
re-instate injecting the image pull secret into the namespace

### DIFF
--- a/docs/install-advanced.md
+++ b/docs/install-advanced.md
@@ -38,7 +38,7 @@ We'll also need to log into the cluster to push images from our local docker dae
 $ az acr login -n myregistry -g myresourcegroup
 ```
 
-
+NOTE: Before deploying the chart to the cluster, Draft will inject a registry auth secret into the destination namespace so the image can be pulled into the cluster. You do not need to add a container registry secret into your chart; Draft will do this for you.
 
 ## Running Tiller with RBAC enabled
 

--- a/pkg/builder/registry.go
+++ b/pkg/builder/registry.go
@@ -1,0 +1,48 @@
+package builder
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/docker/docker/api/types"
+)
+
+// DockerConfigEntryWithAuth is used solely for translating docker's AuthConfig token
+// into a credentialprovider.dockerConfigEntry during JSON deserialization.
+//
+// pulled from https://github.com/kubernetes/kubernetes/blob/97892854cfa736315378cc2c206a7f4b3e190d05/pkg/credentialprovider/config.go#L232-L243
+type DockerConfigEntryWithAuth struct {
+	// +optional
+	Username string `json:"username,omitempty"`
+	// +optional
+	Password string `json:"password,omitempty"`
+	// +optional
+	Email string `json:"email,omitempty"`
+	// +optional
+	Auth string `json:"auth,omitempty"`
+}
+
+// FromAuthConfigToken converts a docker auth token into type DockerConfigEntryWithAuth. This allows us to
+// Marshal the object into a Kubernetes registry auth secret.
+func FromAuthConfigToken(authToken string) (*DockerConfigEntryWithAuth, error) {
+	data, err := base64.StdEncoding.DecodeString(authToken)
+	if err != nil {
+		return nil, err
+	}
+	var regAuth types.AuthConfig
+	if err := json.Unmarshal(data, &regAuth); err != nil {
+		return nil, err
+	}
+	return FromAuthConfig(regAuth), nil
+}
+
+// FromAuthConfig converts a docker auth token into type DockerConfigEntryWithAuth. This allows us to
+// Marshal the object into a Kubernetes registry auth secret.
+func FromAuthConfig(ac types.AuthConfig) *DockerConfigEntryWithAuth {
+	return &DockerConfigEntryWithAuth{
+		Username: ac.Username,
+		Password: ac.Password,
+		Email:    ac.Email,
+		Auth:     ac.Auth,
+	}
+}

--- a/pkg/builder/registry_test.go
+++ b/pkg/builder/registry_test.go
@@ -1,0 +1,33 @@
+package builder
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFromAuthConfigToken(t *testing.T) {
+	var authConfigTests = []struct {
+		input    string
+		fail     bool
+		expected *DockerConfigEntryWithAuth
+	}{
+		{"", true, nil},
+		{"badbase64input", true, nil},
+		{"e30K", false, &DockerConfigEntryWithAuth{}},
+		{"eyJ1c2VybmFtZSI6InVzZXJuYW1lIiwicGFzc3dvcmQiOiJwYXNzd29yZCJ9Cg==", false, &DockerConfigEntryWithAuth{Username: "username", Password: "password"}},
+		{"eyJ1c2VybmFtZSI6InVzZXJuYW1lIiwicGFzc3dvcmQiOiJwYXNzd29yZCIsImVtYWlsIjoiZW1haWwiLCJhdXRoIjoiYXV0aCJ9Cg==", false, &DockerConfigEntryWithAuth{Username: "username", Password: "password", Email: "email", Auth: "auth"}},
+		{"eyJ1c2VybmFtZSI6InVzZXJuYW1lIiwicGFzc3dvcmQiOiJwYXNzd29yZCIsImVtYWlsIjoiZW1haWwiLCJhdXRoIjoiYXV0aCIsInNlcnZlcmFkZHJlc3MiOiJodHRwOi8vc2VydmVyYWRkcmVzcy5jb20ifQo=", false, &DockerConfigEntryWithAuth{Username: "username", Password: "password", Email: "email", Auth: "auth"}},
+	}
+
+	for _, tt := range authConfigTests {
+		actual, err := FromAuthConfigToken(tt.input)
+		if tt.fail && err == nil {
+			t.Errorf("FromAuthConfigToken(%s) was expected to fail", tt.input)
+		} else if !tt.fail && err != nil {
+			t.Errorf("FromAuthConfigToken(%s) was not expected to fail", tt.input)
+		}
+		if !reflect.DeepEqual(actual, tt.expected) {
+			t.Errorf("FromAuthConfigToken(%s): expected output differs from actual", tt.input)
+		}
+	}
+}


### PR DESCRIPTION
This enables use cases like deploying to an AKS cluster with a private third party registry such as quay.io. This is the same behaviour as draftd used to work in previous releases. I removed it in #573 because I thought all the use cases we were seeing involved a level of trust between the cluster and the registry, but that is not always the case.

This feature is only enabled if the user opts into setting a registry via `draft config set registry`. It performs a lookup in `~/.docker/config` to fetch the config, then injects that into the cluster via an image pull secret.