### PR TITLE
Update brew install to match azure/homebrew-draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Draft makes it easier for developers to build applications that run on Kubernete
 Draft targets the "inner loop" of a developer's workflow: as they hack on code, but before code is committed to version control.
 
 ## Install the draft binary
-To install via homebrew, run `brew tap azure/draft && brew install draft` or download the binary via the [github releases page](https://github.com/Azure/draft/releases)
+To install via homebrew, run `brew tap azure/draft && brew install azure/draft/draft` or download the binary via the [github releases page](https://github.com/Azure/draft/releases)
 
 _Note:_ Draft requires a running Kubernetes cluster and [Helm](https://github.com/kubernetes/helm/blob/master/docs/install.md ). If you don't already have a running Kubernetes cluster, check out the [minikube install guide](docs/install-minikube.md).
 


### PR DESCRIPTION
I've updated the brew install command to match https://github.com/Azure/homebrew-draft/blob/master/README.md.

See https://github.com/Azure/homebrew-draft/pull/10 for reference.
