### PR TITLE
Remove protobuf setup from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,5 @@ ifndef HAS_BINDATA
 endif
 	dep ensure -v
 	scripts/setup-apimachinery.sh
-	scripts/setup-protobuf-include.sh
 
 include versioning.mk

--- a/scripts/setup-protobuf-include.sh
+++ b/scripts/setup-protobuf-include.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-mkdir vendor/protobuf && cd vendor/protobuf
-curl -LO https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
-unzip protoc-3.5.1-linux-x86_64.zip
-cd .. && mkdir protobuf-include
-cp -R protobuf/include protobuf-include/
-rm -rf protobuf


### PR DESCRIPTION
Now that we don't have a server-side component, we can get rid of the setup script for the protocol buffers.