### PR TITLE
Group build logs in directory for each app

### DIFF
--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -79,7 +80,7 @@ func (cn *connectCmd) run(runningEnvironment string) (err error) {
 		ports = overridePorts
 	}
 
-	buildID, err := getLatestBuildID()
+	buildID, err := getLatestBuildID(deployedApp.Name)
 	if err != nil {
 		return err
 	}
@@ -143,9 +144,9 @@ func writeContainerLogs(out io.Writer, in io.ReadCloser, containerName string) e
 	}
 }
 
-func getLatestBuildID() (string, error) {
+func getLatestBuildID(appName string) (string, error) {
 	h := draftpath.Home(homePath())
-	files, err := ioutil.ReadDir(h.Logs())
+	files, err := ioutil.ReadDir(filepath.Join(h.Logs(), appName))
 	if err != nil {
 		return "", err
 	}

--- a/cmd/draft/ensure.go
+++ b/cmd/draft/ensure.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"fmt"
-	"os"
+
+	"github.com/Azure/draft/pkg/osutil"
 
 	pluginbase "k8s.io/helm/pkg/plugin"
 
@@ -21,13 +22,9 @@ func (i *initCmd) ensureDirectories() error {
 		i.home.Logs(),
 	}
 	for _, p := range configDirectories {
-		if fi, err := os.Stat(p); err != nil {
-			fmt.Fprintf(i.out, "Creating %s \n", p)
-			if err := os.MkdirAll(p, 0755); err != nil {
-				return fmt.Errorf("Could not create %s: %s", p, err)
-			}
-		} else if !fi.IsDir() {
-			return fmt.Errorf("%s must be a directory", p)
+		err := osutil.EnsureDirectory(p)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -38,19 +35,7 @@ func (i *initCmd) ensureDirectories() error {
 //
 // If it does not exist, this function will create it.
 func (i *initCmd) ensureConfig() error {
-	fi, err := os.Stat(i.home.Config())
-	if err != nil {
-		fmt.Fprintf(i.out, "Creating %s \n", i.home.Config())
-		f, err := os.Create(i.home.Config())
-		if err != nil {
-			return fmt.Errorf("Could not create %s: %s", i.home.Config(), err)
-		}
-		defer f.Close()
-	} else if fi.IsDir() {
-		return fmt.Errorf("%s must not be a directory", i.home.Config())
-	}
-
-	return nil
+	return osutil.EnsureFile(i.home.Config())
 }
 
 // ensurePacks checks to see if the default packs exist.

--- a/cmd/draft/logs.go
+++ b/cmd/draft/logs.go
@@ -88,7 +88,7 @@ func (l *logsCmd) dumpLogs() error {
 }
 
 func (l *logsCmd) tailLogs(offset int64) error {
-	t, err := tail.TailFile(filepath.Join(l.home.Logs(), l.buildID), tail.Config{
+	t, err := tail.TailFile(filepath.Join(l.home.Logs(), l.appName, l.buildID), tail.Config{
 		Location: &tail.SeekInfo{Offset: -offset, Whence: os.SEEK_END},
 		Logger:   tail.DiscardingLogger,
 		Follow:   true,

--- a/cmd/draft/logs.go
+++ b/cmd/draft/logs.go
@@ -7,11 +7,16 @@ import (
 	"path/filepath"
 
 	"github.com/Azure/draft/pkg/draft/draftpath"
+	"github.com/Azure/draft/pkg/draft/local"
 	"github.com/hpcloud/tail"
 	"github.com/spf13/cobra"
 )
 
 const logsDesc = `This command outputs logs from the draft server to help debug builds.`
+
+var (
+	runningEnvironment string
+)
 
 type logsCmd struct {
 	out     io.Writer
@@ -35,7 +40,12 @@ func newLogsCmd(out io.Writer) *cobra.Command {
 		Long:    logsDesc,
 		PreRunE: lc.complete,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			b, err := getLatestBuildID()
+			deployedApp, err := local.DeployedApplication(draftToml, runningEnvironment)
+			if err != nil {
+				return err
+			}
+			lc.appName = deployedApp.Name
+			b, err := getLatestBuildID(lc.appName)
 			if err != nil {
 				return fmt.Errorf("cannot get latest build: %v", err)
 			}
@@ -51,6 +61,7 @@ func newLogsCmd(out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVar(&lc.tail, "tail", false, "tail the logs file as it's being written")
 	f.UintVar(&lc.line, "line", 20, "line location to tail from (offset from end of file)")
+	f.StringVarP(&runningEnvironment, environmentFlagName, environmentFlagShorthand, defaultDraftEnvironment(), environmentFlagUsage)
 	return cmd
 }
 
@@ -67,7 +78,7 @@ func (l *logsCmd) run(_ *cobra.Command, _ []string) error {
 }
 
 func (l *logsCmd) dumpLogs() error {
-	f, err := os.Open(filepath.Join(l.home.Logs(), l.buildID))
+	f, err := os.Open(filepath.Join(l.home.Logs(), l.appName, l.buildID))
 	if err != nil {
 		return fmt.Errorf("could not read logs for %s: %v", l.buildID, err)
 	}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/draft/pkg/draft/local"
 	"github.com/Azure/draft/pkg/draft/manifest"
 	"github.com/Azure/draft/pkg/draft/pack"
+	"github.com/Azure/draft/pkg/osutil"
 	"github.com/Azure/draft/pkg/storage"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/image/build"
@@ -60,8 +61,8 @@ type Builder struct {
 // Logs returns the path to the build logs.
 //
 // Set after Up is called (otherwise "").
-func (b *Builder) Logs() string {
-	return filepath.Join(b.LogsDir, b.id)
+func (b *Builder) Logs(appName string) string {
+	return filepath.Join(b.LogsDir, appName, b.id)
 }
 
 // ID returns the build id.
@@ -125,14 +126,20 @@ func newAppContext(b *Builder, buildCtx *Context) (*AppContext, error) {
 	if err := strvals.ParseInto(inject, vals); err != nil {
 		return nil, err
 	}
-	logf, err := os.OpenFile(b.Logs(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+
+	err = osutil.EnsureDirectory(filepath.Dir(b.Logs(buildCtx.Env.Name)))
+	if err != nil {
+		return nil, err
+	}
+
+	logf, err := os.OpenFile(b.Logs(buildCtx.Env.Name), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return nil, err
 	}
 	state := &storage.Object{
 		BuildID:     b.ID(),
 		ContextID:   ctxtID,
-		LogsFileRef: b.Logs(),
+		LogsFileRef: b.Logs(buildCtx.Env.Name),
 	}
 	return &AppContext{
 		obj:  state,

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -1,6 +1,7 @@
 package osutil
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"syscall"
@@ -34,4 +35,33 @@ func SymlinkWithFallback(oldname, newname string) (err error) {
 		}
 	}
 	return
+}
+
+// EnsureDirectory checks if a directory exists and creates it if it doesn't
+func EnsureDirectory(dir string) error {
+	if fi, err := os.Stat(dir); err != nil {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("Could not create %s: %s", dir, err)
+		}
+	} else if !fi.IsDir() {
+		return fmt.Errorf("%s must be a directory", dir)
+	}
+
+	return nil
+}
+
+// EnsureFile checks if a file exists and creates it if it doesn't
+func EnsureFile(file string) error {
+	fi, err := os.Stat(file)
+	if err != nil {
+		f, err := os.Create(file)
+		if err != nil {
+			return fmt.Errorf("Could not create %s: %s", file, err)
+		}
+		defer f.Close()
+	} else if fi.IsDir() {
+		return fmt.Errorf("%s must not be a directory", file)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Issue context in https://github.com/Azure/draft/issues/618#issuecomment-380512278

To test:

- delete `$DRAFT_HOME/logs`
- now if you build multiple applications, their logs should be in `$DRAFT_HOME/logs/app-name`

- `draft connect` and `draft logs` should respect the current directory and app (and not just connect / get logs for the latest app built and released)

Also added a couple of helper methods in `osutil` - to test, execute `draft init` again (as they ensure directories and files).