### PR TITLE
Implement image build arguments container builder

### DIFF
--- a/docs/reference/dep-006.md
+++ b/docs/reference/dep-006.md
@@ -40,6 +40,7 @@ The format of this file is as follows:
     custom-tags = ["latest", "backend-staging"]
     override-ports = ["8080:8080"]
     chart = "my-app-staging"
+    image-build-args = { BUILD_TIME_ARG = "build-time-argument-value",  HTTP_PROXY = "http://my-proxy" }
 ```
 
 Let's break it down by section:
@@ -76,6 +77,7 @@ name at runtime using `draft up --environment=staging`.
     custom-tags = ["latest", "backend-staging"]
     chart = "javascript"
     dockerfile = "Dockerfile"
+    image-build-args = { BUILD_TIME_ARG = "build-time-argument-value",  HTTP_PROXY = "http://my-proxy" }
     resource-group-name = "foo"
 
 ```
@@ -98,6 +100,7 @@ Here is a run-down on each of the fields:
 - `custom-tags`: specifies the custom tags Draft will push to the container registry. Note that Draft will push and use the computed SHA of the application as the tag of your image for the Helm chart.
 - `chart`: the name of the directory in `charts/` that will be used to release the application for this environment
 - `dockerfile`: the name of the Dockerfile that will be used to build the image for this environment
