### PR TITLE
Adding new error code to separate local repo from installer errors

### DIFF
--- a/pkg/draft/pack/repo/errors.go
+++ b/pkg/draft/pack/repo/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrHomeMissing = errors.New(`pack repo home "$(draft home)/packs" does not exist`)
 	// ErrMissingSource indicates that information about the source of the pack repo was not found
 	ErrMissingSource = errors.New("cannot get information about pack repo source")
+	// ErrNotRepo indicates that the repo synced does not have a packes folder
+	ErrNotRepo = errors.New("no pack/ directory in repo")
 	// ErrRepoDirty indicates that the pack repo was modified
 	ErrRepoDirty = errors.New("pack repo was modified")
 	//ErrVersionDoesNotExist indicates that the requested pack repo version does not exist

--- a/pkg/draft/pack/repo/errors.go
+++ b/pkg/draft/pack/repo/errors.go
@@ -11,7 +11,7 @@ var (
 	ErrHomeMissing = errors.New(`pack repo home "$(draft home)/packs" does not exist`)
 	// ErrMissingSource indicates that information about the source of the pack repo was not found
 	ErrMissingSource = errors.New("cannot get information about pack repo source")
-	// ErrNotRepo indicates that the repo synced does not have a packes folder
+	// ErrNotRepo indicates that the repo synced does not have a packs folder
 	ErrNotRepo = errors.New("no pack/ directory in repo")
 	// ErrRepoDirty indicates that the pack repo was modified
 	ErrRepoDirty = errors.New("pack repo was modified")

--- a/pkg/draft/pack/repo/installer/vcs_installer.go
+++ b/pkg/draft/pack/repo/installer/vcs_installer.go
@@ -73,7 +73,7 @@ func (i *VCSInstaller) Install() error {
 	}
 
 	if !isPackRepo(i.Repo.LocalPath()) {
-		return repo.ErrHomeMissing
+		return repo.ErrNotRepo
 	}
 
 	if err := os.MkdirAll(filepath.Dir(i.Path()), 0755); err != nil {
@@ -92,7 +92,7 @@ func (i *VCSInstaller) Update() error {
 		return err
 	}
 	if !isPackRepo(i.Repo.LocalPath()) {
-		return repo.ErrHomeMissing
+		return repo.ErrNotRepo
 	}
 	return nil
 }


### PR DESCRIPTION
I struggled for a while trying to figure out why I couldn't sync a new repo of Draft packs. The error sounded like I had a problem with my local setup - not the layout of the remote repo. This adds a new error code to clarify why things are failing when adding a new repo.

Before the change - it says I don't have a repo folder on my local machine. That would be accurate if I forgot `draft init`, but the folder is there.

```
draft pack-repo add https://github.com/PatrickLang/Windows-K8s-Samples
Installing pack repo from https://github.com/PatrickLang/Windows-K8s-Samples
Error: pack repo home "$(draft home)/packs" does not exist
Error: exit status 1
```

After the change - it shows an accurate error:
````
draft pack-repo add https://github.com/PatrickLang/Windows-K8s-Samples
Installing pack repo from https://github.com/PatrickLang/Windows-K8s-Samples
Error: no pack/ directory in repo
Error: exit status 1
```

After the chance, adding a new repo still works:
```
 draft pack-repo add https://github.com/PatrickLang/WindowsDraftPacks
Installing pack repo from https://github.com/PatrickLang/WindowsDraftPacks
Installed pack repository github.com/PatrickLang/WindowsDraftPacks
PS C:\Users\patrick\.draft\packs\github.com\PatrickLang> draft pack list
Available Packs:
  github.com/Azure/draft/clojure
  github.com/Azure/draft/csharp
  github.com/Azure/draft/erlang
  github.com/Azure/draft/go
  github.com/Azure/draft/gradle
  github.com/Azure/draft/java
  github.com/Azure/draft/javascript
  github.com/Azure/draft/php
  github.com/Azure/draft/python
  github.com/Azure/draft/ruby
  github.com/Azure/draft/rust
  github.com/Azure/draft/swift
  github.com/PatrickLang/WindowsDraftPacks/CSharpWindowsNetCore
  github.com/PatrickLang/WindowsDraftPacks/CSharpWindowsNetFx
```