### PR TITLE
Support for custom image tags

### DIFF
--- a/docs/reference/dep-006.md
+++ b/docs/reference/dep-006.md
@@ -27,12 +27,15 @@ The format of this file is as follows:
     watch-delay = 1
     override-ports = ["8080:8080"]
     auto-connect = false
+    custom-tags = ["backend-dev"]
 
     [environments.staging]
     name = "example-go"
     namespace = "kube-system"
     build-tar = "build.tar.gz"
     chart-tar = "chart.tar.gz"
+    custom-tags = ["latest", "backend-staging"]
+
 ```
 
 Let's break it down by section:
@@ -65,6 +68,7 @@ name at runtime using `draft up --environment=staging`.
     watch-delay = 2
     override-ports = ["8080:8080", "9229:9229"]
     auto-connect = false
+    custom-tags = ["latest", "backend-staging"]
 ```
 
 Here is a run-down on each of the fields:
@@ -81,10 +85,12 @@ Here is a run-down on each of the fields:
 - `watch-delay`: the delay for local file changes to have stopped before deploying again (in seconds).
 - `override-ports`: the configuration to be passed to the `draft connect` command, in the format "<local-port>:<remote-port>"
 - `auto-connect`: specifies whether Draft should automatically connect to the application after the deplyoment is successful. The local ports are configurable through the `override-ports` field.
+- `custom-tags`: specifies the custom tags Draft will push to the container registry. Note that Draft will push and use the computed SHA of the application as the tag of your image for the Helm chart.
+> Note: It is recommended to [avoid fixed image tags (like `latest`, `canary`, `dev`) in production](https://kubernetes.io/docs/concepts/configuration/overview#container-images), and Helm will not upgrade the release if the image tag is the same.
 
 > For more information on configuring `draft connect`, check [dep-007.md][dep007]
 
-Note: All updates to the `draft.toml` will take effect the next time `draft up --environment=<affected environment>` is invoked _except_ the `namespace` key/value pair. Once a deployment has occurred in the original namespace, it won't be transferred over to another.
+> Note: All updates to the `draft.toml` will take effect the next time `draft up --environment=<affected environment>` is invoked _except_ the `namespace` key/value pair. Once a deployment has occurred in the original namespace, it won't be transferred over to another.
 
 # Rationale
 

--- a/examples/example-go/main.go
+++ b/examples/example-go/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello World, I'm Golang!")
+	fmt.Fprintf(w, "Hello World, I'm Golang 123!")
 }
 
 func main() {

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -36,6 +36,7 @@ type Environment struct {
 	WatchDelay    int      `toml:"watch-delay,omitempty"`
 	OverridePorts []string `toml:"override-ports,omitempty"`
 	AutoConnect   bool     `toml:"auto-connect"`
+	CustomTags    []string `toml:"custom-tags,omitempty"`
 }
 
 // New creates a new manifest with the Environments intialized.

--- a/pkg/draft/manifest/manifest_test.go
+++ b/pkg/draft/manifest/manifest_test.go
@@ -8,7 +8,7 @@ import (
 func TestNew(t *testing.T) {
 	m := New()
 	m.Environments[DefaultEnvironmentName].Name = "foobar"
-	expected := "&{foobar    default [] false false 2 [] false}"
+	expected := "&{foobar    default [] false false 2 [] false []}"
 
 	actual := fmt.Sprintf("%v", m.Environments[DefaultEnvironmentName])
 	if expected != actual {


### PR DESCRIPTION
This PR adds support for custom image tags.
To test, build this branch and add the following config in `draft.toml`:

```
custom-tags = ["latest", "your-custom-tag"]
```

The tags `latest` and `your-custom-tag` will be pushed to the container registry, as well as the auto-generated SHA tag that is currently pushed by Draft.
