### PR TITLE
Add Dockerfile and chart as environment

### DIFF
--- a/cmd/draft/testdata/create/generated/empty/draft.toml
+++ b/cmd/draft/testdata/create/generated/empty/draft.toml
@@ -6,3 +6,5 @@
     watch = false
     watch-delay = 2
     auto-connect = false
+    dockerfile = ""
+    chart = ""

--- a/cmd/draft/testdata/create/generated/html-but-actually-go/draft.toml
+++ b/cmd/draft/testdata/create/generated/html-but-actually-go/draft.toml
@@ -6,3 +6,5 @@
     watch = false
     watch-delay = 2
     auto-connect = false
+    dockerfile = ""
+    chart = ""

--- a/cmd/draft/testdata/create/generated/simple-go-with-draftignore/draft.toml
+++ b/cmd/draft/testdata/create/generated/simple-go-with-draftignore/draft.toml
@@ -6,3 +6,5 @@
     watch = false
     watch-delay = 2
     auto-connect = false
+    dockerfile = ""
+    chart = ""

--- a/cmd/draft/testdata/create/generated/simple-go/draft.toml
+++ b/cmd/draft/testdata/create/generated/simple-go/draft.toml
@@ -6,3 +6,5 @@
     watch = false
     watch-delay = 2
     auto-connect = false
+    dockerfile = ""
+    chart = ""

--- a/docs/reference/dep-006.md
+++ b/docs/reference/dep-006.md
@@ -25,9 +25,11 @@ The format of this file is as follows:
     set = ["foo=bar", "car=star"]
     watch = true
     watch-delay = 1
-    override-ports = ["8080:8080"]
+    override-ports = ["8080:8080", "9229:9229"]
     auto-connect = false
     custom-tags = ["backend-dev"]
+    chart = "my-app-dev"
+    dockerfile = "Dockerfile.dev"
 
     [environments.staging]
     name = "example-go"
@@ -35,7 +37,8 @@ The format of this file is as follows:
     build-tar = "build.tar.gz"
     chart-tar = "chart.tar.gz"
     custom-tags = ["latest", "backend-staging"]
-
+    override-ports = ["8080:8080"]
+    chart = "my-app-staging"
 ```
 
 Let's break it down by section:
@@ -69,6 +72,9 @@ name at runtime using `draft up --environment=staging`.
     override-ports = ["8080:8080", "9229:9229"]
     auto-connect = false
     custom-tags = ["latest", "backend-staging"]
+    chart = "javascript"
+    dockerfile = "Dockerfile"
+
 ```
 
 Here is a run-down on each of the fields:
@@ -86,11 +92,16 @@ Here is a run-down on each of the fields:
 - `override-ports`: the configuration to be passed to the `draft connect` command, in the format `LOCALHOST_PORT:CONTAINER_PORT`
 - `auto-connect`: specifies whether Draft should automatically connect to the application after the deplyoment is successful. The local ports are configurable through the `override-ports` field.
 - `custom-tags`: specifies the custom tags Draft will push to the container registry. Note that Draft will push and use the computed SHA of the application as the tag of your image for the Helm chart.
-> Note: It is recommended to [avoid fixed image tags (like `latest`, `canary`, `dev`) in production](https://kubernetes.io/docs/concepts/configuration/overview#container-images), and Helm will not upgrade the release if the image tag is the same.
+- `chart`: the name of the directory in `charts/` that will be used to release the application for this environment
+- `dockerfile`: the name of the Dockerfile that will be used to build the image for this environment
 
-> For more information on configuring `draft connect`, check [dep-007.md][dep007]
+> Note: It is recommended to [avoid fixed image tags (like `latest`, `canary`, `dev`) in production](https://kubernetes.io/docs/concepts/configuration/overview#container-images), and if the image tag is the same in your chart, Helm will not upgrade your release.
 
-> Note: All updates to the `draft.toml` will take effect the next time `draft up --environment=<affected environment>` is invoked _except_ the `namespace` key/value pair. Once a deployment has occurred in the original namespace, it won't be transferred over to another.
+> For more information on configuring `draft connect`, check [dep-007.md][dep007].
+
+> Note: All updates to `draft.toml` will take effect the next time `draft <command> --environment=<affected environment>` is invoked. This way, you can execute `draft up`, `draft connect`, `draft delete`, `draft logs` with different environments and work on your application with different configuration. 
+
+> Note: The `namespace` key/value pair cannot be modified if the value is changed in `draft.toml`. Once a deployment has occurred in the original namespace, it won't be transferred over to another namespace. To do this, you can delete your application using  `draft delete --environment=<affected environment>` and then re-create it using `draft up --environment=<affected environment> `.
 
 # Rationale
 

--- a/examples/example-go/main.go
+++ b/examples/example-go/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello World, I'm Golang 123!")
+	fmt.Fprintf(w, "Hello World, I'm Golang!")
 }
 
 func main() {

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -2,11 +2,16 @@ package builder
 
 import (
 	"testing"
+
+	"github.com/Azure/draft/pkg/draft/manifest"
 )
 
 func TestArchiveSrc(t *testing.T) {
 	ctx := &Context{
 		AppDir: "testdata/simple",
+		Env: &manifest.Environment{
+			Dockerfile: "",
+		},
 	}
 
 	if err := archiveSrc(ctx); err != nil {

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -37,6 +37,8 @@ type Environment struct {
 	OverridePorts []string `toml:"override-ports,omitempty"`
 	AutoConnect   bool     `toml:"auto-connect"`
 	CustomTags    []string `toml:"custom-tags,omitempty"`
+	Dockerfile    string   `toml:"dockerfile"`
+	Chart         string   `toml:"chart"`
 }
 
 // New creates a new manifest with the Environments intialized.

--- a/pkg/draft/manifest/manifest_test.go
+++ b/pkg/draft/manifest/manifest_test.go
@@ -8,7 +8,7 @@ import (
 func TestNew(t *testing.T) {
 	m := New()
 	m.Environments[DefaultEnvironmentName].Name = "foobar"
-	expected := "&{foobar    default [] false false 2 [] false []}"
+	expected := "&{foobar    default [] false false 2 [] false []  }"
 
 	actual := fmt.Sprintf("%v", m.Environments[DefaultEnvironmentName])
 	if expected != actual {


### PR DESCRIPTION
This PR adds the ability to specify the Dockerfile and chart used for a specific environment in `draft.toml`.


To test:

 - `git clone https://github.com/radu-matei/draft-env-sample`
- `draft up` - this will `up` the default environment, using `Dockerfile` and the `javascript` chart
  - `draft connect` - will connect only to port 8080
- `draft up --environment debug` - this will `up` the debug environment, using `Dockerfile.debug` and the `node-debug` chart
  - `draft connect --environment debug` - will connect only to ports 8080 and 9229

Also make sure to try with a clean `draft create` and `draft up`.