### PR TITLE
Fix wrong Dockerfile path when running draft up from another directory

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -264,7 +264,9 @@ func loadValues(ctx *Context) error {
 }
 
 func archiveSrc(ctx *Context) error {
-	contextDir, relDockerfile, err := build.GetContextFromLocalDir(ctx.AppDir, ctx.Env.Dockerfile)
+
+	dockerfilePath := filepath.Join(ctx.AppDir, ctx.Env.Dockerfile)
+	contextDir, relDockerfile, err := build.GetContextFromLocalDir(ctx.AppDir, dockerfilePath)
 	if err != nil {
 		return fmt.Errorf("unable to prepare docker context: %s", err)
 	}


### PR DESCRIPTION
To test this:

- change the name of your Dockerfile in the directory and change that name in `draft.toml` - for example, using `example-go` from this repo:

```
[environments]
  [environments.development]
    name = "testing-golang"
    namespace = "default"
    custom-tags = ["latest", "canary"]
    dockerfile = "Dockerfile.golang"
```

- run: `draft up examples/example-go` and everything should work as intented

Anyone around who can test on Windows before I do?

closes #720 

Thanks, @bacongobbler, for quickly identifying the issue!