### PR TITLE
docs(dep-006): fix formatting

### DIFF
--- a/docs/reference/dep-006.md
+++ b/docs/reference/dep-006.md
@@ -83,7 +83,7 @@ Here is a run-down on each of the fields:
 - `wait`: specifies whether or not to wait for all resources to be ready when Helm installs the chart.
 - `watch`: whether or not to deploy the app automatically when local files change.
 - `watch-delay`: the delay for local file changes to have stopped before deploying again (in seconds).
-- `override-ports`: the configuration to be passed to the `draft connect` command, in the format "<local-port>:<remote-port>"
+- `override-ports`: the configuration to be passed to the `draft connect` command, in the format `LOCALHOST_PORT:CONTAINER_PORT`
 - `auto-connect`: specifies whether Draft should automatically connect to the application after the deplyoment is successful. The local ports are configurable through the `override-ports` field.
 - `custom-tags`: specifies the custom tags Draft will push to the container registry. Note that Draft will push and use the computed SHA of the application as the tag of your image for the Helm chart.
 > Note: It is recommended to [avoid fixed image tags (like `latest`, `canary`, `dev`) in production](https://kubernetes.io/docs/concepts/configuration/overview#container-images), and Helm will not upgrade the release if the image tag is the same.


### PR DESCRIPTION
The formatting on <local-port>:<remote-port> is being interpreted as an
HTML-like tag in GitHub's markdown renderer. This changes it to all caps
like an env var.

I also tried to make it slightly clearer that the first port was the one
on localhost, and the second was the one for the container. Earlier, I
got confused and interpreted "local" as "the port local to the binary"
and "remote" as "the tunnel".