### PR TITLE
Using Dockerfile as default for dockerfile in draft.toml

### DIFF
--- a/cmd/draft/testdata/create/generated/empty/draft.toml
+++ b/cmd/draft/testdata/create/generated/empty/draft.toml
@@ -6,5 +6,5 @@
     watch = false
     watch-delay = 2
     auto-connect = false
-    dockerfile = ""
+    dockerfile = "Dockerfile"
     chart = ""

--- a/cmd/draft/testdata/create/generated/html-but-actually-go/draft.toml
+++ b/cmd/draft/testdata/create/generated/html-but-actually-go/draft.toml
@@ -6,5 +6,5 @@
     watch = false
     watch-delay = 2
     auto-connect = false
-    dockerfile = ""
+    dockerfile = "Dockerfile"
     chart = ""

--- a/cmd/draft/testdata/create/generated/simple-go-with-draftignore/draft.toml
+++ b/cmd/draft/testdata/create/generated/simple-go-with-draftignore/draft.toml
@@ -6,5 +6,5 @@
     watch = false
     watch-delay = 2
     auto-connect = false
-    dockerfile = ""
+    dockerfile = "Dockerfile"
     chart = ""

--- a/cmd/draft/testdata/create/generated/simple-go/draft.toml
+++ b/cmd/draft/testdata/create/generated/simple-go/draft.toml
@@ -6,5 +6,5 @@
     watch = false
     watch-delay = 2
     auto-connect = false
-    dockerfile = ""
+    dockerfile = "Dockerfile"
     chart = ""

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -58,7 +58,7 @@ func New() *Manifest {
 		Watch:       false,
 		WatchDelay:  DefaultWatchDelaySeconds,
 		AutoConnect: false,
-		Dockerfile:  DefaultDockerfile
+		Dockerfile:  DefaultDockerfile,
 	}
 	return &m
 }

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -16,6 +16,8 @@ const (
 	// DefaultWatchDelaySeconds is the time delay between files being changed and when a
 	// new draft up` invocation is called when --watch is supplied.
 	DefaultWatchDelaySeconds = 2
+	// DefaultDockerfile is the Dockerfile being used by default
+	DefaultDockerfile = "Dockerfile"
 )
 
 // Manifest represents a draft.toml
@@ -56,6 +58,7 @@ func New() *Manifest {
 		Watch:       false,
 		WatchDelay:  DefaultWatchDelaySeconds,
 		AutoConnect: false,
+		Dockerfile:  DefaultDockerfile
 	}
 	return &m
 }

--- a/pkg/draft/manifest/manifest_test.go
+++ b/pkg/draft/manifest/manifest_test.go
@@ -8,7 +8,7 @@ import (
 func TestNew(t *testing.T) {
 	m := New()
 	m.Environments[DefaultEnvironmentName].Name = "foobar"
-	expected := "&{foobar      default [] true false 2 [] false []   map[]}"
+	expected := "&{foobar      default [] true false 2 [] false [] Dockerfile  map[]}"
 
 	actual := fmt.Sprintf("%v", m.Environments[DefaultEnvironmentName])
 	if expected != actual {

--- a/pkg/draft/testdata/app/draft.toml
+++ b/pkg/draft/testdata/app/draft.toml
@@ -5,3 +5,4 @@
     wait = false
     watch = false
     watch-delay = 2
+    dockerfile = "Dockerfile"


### PR DESCRIPTION
Fix #808 

This solution adds default value for dockerfile in draft.toml to Dockerfile.