### PR TITLE
use strings.Replace instead of strings.Trim in getRegistryName

### DIFF
--- a/pkg/builder/azure/builder.go
+++ b/pkg/builder/azure/builder.go
@@ -213,7 +213,7 @@ func (b *Builder) AuthToken(ctx context.Context, app *builder.AppContext) (strin
 }
 
 func getRegistryName(registry string) string {
-	return strings.Trim(registry, ".azurecr.io")
+	return strings.Replace(registry, ".azurecr.io", "", 1)
 }
 
 func blobComplete(metadata azblob.Metadata) bool {

--- a/pkg/builder/azure/builder_test.go
+++ b/pkg/builder/azure/builder_test.go
@@ -1,0 +1,12 @@
+package azure
+
+import "testing"
+
+func TestGetRegistryName(t *testing.T) {
+	input := "acrdevname.azurecr.io"
+	expected := "acrdevname"
+	output := getRegistryName(input)
+	if output != expected {
+		t.Errorf("getRegistryName: expected %v but got %v", expected, output)
+	}
+}


### PR DESCRIPTION
Trim works with a cutset, i.e. all single characters contained in the cutset are
removed. This leads to unexpected and wrong behavior, since getRegistryName
should only remove a specific string contained in its given input.
Fixes #712