### PR TITLE
fix init on windows

### DIFF
--- a/cmd/draft/plugin_windows.go
+++ b/cmd/draft/plugin_windows.go
@@ -22,7 +22,7 @@ func runHook(p *plugin.Plugin, event string) error {
 		return nil
 	}
 
-	prog := exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-NoLogo", "-NonInteractive", "-NoProfile", "-WindowStyle", "Hidden", "-Command", hook)
+	prog := exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-NoLogo", "-NonInteractive", "-NoProfile", "-Command", hook)
 
 	debug("running %s hook: %s %v", event, prog.Path, prog.Args)
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -97,7 +97,7 @@ type Plugin struct {
 //
 // The result is suitable to pass to exec.Command.
 func (p *Plugin) PrepareCommand(extraArgs []string) (string, []string) {
-	parts := strings.Split(os.ExpandEnv(p.Metadata.Command), " ")
+	parts := strings.Split(p.Metadata.Command, " ")
 	main := parts[0]
 	baseArgs := []string{}
 	if len(parts) > 1 {
@@ -106,7 +106,13 @@ func (p *Plugin) PrepareCommand(extraArgs []string) (string, []string) {
 	if !p.Metadata.IgnoreFlags {
 		baseArgs = append(baseArgs, extraArgs...)
 	}
-	return main, baseArgs
+
+	expandedArgs := make([]string, 0, len(baseArgs))
+	for _, baseArg := range baseArgs {
+		expandedArgs = append(expandedArgs, os.ExpandEnv(baseArg))
+	}
+
+	return os.ExpandEnv(main), expandedArgs
 }
 
 // LoadDir loads a plugin from the given directory.


### PR DESCRIPTION
Refer to #715 

While reproducing this, i hit three problems:

1) Running the plugin - PrepareCommand tries to determine the executable by splitting with " " - in case of whitespace in path it will compute a wrong path for the executable. See my changes - i work around it by expanding the environment var after splitting, and not before. This is not super clean, but works.

2) At least for me, when the hook get.ps1 is called, on my Win10 VM, the window closes immediatly. This is due to the WindowStyle Hidden flag when calling powershell for the hook. It still works correctly, but it's strange if your cli window just disappears (and makes debugging a nightmare)

3) Downloading the default plugin pack - The install hook of the default plugin repo has to be adjusted, because powershell requires a specific notation with an "&" if you require support for Commands that include whitespaces. I made a separate PR for this on the draft-pack-repo: https://github.com/draftcreate/draft-pack-repo/pull/27
Note that the version for the draft-pack has to be updated afterwards, if this gets merged.

I'm very happy if somebody tests these changes, i'm a linux user and not very comfortable with powershell. It works on my Win10 VM.