### PR TITLE
inject plugin version into the plugin environment

### DIFF
--- a/cmd/draft/plugin.go
+++ b/cmd/draft/plugin.go
@@ -105,7 +105,7 @@ func loadPlugins(baseCmd *cobra.Command, home draftpath.Home, out io.Writer, in 
 				// Call setupEnv before PrepareCommand because
 				// PrepareCommand uses os.ExpandEnv and expects the
 				// setupEnv vars.
-				setupPluginEnv(md.Name, plug.Dir, plugdirs, draftpath.Home(homePath()))
+				setupPluginEnv(md.Name, plug.Metadata.Version, plug.Dir, plugdirs, draftpath.Home(homePath()))
 				main, argv := plug.PrepareCommand(u)
 
 				prog := exec.Command(main, argv...)
@@ -188,7 +188,7 @@ func runHook(p *plugin.Plugin, event string) error {
 	debug("running %s hook: %s %v", event, prog.Path, prog.Args)
 
 	home := draftpath.Home(homePath())
-	setupPluginEnv(p.Metadata.Name, p.Dir, home.Plugins(), home)
+	setupPluginEnv(p.Metadata.Name, p.Metadata.Version, p.Dir, home.Plugins(), home)
 	prog.Stdout, prog.Stderr = os.Stdout, os.Stderr
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
@@ -203,12 +203,13 @@ func runHook(p *plugin.Plugin, event string) error {
 // setupPluginEnv prepares os.Env for plugins. It operates on os.Env because
 // the plugin subsystem itself needs access to the environment variables
 // created here.
-func setupPluginEnv(shortname, base, plugdirs string, home draftpath.Home) {
+func setupPluginEnv(shortname, ver, base, plugdirs string, home draftpath.Home) {
 	// Set extra env vars:
 	for key, val := range map[string]string{
-		"DRAFT_PLUGIN_NAME": shortname,
-		"DRAFT_PLUGIN_DIR":  base,
-		"DRAFT_BIN":         os.Args[0],
+		"DRAFT_PLUGIN_NAME":    shortname,
+		"DRAFT_PLUGIN_VERSION": ver,
+		"DRAFT_PLUGIN_DIR":     base,
+		"DRAFT_BIN":            os.Args[0],
 
 		// Set vars that may not have been set, and save client the
 		// trouble of re-parsing.

--- a/cmd/draft/plugin_test.go
+++ b/cmd/draft/plugin_test.go
@@ -140,6 +140,7 @@ func TestLoadPlugins(t *testing.T) {
 
 func TestSetupEnv(t *testing.T) {
 	name := "pequod"
+	ver := "0.1.0"
 	ph := draftpath.Home("testdata/drafthome")
 	base := filepath.Join(ph.Plugins(), name)
 	plugdirs := ph.Plugins()
@@ -150,12 +151,13 @@ func TestSetupEnv(t *testing.T) {
 
 	resetEnvVars := unsetEnvVars()
 	defer resetEnvVars()
-	setupPluginEnv(name, base, plugdirs, ph)
+	setupPluginEnv(name, ver, base, plugdirs, ph)
 	for _, tt := range []struct {
 		name   string
 		expect string
 	}{
 		{"DRAFT_PLUGIN_NAME", name},
+		{"DRAFT_PLUGIN_VERSION", ver},
 		{"DRAFT_PLUGIN_DIR", base},
 		{"DRAFT_PLUGIN", ph.Plugins()},
 		{"DRAFT_DEBUG", "1"},


### PR DESCRIPTION
This way, install hooks invoked via `draft plugin install` know which version of the plugin to install.

relates to #627. After this, we need to give draft-pack-repo knowledge of this envvar.