### PR TITLE
Update CircleCI Go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,10 @@ jobs:
   build:
     working_directory: /go/src/github.com/Azure/draft
     docker:
-      - image: golang:1.9
+      - image: golang:1.11.1
     environment:
       AZURE_CONTAINER: "draft"
       AZURE_STORAGE_ACCOUNT: "azuredraft"
-      DOCKER_USERNAME: "bacongobbler"
     steps:
       - checkout
       - run: echo 'export PATH=/go/src/github.com/Azure/draft/bin:$PATH' >> $BASH_ENV


### PR DESCRIPTION
This PR updates the Go version used in CircleCI to the latest current version (Go 1.11.1).
It also removes an unused reference to `DOCKER_USERNAME` (used in the past, when Draft used to have a cluster component).


closes #873 