### PR TITLE
Remove onbuild from testdata

### DIFF
--- a/cmd/draft/testdata/create/generated/empty/Dockerfile
+++ b/cmd/draft/testdata/create/generated/empty/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:onbuild
+FROM golang
 ENV PORT 8080
 EXPOSE 8080

--- a/cmd/draft/testdata/create/generated/html-but-actually-go/Dockerfile
+++ b/cmd/draft/testdata/create/generated/html-but-actually-go/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:onbuild
+FROM golang
 ENV PORT 8080
 EXPOSE 8080

--- a/cmd/draft/testdata/create/generated/simple-go-with-draftignore/Dockerfile
+++ b/cmd/draft/testdata/create/generated/simple-go-with-draftignore/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:onbuild
+FROM golang
 ENV PORT 8080
 EXPOSE 8080

--- a/cmd/draft/testdata/create/generated/simple-go/Dockerfile
+++ b/cmd/draft/testdata/create/generated/simple-go/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:onbuild
+FROM golang
 ENV PORT 8080
 EXPOSE 8080

--- a/pkg/draft/pack/load_test.go
+++ b/pkg/draft/pack/load_test.go
@@ -10,7 +10,7 @@ import (
 const (
 	packName           = "foo"
 	dockerfileName     = "Dockerfile"
-	expectedDockerfile = `FROM python:onbuild
+	expectedDockerfile = `FROM python
 
 CMD [ "python", "./hello.py" ]
 

--- a/pkg/draft/pack/testdata/pack-python/Dockerfile
+++ b/pkg/draft/pack/testdata/pack-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:onbuild
+FROM python
 
 CMD [ "python", "./hello.py" ]
 


### PR DESCRIPTION
This PR aims at removing the `onbuild` tags from the Dockerfiles in the testdata.
Resolves #890 

cc @bjornmagnusson 