### PR TITLE
Allow charts in other directories

### DIFF
--- a/docs/reference/dep-006.md
+++ b/docs/reference/dep-006.md
@@ -29,7 +29,7 @@ The format of this file is as follows:
     override-ports = ["8080:8080", "9229:9229"]
     auto-connect = false
     custom-tags = ["backend-dev"]
-    chart = "my-app-dev"
+    chart = "charts/my-app-dev"
     dockerfile = "Dockerfile.dev"
 
     [environments.staging]
@@ -39,7 +39,7 @@ The format of this file is as follows:
     chart-tar = "chart.tar.gz"
     custom-tags = ["latest", "backend-staging"]
     override-ports = ["8080:8080"]
-    chart = "my-app-staging"
+    chart = "charts/my-app-staging"
 ```
 
 Let's break it down by section:
@@ -74,7 +74,7 @@ name at runtime using `draft up --environment=staging`.
     override-ports = ["8080:8080", "9229:9229"]
     auto-connect = false
     custom-tags = ["latest", "backend-staging"]
-    chart = "javascript"
+    chart = "charts/javascript"
     dockerfile = "Dockerfile"
     resource-group-name = "foo"
 
@@ -96,7 +96,7 @@ Here is a run-down on each of the fields:
 - `override-ports`: the configuration to be passed to the `draft connect` command, in the format `LOCALHOST_PORT:CONTAINER_PORT`
 - `auto-connect`: specifies whether Draft should automatically connect to the application after the deplyoment is successful. The local ports are configurable through the `override-ports` field.
 - `custom-tags`: specifies the custom tags Draft will push to the container registry. Note that Draft will push and use the computed SHA of the application as the tag of your image for the Helm chart.
-- `chart`: the name of the directory in `charts/` that will be used to release the application for this environment
+- `chart`: the chart (local path, relative to `draft.toml`) that will be used to release the application for this environment. If no value is specified, Draft will try to use the first directory from `charts/`. 
 - `dockerfile`: the name of the Dockerfile that will be used to build the image for this environment
 - `resource-group-name`: the name of the resource group hosting the container registry. Only used when the container builder is set to `acrbuild`
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -219,12 +219,12 @@ func loadArchive(ctx *Context) (err error) {
 
 	// if a chart was specified in manifest, use it
 	if ctx.Env.Chart != "" {
-		ctx.Chart, err = chartutil.Load(filepath.Join(ctx.AppDir, pack.ChartsDir, ctx.Env.Chart))
+		ctx.Chart, err = chartutil.Load(filepath.Join(ctx.AppDir, ctx.Env.Chart))
 		if err != nil {
 			return err
 		}
 	} else {
-		// otherwise, find the first directory in chart/ and assume that is the chart we want to deploy.
+		// otherwise, find the first directory in charts/ and assume that is the chart we want to deploy.
 		chartDir := filepath.Join(ctx.AppDir, pack.ChartsDir)
 		files, err := ioutil.ReadDir(chartDir)
 		if err != nil {


### PR DESCRIPTION
This PR enables specifying a local path for your charts (other than `charts/`).

To test this, place your chart in a directory other than `charts/`, then in `draft.toml` specify the relative path to the chart you want to release - for example: `charts = "deploy/javascript"`.
The default behaviour is persisted - if nothing was specified in the environment, Draft will try to deploy the first directory in `charts/`.

Please note that this PR opens the possibility to release a chart from upper levels, allowing scenarios where you have all charts for your services in another folder.

closes #739 