### PR TITLE
Fix create permissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,4 @@
-# Contributing
 
-The Draft project accepts contributions via GitHub pull requests. This document outlines the process to help get your contribution accepted.
-
-## Reporting a Security Issue
 
 Most of the time, when you find a bug in Draft, it should be reported using GitHub issues. However, if you are reporting a security vulnerability, please email a report to one of the [core maintainers][owners] directly. This will give the maintainers a chance to try to fix the issue before it is exploited in the wild.
 
@@ -10,7 +6,7 @@ Most of the time, when you find a bug in Draft, it should be reported using GitH
 
 We'd love to accept your patches! Before we can take them, we have to jump a couple of legal hurdles.
 
-Community contributors to code repositories open sourced by Microsoft must sign the [Microsoft Contributor License Agreement][cla]. By signing a CLA, we ensure that the community is free to use your contributions. 
+Community contributors to code repositories open sourced by Microsoft must sign the [Microsoft Contributor License Agreement][cla]. By signing a CLA, we ensure that the community is free to use your contributions.
 
 Once you are CLA'ed, we'll be able to accept your pull requests. For any issues that you face during this process, please write a comment explaining the issue and we will help get it sorted out.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,8 @@
+# Contributing
 
+The Draft project accepts contributions via GitHub pull requests. This document outlines the process to help get your contribution accepted.
+
+## Reporting a Security Issue
 
 Most of the time, when you find a bug in Draft, it should be reported using GitHub issues. However, if you are reporting a security vulnerability, please email a report to one of the [core maintainers][owners] directly. This will give the maintainers a chance to try to fix the issue before it is exploited in the wild.
 

