### PR TITLE
Add default Dockerfile name in builder

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -40,6 +40,8 @@ const (
 	PullSecretName = "draft-pullsecret"
 	// DefaultServiceAccountName is the name of the default service account draft will modify with the imagepullsecret
 	DefaultServiceAccountName = "default"
+	// DefaultDockerfile represents the default name of the Dockerfile if not specified in draft.toml
+	DefaultDockerfile = "Dockerfile"
 )
 
 // Builder contains information about the build environment
@@ -264,6 +266,9 @@ func loadValues(ctx *Context) error {
 }
 
 func archiveSrc(ctx *Context) error {
+	if ctx.Env.Dockerfile == "" {
+		ctx.Env.Dockerfile = DefaultDockerfile
+	}
 
 	dockerfilePath := filepath.Join(ctx.AppDir, ctx.Env.Dockerfile)
 	contextDir, relDockerfile, err := build.GetContextFromLocalDir(ctx.AppDir, dockerfilePath)


### PR DESCRIPTION
Ever since #798 was merged, omitting the name of the Dockerfile in `draft.toml` broke `draft up`.

This PR checks if the Dockerfile was set in `draft.toml`, and if not, sets it as the default Dockerfile - `Dockerfile`.

To test:

- in one of the examples in this repo do a `draft create`
- `draft up` - this should work now even if the `dockerfile` field in `draft.toml` is empty (`""`) or missing
- add the actual Dockerfile name (`Dockerfile`) in `draft.toml` and run `draft up` again - this should still work.

closes #869 