### PR TITLE
Avoid panic when using config set before draft init

### DIFF
--- a/cmd/draft/config_set.go
+++ b/cmd/draft/config_set.go
@@ -44,7 +44,7 @@ func (ccmd *configSetCmd) complete(args []string) error {
 
 func (ccmd *configSetCmd) run() error {
 	if globalConfig == nil {
-		return fmt.Errorf("Draft configuration in $DRAFT_HOME/config.toml has not been initialized")
+		return fmt.Errorf("Draft configuration in $DRAFT_HOME/config.toml has not been initialized. Run draft init to get started.")
 	}
 	globalConfig[ccmd.key] = ccmd.value
 	return SaveConfig(globalConfig)

--- a/cmd/draft/config_set.go
+++ b/cmd/draft/config_set.go
@@ -43,6 +43,9 @@ func (ccmd *configSetCmd) complete(args []string) error {
 }
 
 func (ccmd *configSetCmd) run() error {
+	if globalConfig == nil {
+		return fmt.Errorf("Draft configuration in $DRAFT_HOME/config.toml has not been initialized")
+	}
 	globalConfig[ccmd.key] = ccmd.value
 	return SaveConfig(globalConfig)
 }


### PR DESCRIPTION
Output error message instead of golang panic stacktrace.

Fixes #824 