### PR TITLE
i have used 'Search In Files' in VScode to isolate all reference to '…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 * implemented Draft tasks (see DEP 008)
 * introduced ACR Build support, with support for writing alternative container builders (see DEP 009)
 * introduced Windows support
-* introduced Powershell support for plugin install hooks
+* introduced Powershell support for plugin install tasks
 * introduced `draft pack list`
 * introduced support for custom image tags on `draft up`
 * introduced `draft init --config` to specify a default set of plugins and pack repositories to bootstrap Draft

--- a/cmd/draft/plugin_install.go
+++ b/cmd/draft/plugin_install.go
@@ -68,7 +68,7 @@ func (pcmd *pluginInstallCmd) run() error {
 	}
 
 	debug("running any install instructions for plugin: %s", p.Metadata.Name)
-	if err := runHook(p, plugin.Install); err != nil {
+	if err := runTask(p, plugin.Install); err != nil {
 		return err
 	}
 

--- a/cmd/draft/plugin_remove.go
+++ b/cmd/draft/plugin_remove.go
@@ -71,7 +71,7 @@ func removePlugin(p *plugin.Plugin) error {
 	if err := os.RemoveAll(p.Dir); err != nil {
 		return err
 	}
-	return runHook(p, plugin.Delete)
+	return runTask(p, plugin.Delete)
 }
 
 func findPlugin(plugins []*plugin.Plugin, name string) *plugin.Plugin {

--- a/cmd/draft/plugin_unix.go
+++ b/cmd/draft/plugin_unix.go
@@ -11,20 +11,20 @@ import (
 	"github.com/Azure/draft/pkg/plugin"
 )
 
-// runHook will execute a plugin hook.
-func runHook(p *plugin.Plugin, event string) error {
-	hooks, ok := p.Metadata.PlatformHooks["bash"]
+// runTask will execute a plugin task.
+func runTask(p *plugin.Plugin, event string) error {
+	tasks, ok := p.Metadata.PlatformTasks["bash"]
 	if !ok {
 		return nil
 	}
-	hook := hooks.Get(event)
-	if hook == "" {
+	task := tasks.Get(event)
+	if task == "" {
 		return nil
 	}
 
-	prog := exec.Command("sh", "-c", hook)
+	prog := exec.Command("sh", "-c", task)
 
-	debug("running %s hook: %s %v", event, prog.Path, prog.Args)
+	debug("running %s task: %s %v", event, prog.Path, prog.Args)
 
 	home := draftpath.Home(homePath())
 	setupPluginEnv(p.Metadata.Name, p.Metadata.Version, p.Dir, home.Plugins(), home)
@@ -32,7 +32,7 @@ func runHook(p *plugin.Plugin, event string) error {
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
 			os.Stderr.Write(eerr.Stderr)
-			return fmt.Errorf("plugin %s hook for %q exited with error", event, p.Metadata.Name)
+			return fmt.Errorf("plugin %s task for %q exited with error", event, p.Metadata.Name)
 		}
 		return err
 	}

--- a/cmd/draft/plugin_update.go
+++ b/cmd/draft/plugin_update.go
@@ -95,5 +95,5 @@ func updatePlugin(p *plugin.Plugin, home draftpath.Home) error {
 		return err
 	}
 
-	return runHook(updatedPlugin, plugin.Update)
+	return runTask(updatedPlugin, plugin.Update)
 }

--- a/cmd/draft/plugin_windows.go
+++ b/cmd/draft/plugin_windows.go
@@ -11,20 +11,20 @@ import (
 	"github.com/Azure/draft/pkg/plugin"
 )
 
-// runHook will execute a plugin hook.
-func runHook(p *plugin.Plugin, event string) error {
-	hooks, ok := p.Metadata.PlatformHooks["powershell"]
+// runTask will execute a plugin task.
+func runTask(p *plugin.Plugin, event string) error {
+	tasks, ok := p.Metadata.PlatformTasks["powershell"]
 	if !ok {
 		return nil
 	}
-	hook := hooks.Get(event)
-	if hook == "" {
+	task := tasks.Get(event)
+	if task == "" {
 		return nil
 	}
 
-	prog := exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-NoLogo", "-NonInteractive", "-NoProfile", "-Command", hook)
+	prog := exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-NoLogo", "-NonInteractive", "-NoProfile", "-Command", task)
 
-	debug("running %s hook: %s %v", event, prog.Path, prog.Args)
+	debug("running %s task: %s %v", event, prog.Path, prog.Args)
 
 	home := draftpath.Home(homePath())
 	setupPluginEnv(p.Metadata.Name, p.Metadata.Version, p.Dir, home.Plugins(), home)
@@ -32,7 +32,7 @@ func runHook(p *plugin.Plugin, event string) error {
 	if err := prog.Run(); err != nil {
 		if eerr, ok := err.(*exec.ExitError); ok {
 			os.Stderr.Write(eerr.Stderr)
-			return fmt.Errorf("plugin %s hook for %q exited with error", event, p.Metadata.Name)
+			return fmt.Errorf("plugin %s task for %q exited with error", event, p.Metadata.Name)
 		}
 		return err
 	}

--- a/cmd/draft/testdata/plugins/echo/plugin.yaml
+++ b/cmd/draft/testdata/plugins/echo/plugin.yaml
@@ -3,7 +3,7 @@ usage: "echo stuff"
 description: "This echos stuff"
 command: "echo hello"
 version: "1.0.0"
-hooks:
+tasks:
   bash:
     install: "echo installing"
   powershell:

--- a/docs/reference/dep-008.md
+++ b/docs/reference/dep-008.md
@@ -11,7 +11,7 @@ This document describes draft `tasks`, how to define them, and when to use them.
 
 # Motivation
 
-Draft users may find themselves wanting to hook into different parts of the draft application lifecycle. For example, a user may want to set up or install a dependency in their cluster before running `draft up`, run commands in their application container after deploying it to their Kubernetes cluster, or perform cleanup steps after deleting their application. Draft tasks make it possible for users to define and run these types of actions.
+Draft users may find themselves wanting to hook into different parts of the draft application lifecycle. For example, a user may want to set up or install a dependency in their cluster before running `draft up`, run commands in their application container after deploying it to their Kubernetes cluster, or perform cleanup steps after deleting their application. Draft tasks make it possible for users to define and run these types of actions. This event is known as a Task. 
 
 # Specification
 Tasks live in `.draft-tasks.toml` in an application's root directory. If a tasks.toml file is specified in a draft pack, running the `draft create` command will copy `tasks.toml` from the draft pack to `.draft-tasks.toml` in the application's root directory.

--- a/pkg/plugin/Tasks.go
+++ b/pkg/plugin/Tasks.go
@@ -15,7 +15,7 @@ limitations under the License.
 
 package plugin
 
-// Types of hooks
+// Types of tasks
 const (
 	// Install is executed after the plugin is added.
 	Install = "install"
@@ -25,11 +25,11 @@ const (
 	Update = "update"
 )
 
-// Hooks is a map of events to commands.
-type Hooks map[string]string
+// Tasks is a map of events to commands.
+type Tasks map[string]string
 
-// Get returns a hook for an event.
-func (hooks Hooks) Get(event string) string {
-	h, _ := hooks[event]
+// Get returns a task for an event.
+func (tasks Tasks) Get(event string) string {
+	h, _ := tasks[event]
 	return h
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -74,8 +74,8 @@ type Metadata struct {
 	// automatic setting of HELM_HOST.
 	UseTunnel bool `json:"useTunnel"`
 
-	// PlatformHooks are commands that will run on events based on the platform specified.
-	PlatformHooks map[string]Hooks `json:"hooks"`
+	// PlatformTasks are commands that will run on events based on the platform specified.
+	PlatformTasks map[string]Tasks `json:"tasks"`
 
 	// Downloaders field is used if the plugin supply downloader mechanism
 	// for special protocols.

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -83,7 +83,7 @@ func TestLoadDir(t *testing.T) {
 		Command:     "$HELM_PLUGIN_SELF/hello.sh",
 		UseTunnel:   true,
 		IgnoreFlags: true,
-		PlatformHooks: map[string]Hooks{
+		PlatformTasks: map[string]Tasks{
 			"bash": {
 				Install: "echo installing...",
 			},

--- a/pkg/plugin/testdata/plugdir/echo/plugin.yaml
+++ b/pkg/plugin/testdata/plugdir/echo/plugin.yaml
@@ -4,6 +4,6 @@ usage: "echo something"
 description: |-
   This is a testing fixture. Thank you Helm.
 command: "echo Hello"
-hooks:
+tasks:
   bash:
     install: "echo Installing"

--- a/pkg/plugin/testdata/plugdir/hello/plugin.yaml
+++ b/pkg/plugin/testdata/plugdir/hello/plugin.yaml
@@ -5,6 +5,6 @@ description: "description"
 command: "$HELM_PLUGIN_SELF/hello.sh"
 useTunnel: true
 ignoreFlags: true
-hooks:
+tasks:
   bash:
     install: "echo installing..."


### PR DESCRIPTION
used VSCode 'find in files' for 'Hook' and manually changed them to Task or Tasks. including renaming plugin/Hooks.go to Tasks.go happy hacktoberfest. hope i didn't eff it up. :) 


I added a line in docs/reference/dep-008 to the paragraph about hook functionality. I kept it the same, but added a line stating that this functionality is referred to as a Task. :) 
