### PR TITLE
Gopkg.toml: remove errors when running `dep ensure`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1221,6 +1221,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8c2333b4072ac5cfd4f0559f25bb411b602099ffe21e8693e403d66a8a97e5db"
+  inputs-digest = "502f47cfa5da99eeec46fc6b4bc762b21711b952e7b57e611637af60b0649dbc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,10 +1,4 @@
 [[constraint]]
-  name = "github.com/BurntSushi/toml"
-
-[[constraint]]
-  name = "github.com/Masterminds/semver"
-
-[[constraint]]
   name = "github.com/Masterminds/vcs"
   version = "1.11.1"
 
@@ -24,39 +18,6 @@
 [[override]]
   name = "github.com/docker/distribution"
   revision = "a97d7c0c155be14d1380c075d3197a5d89c2abc2"
-
-[[constraint]]
-  name = "github.com/fatih/color"
-
-[[constraint]]
-  name = "github.com/golang/protobuf"
-
-[[constraint]]
-  name = "github.com/gosuri/uitable"
-
-[[constraint]]
-  name = "github.com/oklog/ulid"
-
-[[constraint]]
-  name = "github.com/rjeczalik/notify"
-
-[[constraint]]
-  name = "github.com/spf13/cobra"
-
-[[constraint]]
-  name = "github.com/technosophos/moniker"
-
-[[constraint]]
-  name = "golang.org/x/crypto"
-
-[[constraint]]
-  name = "golang.org/x/net"
-
-[[constraint]]
-  name = "github.com/ghodss/yaml"
-
-[[constraint]]
-  name = "github.com/hpcloud/tail"
 
 [[constraint]]
   name = "k8s.io/helm"


### PR DESCRIPTION
The following removed lines where unnecessary since they are in
Gopkg.lock and causing error output when running `dep ensure`:

```
$ dep ensure
dep: WARNING: branch, version, revision, or source should be provided for "github.com/BurntSushi/toml"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/Masterminds/semver"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/fatih/color"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/golang/protobuf"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/gosuri/uitable"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/oklog/ulid"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/rjeczalik/notify"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/spf13/cobra"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/technosophos/moniker"
dep: WARNING: branch, version, revision, or source should be provided for "golang.org/x/crypto"
dep: WARNING: branch, version, revision, or source should be provided for "golang.org/x/net"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/ghodss/yaml"
dep: WARNING: branch, version, revision, or source should be provided for "github.com/hpcloud/tail"
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  golang.org/x/crypto

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies.
```

Signed-off-by: Jess Frazelle <acidburn@microsoft.com>