### PR TITLE
fix linter suggestion

### DIFF
--- a/cmd/draft/connect.go
+++ b/cmd/draft/connect.go
@@ -142,24 +142,24 @@ func (cn *connectCmd) run(runningEnvironment string) (err error) {
 		os.Stdout.Close()
 		<-done
 		return nil
-	} else {
-		for _, cc := range connection.ContainerConnections {
-			readCloser, err := connection.RequestLogStream(deployedApp.Namespace, cc.ContainerName, cn.logLines)
-			if err != nil {
-				return err
-			}
-			defer readCloser.Close()
-			go writeContainerLogs(cn.out, readCloser, cc.ContainerName)
+	}
+
+	for _, cc := range connection.ContainerConnections {
+		readCloser, err := connection.RequestLogStream(deployedApp.Namespace, cc.ContainerName, cn.logLines)
+		if err != nil {
+			return err
 		}
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				fmt.Fprintf(cn.out, connectionMessage)
-			case <-done:
-				return nil
-			}
+		defer readCloser.Close()
+		go writeContainerLogs(cn.out, readCloser, cc.ContainerName)
+	}
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			fmt.Fprintf(cn.out, connectionMessage)
+		case <-done:
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
because the `if` block ends with a return statement, the `else` block isn't necessary.
This lowers the Cyclomatic complexity of the given block of code.