### PR TITLE
Updated README to include gif instead of asciinema

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Note:_ Draft requires a running Kubernetes cluster and [Helm](https://github.co
 
 ## Overview
 
-[![asciicast](https://asciinema.org/a/WGVE7JNodpBEOautl105tdc97.png)](https://asciinema.org/a/WGVE7JNodpBEOautl105tdc97)
+<a href="https://gfycat.com/TenseDifferentJuliabutterfly"><img src="https://thumbs.gfycat.com/TenseDifferentJuliabutterfly-size_restricted.gif" alt="gif" width="500"/></a>
 
 Using Draft is as simple as:
 


### PR DESCRIPTION
Resolved part of #765

Couldn't find a better way to host such a large gif file and cannot embed an iframe form gfycat. This is the best way I could think of.