### PR TITLE
Command-line documentation for draft config set

### DIFF
--- a/cmd/draft/config.go
+++ b/cmd/draft/config.go
@@ -14,6 +14,19 @@ const (
 	configHelp = `Manage global Draft configuration stored in $DRAFT_HOME/config.toml.`
 )
 
+type configKey struct {
+	name        string
+	description string
+}
+
+var (
+	registry           = configKey{name: "registry", description: "Registry to push built containers to (e.g. docker.io/foo, foo.azurecr.io)"}
+	containerBuilder   = configKey{name: "container-builder", description: "How to build the container (supported values: docker, acrbuild)"}
+	resourceGroupName  = configKey{name: "resource-group-name", description: "The Azure resource group of the container registry (for Azure registries only)"}
+	disablePushWarning = configKey{name: "disable-push-warning", description: "Suppresses warning if no registry set"}
+	configKeys         = []configKey{registry, containerBuilder, resourceGroupName, disablePushWarning}
+)
+
 // DraftConfig is the configuration stored in $DRAFT_HOME/config.toml
 type DraftConfig map[string]string
 

--- a/cmd/draft/config_set.go
+++ b/cmd/draft/config_set.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -32,7 +34,7 @@ func newConfigSetCmd(out io.Writer) *cobra.Command {
 }
 
 func (ccmd *configSetCmd) complete(args []string) error {
-	if err := validateArgs(args, ccmd.args); err != nil {
+	if err := validateConfigSetArgs(args, ccmd.args); err != nil {
 		return err
 	}
 	ccmd.key = args[0]
@@ -43,4 +45,23 @@ func (ccmd *configSetCmd) complete(args []string) error {
 func (ccmd *configSetCmd) run() error {
 	globalConfig[ccmd.key] = ccmd.value
 	return SaveConfig(globalConfig)
+}
+
+func validateConfigSetArgs(args, expectedArgs []string) error {
+	if len(args) == 1 {
+		for _, k := range configKeys {
+			if k.name == args[0] {
+				return fmt.Errorf("This command needs a value: %v", k.description)
+			}
+		}
+		return fmt.Errorf("This command needs a value. No help available for key '%v'", args[0])
+	}
+	if len(args) != len(expectedArgs) {
+		keys := []string{}
+		for _, k := range configKeys {
+			keys = append(keys, "  "+k.name+": "+k.description)
+		}
+		return fmt.Errorf("This command needs a key and a value to set it to. Supported keys:\n%v", strings.Join(keys, "\n"))
+	}
+	return nil
 }

--- a/cmd/draft/up.go
+++ b/cmd/draft/up.go
@@ -150,22 +150,22 @@ func (u *upCmd) run(environment string) (err error) {
 		return fmt.Errorf("failed loading build context with env %q: %v", environment, err)
 	}
 
-	if configuredBuilder, ok := globalConfig["container-builder"]; ok {
+	if configuredBuilder, ok := globalConfig[containerBuilder.name]; ok {
 		buildctx.Env.ContainerBuilder = configuredBuilder
 	}
 
 	// if a registry has been set in their global config but nothing was in draft.toml, use that instead
-	if reg, ok := globalConfig["registry"]; ok {
+	if reg, ok := globalConfig[registry.name]; ok {
 		buildctx.Env.Registry = reg
 	}
 
-	if configuredResourceGroup, ok := globalConfig["resource-group-name"]; ok {
+	if configuredResourceGroup, ok := globalConfig[resourceGroupName.name]; ok {
 		buildctx.Env.ResourceGroupName = configuredResourceGroup
 	}
 
 	if buildctx.Env.Registry == "" {
 		// give a way for minikube users (and users who understand what they're doing) a way to opt out
-		if _, ok := globalConfig["disable-push-warning"]; !ok {
+		if _, ok := globalConfig[disablePushWarning.name]; !ok {
 			fmt.Fprintln(u.out, "WARNING: no registry has been set, therefore Draft will not push to a container registry. This can be fixed by running `draft config set registry docker.io/myusername`")
 			fmt.Fprintln(u.out, "Hint: this warning can be disabled by running `draft config set disable-push-warning 1`")
 		}


### PR DESCRIPTION
Provides additional feedback to users trying to use `draft config set`, by listing the known config keys or providing help on the value required for the selected config key.  The behaviour is now:

`draft config set`: Message now reads:

```
Error: This command needs a key and a value to set it to. Supported keys:
  registry: Registry to push built containers to (e.g. docker.io/foo, foo.azurecr.io)
  container-builder: How to build the container (supported values: docker, acrbuild)
  ... etc ...
```

`draft config set foo`: Message now reads `Error: This command needs a value: Registry to push built containers to (e.g. docker.io/foo, foo.azurecr.io)`.  If the key is not a known one, the second part of the message is instead `No help available for key 'foo'`.

These changes only affect the messages displayed when arguments are missing.  They do not validate the keys, so do not prevent users from making mistakes (e.g. `draft config set registyr docker.io/foo`).

There is a maintenance consideration here where new config entries need to be added to the `configKeys` collection.  Failing to do this won't stop them being used (set/listed/got), but they won't show up in the docs.

Behaviour and design are both very much up for grabs - feedback welcome.  E.g. do we want to validate, are the messages correct, is the use of a specialised validation method for `config set` unacceptable, etc.

Fixes #729.