### PR TITLE
Fix golint warning: redundant if ...; err != nil check, just return error instead.

### DIFF
--- a/cmd/draft/init.go
+++ b/cmd/draft/init.go
@@ -101,11 +101,7 @@ func (i *initCmd) setupDraftHome(plugins []plugin.Builtin, repos []repo.Builtin)
 	if err := i.ensurePlugins(plugins); err != nil {
 		return err
 	}
-	if err := i.ensurePacks(repos); err != nil {
-		return err
-	}
-
-	return nil
+	return i.ensurePacks(repos)
 }
 
 type obj struct {


### PR DESCRIPTION
This PR removes an unnecessary if condition to cleanup a golint warning.
Should be really straightforward.