### PR TITLE
Packs: corrected gradle docker image

### DIFF
--- a/packs/gradle/Dockerfile
+++ b/packs/gradle/Dockerfile
@@ -1,11 +1,12 @@
 FROM gradle:jdk10 as BUILD
 
-COPY . /project
-RUN gradle -b /project/build.gradle clean build
+COPY --chown=gradle:gradle . /project
+RUN gradle -i -s -b /project/build.gradle clean installDist && \
+    rm -rf /project/build/install/*/bin/*.bat
 
 FROM openjdk:10-jre-slim
 ENV PORT 4567
 EXPOSE 4567
-COPY --from=BUILD /project/target/app.jar /opt/app.jar
-WORKDIR /opt
-CMD ["java", "-jar", "app.jar"]
+COPY --from=BUILD /project/build/install/* /opt/
+WORKDIR /opt/bin
+CMD ["/bin/bash", "-c", "find -type f -name '*' | xargs bash"]


### PR DESCRIPTION
Corrects docker image in the gradle pack.
Fixes in file permissions and the way the app is ran