### PR TITLE
Reorder tasks and load during draft up

### DIFF
--- a/cmd/draft/up.go
+++ b/cmd/draft/up.go
@@ -146,6 +146,20 @@ func (u *upCmd) run(environment string) (err error) {
 		bldr       = builder.New()
 	)
 	bldr.LogsDir = u.home.Logs()
+
+	taskList, err := tasks.Load(tasksTOMLFile)
+	if err != nil {
+		if err == tasks.ErrNoTaskFile {
+			debug(err.Error())
+		} else {
+			return err
+		}
+	} else {
+		if _, err = taskList.Run(tasks.PreUp, ""); err != nil {
+			return err
+		}
+	}
+
 	if buildctx, err = builder.LoadWithEnv(u.src, environment); err != nil {
 		return fmt.Errorf("failed loading build context with env %q: %v", environment, err)
 	}
@@ -215,19 +229,6 @@ func (u *upCmd) run(environment string) (err error) {
 	bldr.Helm, err = setupHelm(bldr.Kube, kubeConfig, tillerNamespace)
 	if err != nil {
 		return fmt.Errorf("Could not get a helm client: %s", err)
-	}
-
-	taskList, err := tasks.Load(tasksTOMLFile)
-	if err != nil {
-		if err == tasks.ErrNoTaskFile {
-			debug(err.Error())
-		} else {
-			return err
-		}
-	} else {
-		if _, err = taskList.Run(tasks.PreUp, ""); err != nil {
-			return err
-		}
 	}
 
 	// setup the storage engine


### PR DESCRIPTION
Addresses issue from https://github.com/Azure/draft/issues/805 where 

> pre-up draft tasks happen after the environment and helm chart have been loaded in to memory, so it's not possible to download helm dependencies using helm dependency update a pre-up task and have them loaded with the rest of the chart and deployed. 

Discovered by @sam-doordash 