### PR TITLE
Adding example usage of set in draft.toml

### DIFF
--- a/docs/reference/dep-006.md
+++ b/docs/reference/dep-006.md
@@ -111,6 +111,35 @@ Here is a run-down on each of the fields:
 
 > Note: The `namespace` key/value pair cannot be modified if the value is changed in `draft.toml`. Once a deployment has occurred in the original namespace, it won't be transferred over to another namespace. To do this, you can delete your application using  `draft delete --environment=<affected environment>` and then re-create it using `draft up --environment=<affected environment> `.
 
+## Examples
+
+Here are some more examples of how each field can be used:
+
+### Set
+
+Set must be a map, but can have multiple key/value pairs set such as `set = [ "key1"="val1", "key2"="val2"]`. If you want to set fields within a  map in the Helm `values.yaml`, then use a dotted notation.
+
+For example, if the Helm values.yaml defines a service:
+
+```
+...
+service:
+  name: website
+  type: ClusterIP
+  externalPort: 8080
+  internalPort: 80
+```
+
+
+And you want to override the `type` and `externalPort` values, you would include both of them in the map for `set` in `draft.toml`
+
+```
+  [environments.live]
+    ...
+    set = ["service.type=LoadBalancer", "service.externalPort=80"]
+```
+
+
 # Rationale
 
 ## Why TOML
@@ -140,6 +169,9 @@ There is an [excellent blog post](https://arp242.net/weblog/yaml_probably_not_so
 JSON certainly has its place and is stricter than YAML on field types, but it is not a human-readable markup language. You can't write comments in JSON. That's a non-starter for a file that's meant to be used by developers to express how their application is deployed to production. At the end of the day, we're writing a tool for developers, not machines. For projects that stand up infrastructure like [acs-engine](https://github.com/Azure/acs-engine) or [kops](https://github.com/kubernetes/kops), JSON is an excellent fit.
 
 
+
+
+<!-- end matter -->
 [ACR Build]: https://aka.ms/acr/build
 [helm#1707]: https://github.com/kubernetes/helm/issues/1707#issuecomment-268347183
 [toml]: https://github.com/toml-lang/toml


### PR DESCRIPTION
I wanted to be able to use a different service type and port number in different environments. I may debug on a clusterIP, but want to deploy to an external IP and port 80 for production. I couldn't find a clear explanation of how to use `set` so I added an explanation and samples.