### PR TITLE
Simplify brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Draft makes it easier for developers to build applications that run on Kubernete
 Draft targets the "inner loop" of a developer's workflow: as they hack on code, but before code is committed to version control.
 
 ## Install the draft binary
-To install via homebrew, run `brew tap azure/draft && brew install azure/draft/draft` or download the binary via the [github releases page](https://github.com/Azure/draft/releases)
+To install via homebrew, run `brew install azure/draft/draft` or download the binary via the [github releases page](https://github.com/Azure/draft/releases)
 
 _Note:_ Draft requires a running Kubernetes cluster and [Helm](https://github.com/kubernetes/helm/blob/master/docs/install.md ). If you don't already have a running Kubernetes cluster, check out the [minikube install guide](docs/install-minikube.md).
 

--- a/docs/install-minikube.md
+++ b/docs/install-minikube.md
@@ -35,8 +35,7 @@ Afterwards, fetch [the latest release of Draft](https://github.com/Azure/draft/r
 Installing Draft via Homebrew can be done using
 
 ```shell
-$ brew tap azure/draft
-$ brew install draft
+$ brew install azure/draft/draft
 ```
 
 Canary releases of the Draft client can be found at the following links:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -60,7 +60,6 @@ $ draft version
 To install Draft on MacOS using [Homebrew](https://brew.sh/):
 
 ```console
-$ brew tap azure/draft
 $ brew install azure/draft/draft
 ```
 


### PR DESCRIPTION
I noticed [another repo][1] using this shorthand for a fully qualified install from a third party tap.

The [Homebrew docs][2] confirm that `brew tap ...` is redundant when running brew install with the fully qualified tap as this project already does.

I have tested this change as follows.

Uninstall:

```
$ brew uninstall azure/draft/draft
Uninstalling /usr/local/Cellar/draft/0.16.0... (5 files, 54.0MB)
$ brew untap azure/draft
Untapping azure/draft...
Untapped 1 formula (32 files, 29.4KB).
```

Verify:

```
$ brew tap | grep draft
$ brew list | grep draft
```

Install:

```
$ brew install azure/draft/draft
==> Tapping azure/draft
Cloning into '/usr/local/Homebrew/Library/Taps/azure/homebrew-draft'...
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 6 (delta 0), reused 5 (delta 0), pack-reused 0
Unpacking objects: 100% (6/6), done.
Tapped 1 formula (32 files, 29.4KB).
==> Installing draft from azure/draft
==> Downloading https://azuredraft.blob.core.windows.net/draft/draft-v0.16.0-darwin-amd64.tar.gz
Already downloaded: /Users/taylor/Library/Caches/Homebrew/downloads/1fcfc7685f91047db9241ec2c2ebc2a29d9fd8542a9a8b5d80e4c23c643b02ca--draft-v0.16.0-darwin-amd64.tar.gz
==> Caveats
Be aware that Draft is currently experimental and does not have a stable
release yet. We make no backwards-compatible guarantees between releases.

When upgrading, make sure to `rm -rf ~/.draft` before bootstrapping Draft
according to the installation guide:

  https://github.com/Azure/draft/blob/v0.16.0/docs/install.md

If you bootstrapped an application using `draft create`, you'll also
want to remove the files `draft create` generated before running
`draft create && draft up` again.

Please make sure to read the release notes for further information:

  https://github.com/Azure/draft/releases/tag/v0.16.0
==> Summary
🍺  /usr/local/Cellar/draft/0.16.0: 5 files, 54.0MB, built in 2 seconds
```

Verify:

```
$ brew tap | grep draft
azure/draft
$ brew list | grep draft
draft
```

[1]: https://github.com/go-task/task/blob/9a062d90d17eca96ef66086f9985b40c7fd44849/docs/installation.md#homebrew
[2]: https://github.com/Homebrew/brew/blob/master/docs/How-to-Create-and-Maintain-a-Tap.md#installing
