### PR TITLE
use strings.TrimSuffix instead of strings.Replace

### DIFF
--- a/pkg/builder/azure/builder.go
+++ b/pkg/builder/azure/builder.go
@@ -213,7 +213,7 @@ func (b *Builder) AuthToken(ctx context.Context, app *builder.AppContext) (strin
 }
 
 func getRegistryName(registry string) string {
-	return strings.Replace(registry, ".azurecr.io", "", 1)
+	return strings.TrimSuffix(registry, ".azurecr.io")
 }
 
 func blobComplete(metadata azblob.Metadata) bool {

--- a/pkg/builder/azure/builder_test.go
+++ b/pkg/builder/azure/builder_test.go
@@ -3,10 +3,21 @@ package azure
 import "testing"
 
 func TestGetRegistryName(t *testing.T) {
-	input := "acrdevname.azurecr.io"
-	expected := "acrdevname"
-	output := getRegistryName(input)
-	if output != expected {
-		t.Errorf("getRegistryName: expected %v but got %v", expected, output)
+	var registryNameTests = []struct {
+		in  string
+		out string
+	}{
+		{"acrdevname.azurecr.io", "acrdevname"},
+		{"jpalma.azurecr.io", "jpalma"},
+		{"usdraftacr.azurecr.io", "usdraftacr"},
+	}
+
+	for _, tt := range registryNameTests {
+		t.Run(tt.in, func(t *testing.T) {
+			actual := getRegistryName(tt.in)
+			if actual != tt.out {
+				t.Errorf("expected %v but got %v", tt.out, actual)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`strings.TrimSuffix` is a safer option than `strings.Replace` for this operation. This might also fix a bug where a registry name such as "usdraftacr.azurecr.io" is getting trimmed down to "sdraft".