### PR TITLE
Error if no packs in pack folder on draft create

### DIFF
--- a/cmd/draft/create.go
+++ b/cmd/draft/create.go
@@ -89,6 +89,9 @@ func (c *createCmd) run() error {
 		fmt.Fprintln(c.out, "--> chart directory charts/ already exists. Ready to sail!")
 		return nil
 	}
+	if !checkPacksExist(c.home.Packs(), c.out) {
+		return fmt.Errorf("No packs found in %s, did you `draft init`?", c.home.Packs())
+	}
 
 	if c.pack != "" {
 		// --pack was explicitly defined, so we can just lazily use that here. No detection required.
@@ -168,6 +171,15 @@ func (c *createCmd) normalizeApplicationName() {
 		lowerCaseName,
 	)
 	c.appName = lowerCaseName
+}
+
+// checkPacksExist checks for the existence of packs in the pack directory.
+// This is helpful for catching if the user didn't run `draft init` first.
+func checkPacksExist(packHome string, out io.Writer) bool {
+	if _, err := os.Stat(packHome); os.IsNotExist(err) {
+		return false
+	}
+	return true
 }
 
 // doPackDetection performs pack detection across all the packs available in $(draft home)/packs in


### PR DESCRIPTION
For new users, forgetting to run `draft init` is not as obvious as it should be. This PR throws an error if the packs directory is empty when running `draft create`, which is normally caused by not running `draft init` first.

Fixes: https://github.com/Azure/draft/issues/925

Before:
```
$ draft create
--> Draft detected Go (100.000000%)
--> Could not find a pack for Go. Trying to find the next likely language match...
Error: no languages were detected
```

After:
```
$ draft create
Error: No packs found in /home/klaw/.draft/packs, did you `draft init`?
```