### PR TITLE
add .dockerignore and .draft-tasks.toml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ examples/**/Dockerfile
 examples/**/charts/
 examples/**/draft.toml
 examples/**/.draftignore
+examples/**/.dockerignore
+examples/**/.draft-tasks.toml
 examples/**/target
 pkg/linguist/data/classifier
 pkg/linguist/data/linguist


### PR DESCRIPTION
I'm finding these files pulled in from the draft pack when using the example-python app. Adding these to .gitignore so I don't accidentally commit these files to the example apps.