### PR TITLE
[Feature] use cwd for Chartname if appName not given

### DIFF
--- a/pkg/draft/pack/create.go
+++ b/pkg/draft/pack/create.go
@@ -2,6 +2,8 @@ package pack
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/Azure/draft/pkg/draft/pack/repo"
 )
@@ -17,6 +19,11 @@ func CreateFrom(dest, src string, appName string) error {
 	// Update ChartName if appName is non-empty
 	if appName != "" {
 		pack.Chart.Metadata.Name = appName
+	} else {
+		cwd, err := os.Getwd()
+		if err == nil {
+			pack.Chart.Metadata.Name = filepath.Base(cwd)
+		}
 	}
 	return pack.SaveDir(dest)
 }


### PR DESCRIPTION
Addresses ChartName change to match current dir if appName not supplied.

```
example-go $ ../../bin/draft create
--> Draft detected Go (80.633803%)
--> Ready to sail
example-go $ tree -L 2
.
├── Dockerfile
├── charts
│   └── example-go
├── draft.toml
├── glide.yaml
└── main.go

2 directories, 4 files
```
Original concern here: https://github.com/Azure/draft/pull/784