### PR TITLE
Docs: Dont allow pushing upstream

### DIFF
--- a/docs/contributing/hacking.md
+++ b/docs/contributing/hacking.md
@@ -53,10 +53,11 @@ $ cd draft
 ```
 
 Add the conventional [upstream][] `git` remote in order to fetch changes from Draft's main master
-branch and to create pull requests:
+branch and to create pull requests. Furthermore, configure git to not allow you to push upstream:
 
 ```shell
 $ git remote add upstream https://github.com/Azure/draft.git
+$ git remote set-url --push upstream no_push
 ```
 
 ## Build Your Changes


### PR DESCRIPTION
I noticed that in the draft/contributing/hacking.md, there was nothing about preventing someone from making the mistake of pushing changes upstream to master.  I edited the doc to include the simple git command to prevent that from happening. #newbiecontributor