### PR TITLE
Support specifying custom values files

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1616,6 +1616,7 @@
     "github.com/technosophos/moniker",
     "golang.org/x/net/context",
     "google.golang.org/grpc",
+    "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	yaml "gopkg.in/yaml.v2"
 	"k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -250,14 +251,67 @@ func loadArchive(ctx *Context) (err error) {
 	return nil
 }
 
+// Merges source and destination map, preferring values from the source map
+func mergeValues(dest map[string]interface{}, src map[string]interface{}) map[string]interface{} {
+	for k, v := range src {
+		// If the key doesn't exist already, then just set the key to that value
+		if _, exists := dest[k]; !exists {
+			dest[k] = v
+			continue
+		}
+		nextMap, ok := v.(map[string]interface{})
+		// If it isn't another map, overwrite the value
+		if !ok {
+			dest[k] = v
+			continue
+		}
+		// Edge case: If the key exists in the destination, but isn't a map
+		destMap, isMap := dest[k].(map[string]interface{})
+		// If the source map has a map for this key, prefer it
+		if !isMap {
+			dest[k] = v
+			continue
+		}
+		// If we got to this point, it is a map in both, so merge them
+		dest[k] = mergeValues(destMap, nextMap)
+	}
+	return dest
+}
+
 func loadValues(ctx *Context) error {
-	var vals = make(chartutil.Values)
+	var vals = map[string]interface{}{}
+
+	// User specified values files via -f/values-files
+	for _, filePath := range ctx.Env.ValuesFiles {
+		currentMap := map[string]interface{}{}
+
+		var bytes []byte
+		var err error
+		if strings.TrimSpace(filePath) == "-" {
+			bytes, err = ioutil.ReadAll(os.Stdin)
+		} else {
+			bytes, err = ioutil.ReadFile(filePath)
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if err := yaml.Unmarshal(bytes, &currentMap); err != nil {
+			return fmt.Errorf("failed to parse %s: %s", filePath, err)
+		}
+		// Merge with the previous map
+		vals = mergeValues(vals, currentMap)
+	}
+
+	// User specified values files via --set/set
 	for _, val := range ctx.Env.Values {
 		if err := strvals.ParseInto(val, vals); err != nil {
 			return fmt.Errorf("failed to parse %q from draft.toml: %v", val, err)
 		}
 	}
-	s, err := vals.YAML()
+	b, err := yaml.Marshal(vals)
+	s := string(b)
 	if err != nil {
 		return fmt.Errorf("failed to encode values: %v", err)
 	}

--- a/pkg/draft/manifest/manifest.go
+++ b/pkg/draft/manifest/manifest.go
@@ -35,6 +35,7 @@ type Environment struct {
 	ChartTarPath      string            `toml:"chart-tar,omitempty"`
 	Namespace         string            `toml:"namespace,omitempty"`
 	Values            []string          `toml:"set,omitempty"`
+	ValuesFiles       []string          `toml:"values-files,omitempty"`
 	Wait              bool              `toml:"wait"`
 	Watch             bool              `toml:"watch"`
 	WatchDelay        int               `toml:"watch-delay,omitempty"`


### PR DESCRIPTION
Helm has code for this here: https://github.com/helm/helm/blob/master/cmd/helm/install.go#L358

It would probably be a better approach to try move their code for it to
k8s.io/helm/pkg/chartutil, and then use that here. For now I just copied out
the necessary bits, because their version supports things like custom protocols,
like values files from ftp or http, which I don't think we need. Though
matching what helm supports is probably a better idea.

TODO: I still need to add tests for this.

Closes https://github.com/Azure/draft/issues/818
Closes https://github.com/Azure/draft/issues/856

Signed-off-by: William Stewart <zoidbergwill@gmail.com>