### PR TITLE
Remove onbuild from docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,7 +23,7 @@ $ ls -a
 .draft-tasks.toml Dockerfile        charts/           requirements.txt
 ```
 
-The `charts/` and `Dockerfile` assets created by Draft default to a basic Python configuration. This `Dockerfile` harnesses the [python:onbuild](https://hub.docker.com/_/python/) image, which will install the dependencies in `requirements.txt` and copy the current directory into `/usr/src/app`. To align with the `internalPort` service value in `charts/python/values.yaml`, this `Dockerfile` exposes port 8080 from the container.
+The `charts/` and `Dockerfile` assets created by Draft default to a basic Python configuration. This `Dockerfile` uses the [python](https://hub.docker.com/_/python/) image, and will install the dependencies in `requirements.txt` and copy the current directory into `/usr/src/app`. To align with the `internalPort` service value in `charts/python/values.yaml`, this `Dockerfile` exposes port 8080 from the container.
 
 The `draft.toml` file contains basic configuration details about the application like the name, the repository, which namespace it will be deployed to, and whether to deploy the application automatically when local files change.
 

--- a/docs/reference/dep-003.md
+++ b/docs/reference/dep-003.md
@@ -56,7 +56,7 @@ $ mkdir python
 $ cd python
 $ helm create chart
 Creating chart
-$ echo "FROM python:onbuild" > Dockerfile
+$ echo "FROM python" > Dockerfile
 ```
 
 Plans and ideas to improve the pack creation workflow can be found in [issue 287][#287].


### PR DESCRIPTION
As docker images used in bundled packs does not use onbuild images anymore, the docs should reflect that

Fixes #861 