### PR TITLE
WIP: Fix circle memory issues

### DIFF
--- a/.circleci/deploy-azure.sh
+++ b/.circleci/deploy-azure.sh
@@ -32,7 +32,7 @@ easy_install pyOpenSSL
 pip install --disable-pip-version-check --no-cache-dir azure-cli~=2.0
 
 echo "Building Draft binaries"
-make clean build-cross
+make GOXFLAGS="-parallel 3" clean build-cross
 VERSION="${VERSION}" make dist checksum
 
 echo "Pushing binaries to Azure Blob Storage"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ TESTS     := .
 TESTFLAGS :=
 LDFLAGS   :=
 GOFLAGS   :=
+GOXFLAGS  :=
 BINDIR    := $(CURDIR)/bin
 BINARIES  := draft
 
@@ -30,7 +31,7 @@ build:
 .PHONY: build-cross
 build-cross: LDFLAGS += -extldflags "-static"
 build-cross:
-	CGO_ENABLED=0 gox -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' github.com/Azure/draft/cmd/$(APP)
+	CGO_ENABLED=0 gox -output="_dist/{{.OS}}-{{.Arch}}/{{.Dir}}" -osarch='$(TARGETS)' $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' $(GOXFLAGS) github.com/Azure/draft/cmd/$(APP)
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
gox defaults to numCPU - 1 when cross-compiling, which on CircleCI this happens to be 31. By limiting to 3 parallel builds at one time, we prevent the issue of CircleCI running out of memory.