### PR TITLE
Suppress colorization when it would result in escape sequence noise

### DIFF
--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -2,6 +2,7 @@ package cmdline
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
@@ -34,6 +35,9 @@ func (cli *cmdline) Init(rootctx context.Context, opts ...Option) {
 	DefaultOpts()(&cli.opts)
 	for _, opt := range opts {
 		opt(&cli.opts)
+	}
+	if !consoleSupportsColor() {
+		NoColor()(&cli.opts)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -160,4 +164,11 @@ func passStr(msg string) string {
 func failStr(msg string) string {
 	const fail = "FAIL " + "❌"
 	return fmt.Sprintf("%s: %s", red(msg), fail)
+}
+
+func consoleSupportsColor() bool {
+	// We could try to detect the shell in use (and the mode for the Windows
+	// console), and see if it accepts VT100 escape sequences, but this is
+	// a good enough heuristic to start with!
+	return runtime.GOOS != "windows"
 }


### PR DESCRIPTION
When running `draft up` on Windows under `cmd` or `powershell`, the colourisation escape sequences are not interpreted but just printed to the screen, resulting in confusing noise around the Draft progress messages.  This PR suppresses colourisation on Windows, making messages more readable.

It would be good to detect Windows shells which are capable of handling escape sequences, e.g. `cmder` or `hyper` - this is a first step that addresses what I think is going to be the most common case for Draft on Windows.  It can be refined if required by improving the `cmdline.consoleSupportsColor()` function over time.