### PR TITLE
add Radu Matei as an Admiral of Draft

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,7 @@
 - Matthew Fisher <@bacongobbler>
 - Michelle Noorali <@michelleN>
 - Brian Hardock <@fibonacci1729>
+- Radu Matei <@radu-matei>
 
 # Commodore
 


### PR DESCRIPTION
Radu is an administrator and has been providing valuable features to Draft for some time now; this is just a formality to add him to the OWNERS file for visibility. :heart: 