### PR TITLE
Add quiet flag to up

### DIFF
--- a/cmd/draft/up.go
+++ b/cmd/draft/up.go
@@ -117,14 +117,14 @@ func newUpCmd(out io.Writer) *cobra.Command {
 
 	f = cmd.Flags()
 	f.StringVarP(&runningEnvironment, environmentFlagName, environmentFlagShorthand, defaultDraftEnvironment(), environmentFlagUsage)
-	f.BoolVar(&up.dockerClientOptions.Common.Debug, "docker-debug", false, "Enable debug mode")
-	f.StringVar(&up.dockerClientOptions.Common.LogLevel, "docker-log-level", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
-	f.BoolVar(&up.dockerClientOptions.Common.TLS, "docker-tls", defaultDockerTLS(), "Use TLS; implied by --tlsverify")
+	f.BoolVar(&up.dockerClientOptions.Common.Debug, "docker-debug", false, "enable debug mode")
+	f.StringVar(&up.dockerClientOptions.Common.LogLevel, "docker-log-level", "info", `set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
+	f.BoolVar(&up.dockerClientOptions.Common.TLS, "docker-tls", defaultDockerTLS(), "use TLS; implied by --tlsverify")
 	f.BoolVar(&up.dockerClientOptions.Common.TLSVerify, fmt.Sprintf("docker-%s", dockerflags.FlagTLSVerify), defaultDockerTLSVerify(), "use TLS and verify the remote")
-	f.StringVar(&up.dockerClientOptions.ConfigDir, "docker-config", cliconfig.Dir(), "Location of client config files")
-	f.BoolVarP(&autoConnect, "auto-connect", "", false, "Specifies if draft up should automatically connect to the application")
-	f.BoolVar(&skipImagePush, "skip-image-push", false, "Skip pushing image to registry")
-	f.BoolVarP(&quiet, "quiet", "q", false, "Only output errors")
+	f.StringVar(&up.dockerClientOptions.ConfigDir, "docker-config", cliconfig.Dir(), "location of client config files")
+	f.BoolVarP(&autoConnect, "auto-connect", "", false, "specifies if draft up should automatically connect to the application")
+	f.BoolVar(&skipImagePush, "skip-image-push", false, "skip pushing image to registry")
+	f.BoolVarP(&quiet, "quiet", "q", false, "only output errors")
 
 	up.dockerClientOptions.Common.TLSOptions = &tlsconfig.Options{
 		CAFile:   filepath.Join(dockerCertPath, dockerflags.DefaultCaFile),

--- a/cmd/draft/up.go
+++ b/cmd/draft/up.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -48,6 +49,7 @@ var (
 	dockerCertPath = os.Getenv("DOCKER_CERT_PATH")
 	autoConnect    bool
 	skipImagePush  bool
+	quiet          bool
 )
 
 type upCmd struct {
@@ -118,10 +120,11 @@ func newUpCmd(out io.Writer) *cobra.Command {
 	f.BoolVar(&up.dockerClientOptions.Common.Debug, "docker-debug", false, "Enable debug mode")
 	f.StringVar(&up.dockerClientOptions.Common.LogLevel, "docker-log-level", "info", `Set the logging level ("debug"|"info"|"warn"|"error"|"fatal")`)
 	f.BoolVar(&up.dockerClientOptions.Common.TLS, "docker-tls", defaultDockerTLS(), "Use TLS; implied by --tlsverify")
-	f.BoolVar(&up.dockerClientOptions.Common.TLSVerify, fmt.Sprintf("docker-%s", dockerflags.FlagTLSVerify), defaultDockerTLSVerify(), "Use TLS and verify the remote")
+	f.BoolVar(&up.dockerClientOptions.Common.TLSVerify, fmt.Sprintf("docker-%s", dockerflags.FlagTLSVerify), defaultDockerTLSVerify(), "use TLS and verify the remote")
 	f.StringVar(&up.dockerClientOptions.ConfigDir, "docker-config", cliconfig.Dir(), "Location of client config files")
-	f.BoolVarP(&autoConnect, "auto-connect", "", false, "specifies if draft up should automatically connect to the application")
-	f.BoolVar(&skipImagePush, "skip-image-push", false, "skip pushing image to registry")
+	f.BoolVarP(&autoConnect, "auto-connect", "", false, "Specifies if draft up should automatically connect to the application")
+	f.BoolVar(&skipImagePush, "skip-image-push", false, "Skip pushing image to registry")
+	f.BoolVarP(&quiet, "quiet", "q", false, "Only output errors")
 
 	up.dockerClientOptions.Common.TLSOptions = &tlsconfig.Options{
 		CAFile:   filepath.Join(dockerCertPath, dockerflags.DefaultCaFile),
@@ -241,7 +244,13 @@ func (u *upCmd) run(environment string) (err error) {
 	// setup the storage engine
 	bldr.Storage = configmap.NewConfigMaps(bldr.Kube.CoreV1().ConfigMaps(tillerNamespace))
 	progressC := bldr.Up(ctx, buildctx)
-	cmdline.Display(ctx, buildctx.Env.Name, progressC, cmdline.WithBuildID(bldr.ID))
+	opts := []cmdline.Option{cmdline.WithBuildID(bldr.ID)}
+
+	if quiet {
+		opts = append(opts, cmdline.WithStdout(ioutil.Discard))
+	}
+
+	cmdline.Display(ctx, buildctx.Env.Name, progressC, opts...)
 
 	if buildctx.Env.AutoConnect || autoConnect {
 		c := newConnectCmd(u.out)

--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -125,29 +125,29 @@ func Display(ctx context.Context, app string, summaries <-chan *builder.Summary,
 
 func progress(cli *cmdline, app, desc string, codes <-chan builder.SummaryStatusCode) {
 	start := time.Now()
-	done := make(chan string, 1)
+	done := make(chan builder.SummaryStatusCode, 1)
 	go func() {
 		defer close(done)
 		for code := range codes {
-			switch code {
-			case builder.SummarySuccess:
-				done <- fmt.Sprintf("%s: %s  (%.4fs)\n", cyan(app), passStr(desc), time.Since(start).Seconds())
-				return
-			case builder.SummaryFailure:
-				done <- fmt.Sprintf("%s: %s  (%.4fs)\n", cyan(app), failStr(desc), time.Since(start).Seconds())
-				return
+			if code == builder.SummarySuccess || code == builder.SummaryFailure {
+				done <- code
 			}
 		}
-		done <- "\n"
 	}()
 	m := fmt.Sprintf("%s: %s", cyan(app), yellow(desc))
 	s := `-\|/-`
 	i := 0
 	for {
 		select {
-		case msg := <-done:
-			fmt.Fprintf(cli.opts.stdout, "\r%s", msg)
-			return
+		case code := <-done:
+			switch code {
+			case builder.SummarySuccess:
+				fmt.Fprintf(cli.opts.stdout, "\r%s: %s  (%.4fs)\n", cyan(app), passStr(desc), time.Since(start).Seconds())
+				return
+			case builder.SummaryFailure:
+				fmt.Fprintf(cli.opts.stderr, "\r%s: %s  (%.4fs)\n", cyan(app), failStr(desc), time.Since(start).Seconds())
+				return
+			}
 		default:
 			fmt.Fprintf(cli.opts.stdout, "\r%s %c", m, s[i%len(s)])
 			time.Sleep(50 * time.Millisecond)


### PR DESCRIPTION
This PR adds the `--quiet` flag to the `up` command (fixes #386).