### PR TITLE
Docs: draft create will also copy pack permissions

### DIFF
--- a/docs/reference/dep-003.md
+++ b/docs/reference/dep-003.md
@@ -22,8 +22,9 @@ Draft Packs allows `draft create` to bootstrap an application from a defined pac
 # The Pack Structure
 
 A pack is organized inside a directory in `$(draft home)/packs`. Inside the pack's
-directory, there will be a template `chart/` and a `Dockerfile` that will be injected into the
-application when the pack is requested.
+directory, there will be a template `chart/` and a `Dockerfile` that will be copied into the
+application folder when the pack is requested. File permissions within the requested pack will be
+retained when copied into your application folder.
 
 Inside this directory, Draft will expect a structure like this:
 


### PR DESCRIPTION
Small edit to the docs to highlight that draft create will retain permissions 
#865 