+- `image-build-args`: arguments to pass at image build time. [Follow Docker best practices about passing build time argumetns][docker-build-args]
 - `resource-group-name`: the name of the resource group hosting the container registry. Only used when the container builder is set to `acrbuild`
 
 > Note: It is recommended to [avoid fixed image tags (like `latest`, `canary`, `dev`) in production](https://kubernetes.io/docs/concepts/configuration/overview#container-images), and if the image tag is the same in your chart, Helm will not upgrade your release.
@@ -140,5 +143,6 @@ JSON certainly has its place and is stricter than YAML on field types, but it is
 [ACR Build]: https://aka.ms/acr/build
 [helm#1707]: https://github.com/kubernetes/helm/issues/1707#issuecomment-268347183
 [toml]: https://github.com/toml-lang/toml
+[docker-build-args]: https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg
 [dep007]: dep-007.md
 [dep009]: dep-009.md

--- a/pkg/builder/azure/builder.go
+++ b/pkg/builder/azure/builder.go
@@ -76,11 +76,25 @@ func (b *Builder) Build(ctx context.Context, app *builder.AppContext, out chan<-
 			imageNames = append(imageNames, fmt.Sprintf("%s:%s", app.Ctx.Env.Name, imageNameParts[len(imageNameParts)-1]))
 		}
 
+		var args []containerregistry.BuildArgument
+
+		// TODO: once the API includes this as default, remove it
+		buildArgType := "DockerBuildArgument"
+		for k := range app.Ctx.Env.ImageBuildArgs {
+			name := k
+			value := app.Ctx.Env.ImageBuildArgs[k]
+			arg := containerregistry.BuildArgument{
+				Type:  &buildArgType,
+				Name:  &name,
+				Value: &value,
+			}
+			args = append(args, arg)
+		}
+
 		req := containerregistry.QuickBuildRequest{
 			ImageNames:     to.StringSlicePtr(imageNames),
 			SourceLocation: sourceUploadDefinition.RelativePath,
-			// TODO: make this configurable with https://github.com/Azure/draft/issues/663
-			BuildArguments: nil,
+			BuildArguments: &args,
 			IsPushEnabled:  to.BoolPtr(true),
 			Timeout:        to.Int32Ptr(600),
 			Platform: &containerregistry.PlatformProperties{

--- a/pkg/builder/docker/builder.go
+++ b/pkg/builder/docker/builder.go
@@ -32,9 +32,16 @@ func (b *Builder) Build(ctx context.Context, app *builder.AppContext, out chan<-
 	msgc := make(chan string)
 	errc := make(chan error)
 	go func() {
+		args := make(map[string]*string)
+		for k := range app.Ctx.Env.ImageBuildArgs {
+			v := app.Ctx.Env.ImageBuildArgs[k]
+			args[k] = &v
+		}
+
 		buildopts := types.ImageBuildOptions{
 			Tags:       app.Images,
 			Dockerfile: app.Ctx.Env.Dockerfile,
+			BuildArgs:  args,
 		}
 
 		resp, err := b.DockerClient.Client().ImageBuild(ctx, app.Buf, buildopts)

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -25,22 +25,23 @@ type Manifest struct {
 
 // Environment represents the environment for a given app at build time
 type Environment struct {
-	Name              string   `toml:"name,omitempty"`
-	ContainerBuilder  string   `toml:"container-builder,omitempty"`
-	Registry          string   `toml:"registry,omitempty"`
-	ResourceGroupName string   `toml:"resource-group-name,omitempty"`
-	BuildTarPath      string   `toml:"build-tar,omitempty"`
-	ChartTarPath      string   `toml:"chart-tar,omitempty"`
-	Namespace         string   `toml:"namespace,omitempty"`
-	Values            []string `toml:"set,omitempty"`
-	Wait              bool     `toml:"wait"`
-	Watch             bool     `toml:"watch"`
-	WatchDelay        int      `toml:"watch-delay,omitempty"`
-	OverridePorts     []string `toml:"override-ports,omitempty"`
-	AutoConnect       bool     `toml:"auto-connect"`
-	CustomTags        []string `toml:"custom-tags,omitempty"`
-	Dockerfile        string   `toml:"dockerfile"`
-	Chart             string   `toml:"chart"`
+	Name              string            `toml:"name,omitempty"`
+	ContainerBuilder  string            `toml:"container-builder,omitempty"`
+	Registry          string            `toml:"registry,omitempty"`
+	ResourceGroupName string            `toml:"resource-group-name,omitempty"`
+	BuildTarPath      string            `toml:"build-tar,omitempty"`
+	ChartTarPath      string            `toml:"chart-tar,omitempty"`
+	Namespace         string            `toml:"namespace,omitempty"`
+	Values            []string          `toml:"set,omitempty"`
+	Wait              bool              `toml:"wait"`
+	Watch             bool              `toml:"watch"`
+	WatchDelay        int               `toml:"watch-delay,omitempty"`
+	OverridePorts     []string          `toml:"override-ports,omitempty"`
+	AutoConnect       bool              `toml:"auto-connect"`
+	CustomTags        []string          `toml:"custom-tags,omitempty"`
+	Dockerfile        string            `toml:"dockerfile"`
+	Chart             string            `toml:"chart"`
+	ImageBuildArgs    map[string]string `toml:"image-build-args,omitempty"`
 }
 
 // New creates a new manifest with the Environments intialized.

--- a/pkg/draft/manifest/manifest_test.go
+++ b/pkg/draft/manifest/manifest_test.go
@@ -8,7 +8,7 @@ import (
 func TestNew(t *testing.T) {
 	m := New()
 	m.Environments[DefaultEnvironmentName].Name = "foobar"
-	expected := "&{foobar      default [] true false 2 [] false []  }"
+	expected := "&{foobar      default [] true false 2 [] false []   map[]}"
 
 	actual := fmt.Sprintf("%v", m.Environments[DefaultEnvironmentName])
 	if expected != actual {


### PR DESCRIPTION
This PR adds build arguments for the Docker builder.

To test it: 

- add the following in `draft.toml`:

```
    image-build-args = { BUILD_TIME_ARG = "build-time-argument-value",  HTTP_PROXY = "http://my-proxy" }
```

- use the arguments in your Dockerfile:

```
ARG BUILD_TIME_ARG
RUN echo $BUILD_TIME_ARG
ARG HTTP_PROXY
RUN echo $HTTP_PROXY
```

Here are the [best practices for Docker build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg), linked in the dep here.

closes #663 