### PR TITLE
SDK Bump and Multi Stage Improvement

### DIFF
--- a/packs/csharp/Dockerfile
+++ b/packs/csharp/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk AS builder
+FROM microsoft/dotnet:2.2-sdk AS builder
 WORKDIR /app
 
 # caches restore result by copying csproj file separately
@@ -6,14 +6,14 @@ COPY *.csproj .
 RUN dotnet restore
 
 COPY . .
-RUN dotnet publish --output /app/ --configuration Release
-RUN sed -n 's:.*<AssemblyName>\(.*\)</AssemblyName>.*:\1:p' *.csproj > __assemblyname
-RUN if [ ! -s __assemblyname ]; then filename=$(ls *.csproj); echo ${filename%.*} > __assemblyname; fi
+RUN dotnet publish --output /publish/ --configuration Release
+RUN sed -n 's:.*<AssemblyName>\(.*\)</AssemblyName>.*:\1:p' *.csproj > /publish/__assemblyname
+RUN if [ ! -s __assemblyname ]; then filename=$(ls *.csproj); echo ${filename%.*} > /publish/__assemblyname; fi
 
 # Stage 2
-FROM microsoft/dotnet:2.1-aspnetcore-runtime
+FROM microsoft/dotnet:2.2-aspnetcore-runtime
 WORKDIR /app
-COPY --from=builder /app .
+COPY --from=builder /publish /app
 
 ENV PORT 80
 EXPOSE 80


### PR DESCRIPTION
Updated the .NET container version to latest stable version. Changed publish output to a different folder to prevent code from being published to final container for improved security and also making final image smaller.