--- a/pkg/draft/pack/load.go
+++ b/pkg/draft/pack/load.go
@@ -2,8 +2,7 @@ package pack
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
+		"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -16,7 +15,7 @@ import (
 // and hand off to the appropriate pack reader.
 func FromDir(dir string) (*Pack, error) {
 	pack := new(Pack)
-	pack.Files = make(map[string]io.ReadCloser)
+	pack.Files = make(map[string]PackFile)
 
 	topdir, err := filepath.Abs(dir)
 	if err != nil {
@@ -41,7 +40,7 @@ func FromDir(dir string) (*Pack, error) {
 				return nil, err
 			}
 			if fInfo.Name() != "README.md" {
-				pack.Files[fInfo.Name()] = f
+				pack.Files[fInfo.Name()] = PackFile{f, fInfo.Mode().Perm()}
 			}
 		} else {
 			if fInfo.Name() != "charts" {
@@ -49,8 +48,8 @@ func FromDir(dir string) (*Pack, error) {
 				if err != nil {
 					return nil, err
 				}
-				for k, v := range packFiles {
-					pack.Files[k] = v
+				for k, packFile := range packFiles {
+					pack.Files[k] = packFile
 				}
 			}
 		}
@@ -59,9 +58,9 @@ func FromDir(dir string) (*Pack, error) {
 	return pack, nil
 }
 
-func extractFiles(dir, base string) (map[string]io.ReadCloser, error) {
+func extractFiles(dir, base string) (map[string]PackFile, error) {
 	baseDir := filepath.Join(base, filepath.Base(dir))
-	packFiles := make(map[string]io.ReadCloser)
+	packFiles := make(map[string]PackFile)
 
 	absDir, err := filepath.Abs(dir)
 	if err != nil {
@@ -80,7 +79,7 @@ func extractFiles(dir, base string) (map[string]io.ReadCloser, error) {
 			if err != nil {
 				return nil, err
 			}
-			packFiles[filepath.Join(baseDir, fInfo.Name())] = f
+			packFiles[filepath.Join(baseDir, fInfo.Name())] = PackFile{f, fInfo.Mode().Perm()}
 		} else {
 			nestedPackFiles, err := extractFiles(filepath.Join(dir, fInfo.Name()), baseDir)
 			if err != nil {

--- a/pkg/draft/pack/load.go
+++ b/pkg/draft/pack/load.go
@@ -2,7 +2,7 @@ package pack
 
 import (
 	"fmt"
-		"io/ioutil"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 

--- a/pkg/draft/pack/load_test.go
+++ b/pkg/draft/pack/load_test.go
@@ -29,7 +29,7 @@ func TestFromDir(t *testing.T) {
 
 	defer func() {
 		for _, f := range pack.Files {
-			f.Close()
+			f.file.Close()
 		}
 	}()
 
@@ -42,7 +42,7 @@ func TestFromDir(t *testing.T) {
 		t.Error("expected Dockerfile to have been loaded")
 	}
 
-	dockerfileContents, err := ioutil.ReadAll(dockerfile)
+	dockerfileContents, err := ioutil.ReadAll(dockerfile.file)
 	if err != nil {
 		t.Errorf("expected Dockerfile to be readable, got %v", err)
 	}

--- a/pkg/draft/pack/pack.go
+++ b/pkg/draft/pack/pack.go
@@ -41,7 +41,7 @@ const (
 	TargetTasksFileName = ".draft-tasks.toml"
 )
 
-type PackFile struct{
+type PackFile struct {
 	file io.ReadCloser
 	perm os.FileMode
 }

--- a/pkg/draft/pack/pack.go
+++ b/pkg/draft/pack/pack.go
@@ -74,7 +74,6 @@ func (p *Pack) SaveDir(dest string) error {
 	if !exists {
 		f, ok := p.Files[TasksFileName]
 		if ok {
-			fmt.Println("Pack has a tasks file")
 			newfile, err := os.Create(tasksFilePath)
 			if err != nil {
 				return err
@@ -84,7 +83,6 @@ func (p *Pack) SaveDir(dest string) error {
 			io.Copy(newfile, f.file)
 			os.Chmod(tasksFilePath, f.perm)
 		} else {
-			fmt.Println("Pack DOESN'T have a tasks file")
 			tasksFile, err := os.Create(tasksFilePath)
 			if err != nil {
 				return err

--- a/pkg/draft/pack/pack_test.go
+++ b/pkg/draft/pack/pack_test.go
@@ -24,7 +24,7 @@ cleanup-task = "echo cleanup"
 
 func TestSaveDir(t *testing.T) {
 	dockerPerm := os.FileMode(0666)
-	tasksPerm := os.FileMode(0777)
+	tasksPerm := os.FileMode(0655)
 	p := &Pack{
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{

--- a/pkg/draft/pack/pack_test.go
+++ b/pkg/draft/pack/pack_test.go
@@ -2,7 +2,6 @@ package pack
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"os"
@@ -55,8 +54,7 @@ func TestSaveDir(t *testing.T) {
 		}
 	}
 	if fInfo.Mode() != dockerPerm {
-		fmt.Println("DockerFile perms different")
-		t.Fail()
+		t.Errorf("DockerFile perms different. Expected %s, but got %s", dockerPerm, fInfo.Mode())
 	}
 
 	tasksPath := filepath.Join(dir, TargetTasksFileName)
@@ -69,8 +67,7 @@ func TestSaveDir(t *testing.T) {
 		}
 	}
 	if fInfo.Mode() != tasksPerm {
-		fmt.Println("Tasks file perms different")
-		t.Fail()
+		t.Errorf("Tasks file perms different. Expected %s, but got %s", tasksPerm, fInfo.Mode())
 	}
 
 	data, err := ioutil.ReadFile(tasksPath)

--- a/pkg/draft/pack/pack_test.go
+++ b/pkg/draft/pack/pack_test.go
@@ -2,13 +2,13 @@ package pack
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 	"os"
 	"path/filepath"
 	"testing"
-	"k8s.io/helm/pkg/proto/hapi/chart"
-	"fmt"
-	)
+)
 
 const testDockerfile = `FROM nginx:latest
 `
@@ -32,8 +32,8 @@ func TestSaveDir(t *testing.T) {
 			},
 		},
 		Files: map[string]PackFile{
-			dockerfileName: PackFile{ioutil.NopCloser(bytes.NewBufferString(testDockerfile)), dockerPerm},
-			TasksFileName:  PackFile{ioutil.NopCloser(bytes.NewBufferString(testTasksFile)), tasksPerm},
+			dockerfileName: {ioutil.NopCloser(bytes.NewBufferString(testDockerfile)), dockerPerm},
+			TasksFileName:  {ioutil.NopCloser(bytes.NewBufferString(testTasksFile)), tasksPerm},
 		},
 	}
 	dir, err := ioutil.TempDir("", "draft-pack-test")
@@ -58,7 +58,6 @@ func TestSaveDir(t *testing.T) {
 		fmt.Println("DockerFile perms different")
 		t.Fail()
 	}
-
 
 	tasksPath := filepath.Join(dir, TargetTasksFileName)
 	fInfo, err = os.Stat(tasksPath)
@@ -91,7 +90,7 @@ func TestSaveDirDockerfileExistsInAppDir(t *testing.T) {
 			},
 		},
 		Files: map[string]PackFile{
-			dockerfileName: PackFile{ioutil.NopCloser(bytes.NewBufferString(testDockerfile)), 664},
+			dockerfileName: {ioutil.NopCloser(bytes.NewBufferString(testDockerfile)), 664},
 		},
 	}
 	dir, err := ioutil.TempDir("", "draft-pack-test")

--- a/pkg/draft/pack/pack_test.go
+++ b/pkg/draft/pack/pack_test.go
@@ -2,14 +2,13 @@ package pack
 
 import (
 	"bytes"
-		"io/ioutil"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
-		"k8s.io/helm/pkg/proto/hapi/chart"
+	"k8s.io/helm/pkg/proto/hapi/chart"
 	"fmt"
-	"reflect"
-)
+	)
 
 const testDockerfile = `FROM nginx:latest
 `
@@ -55,12 +54,6 @@ func TestSaveDir(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	fmt.Println("DockerFile on disk perms")
-	fmt.Println(uint32(fInfo.Mode().Perm()))
-	fmt.Println(reflect.TypeOf(fInfo.Mode()))
-	fmt.Println("DockerFile in memory perms")
-	fmt.Println(uint32(dockerPerm))
-	fmt.Println(reflect.TypeOf(dockerPerm))
 	if fInfo.Mode() != dockerPerm {
 		fmt.Println("DockerFile perms different")
 		t.Fail()
@@ -76,12 +69,6 @@ func TestSaveDir(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	fmt.Println("TasksFile on disk perms")
-	fmt.Println(uint32(fInfo.Mode().Perm()))
-	fmt.Println(reflect.TypeOf(fInfo.Mode()))
-	fmt.Println("TasksFile in memory perms")
-	fmt.Println(uint32(tasksPerm))
-	fmt.Println(reflect.TypeOf(tasksPerm))
 	if fInfo.Mode() != tasksPerm {
 		fmt.Println("Tasks file perms different")
 		t.Fail()

--- a/pkg/draft/pack/pack_test.go
+++ b/pkg/draft/pack/pack_test.go
@@ -3,11 +3,12 @@ package pack
 import (
 	"bytes"
 	"io/ioutil"
-	"k8s.io/helm/pkg/proto/hapi/chart"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"k8s.io/helm/pkg/proto/hapi/chart"
 )
 
 const testDockerfile = `FROM nginx:latest

--- a/pkg/draft/pack/pack_test.go
+++ b/pkg/draft/pack/pack_test.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/helm/pkg/proto/hapi/chart"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 

--- a/pkg/draft/pack/pack_test.go
+++ b/pkg/draft/pack/pack_test.go
@@ -22,8 +22,10 @@ cleanup-task = "echo cleanup"
 `
 
 func TestSaveDir(t *testing.T) {
-	dockerPerm := os.FileMode(0666)
-	tasksPerm := os.FileMode(0655)
+	dockerPerm := os.FileMode(0664)
+	winDockerPerm := os.FileMode(0666)
+	tasksPerm := os.FileMode(0644)
+	winTasksPerm := os.FileMode(0666)
 	p := &Pack{
 		Chart: &chart.Chart{
 			Metadata: &chart.Metadata{
@@ -53,7 +55,10 @@ func TestSaveDir(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if fInfo.Mode() != dockerPerm {
+	if fInfo.Mode() != dockerPerm && runtime.GOOS != "windows" {
+		t.Errorf("DockerFile perms different. Expected %s, but got %s", dockerPerm, fInfo.Mode())
+	}
+	if fInfo.Mode() != winDockerPerm && runtime.GOOS == "windows" {
 		t.Errorf("DockerFile perms different. Expected %s, but got %s", dockerPerm, fInfo.Mode())
 	}
 
@@ -66,7 +71,10 @@ func TestSaveDir(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if fInfo.Mode() != tasksPerm {
+	if fInfo.Mode() != tasksPerm && runtime.GOOS != "windows" {
+		t.Errorf("Tasks file perms different. Expected %s, but got %s", tasksPerm, fInfo.Mode())
+	}
+	if fInfo.Mode() != winTasksPerm && runtime.GOOS == "windows" {
 		t.Errorf("Tasks file perms different. Expected %s, but got %s", tasksPerm, fInfo.Mode())
 	}
 


### PR DESCRIPTION
This includes a major logic change and the appropriate tests. The big change: the Pack struct's File data is now of type map[string]PackFile instead of map[string]io.ReadCloser. This allows Pack to have both the data from a file, as well as its file permissions. Everything using Pack has been updated to use the new structure.