### PR TITLE
Fix dead link to installation guide and update helm repository link

### DIFF
--- a/docs/contributing/hacking.md
+++ b/docs/contributing/hacking.md
@@ -85,10 +85,10 @@ $ make clean
 
 
 [docker]: https://www.docker.com/
-[install]: ../install.md
+[install]: ../install-minikube.md
 [git]: https://git-scm.com/
 [go]: https://golang.org/
-[helm]: https://github.com/kubernetes/helm
+[helm]: https://github.com/helm/helm
 [Homebrew]: https://brew.sh/
 [Kubernetes]: https://github.com/kubernetes/kubernetes
 [minikube]: https://github.com/kubernetes/minikube

--- a/docs/contributing/hacking.md
+++ b/docs/contributing/hacking.md
@@ -10,7 +10,7 @@ To compile and test Draft binaries and to build Docker images, you will need:
  - a [Kubernetes][] cluster. We recommend [minikube][].
  - [docker][]
  - [git][]
- - [helm][], using the same version as recommended in the [installation guide][install].
+ - [helm][], see the [quickstart guide][quickstart] for installing helm
  - [Go][] 1.8 or later, with support for compiling to `linux/amd64`
 
 In most cases, install the prerequisite according to its instructions. See the next section
@@ -85,7 +85,7 @@ $ make clean
 
 
 [docker]: https://www.docker.com/
-[install]: ../install-minikube.md
+[quickstart]: ../quickstart.md#install-and-configure-helm
 [git]: https://git-scm.com/
 [go]: https://golang.org/
 [helm]: https://github.com/helm/helm


### PR DESCRIPTION
Fixes a dead link to the install-minikube.md guide which was previously named `install.md` and got renamed in #647.