### PR TITLE
add default case in workflows.go

### DIFF
--- a/pkg/workflows/workflows.go
+++ b/pkg/workflows/workflows.go
@@ -67,7 +67,7 @@ func updateProductionDeployments(deployType, dest string, config *WorkflowConfig
 	switch deployType {
 	case "helm":
 		return setHelmContainerImage(dest+"/charts/production.yaml", productionImage)
-	case "kustomize":
+	case "default":
 		return setDeploymentContainerImage(dest+"/overlays/production/deployment.yaml", productionImage)
 	}
 	return nil

--- a/pkg/workflows/workflows.go
+++ b/pkg/workflows/workflows.go
@@ -67,9 +67,12 @@ func updateProductionDeployments(deployType, dest string, config *WorkflowConfig
 	switch deployType {
 	case "helm":
 		return setHelmContainerImage(dest+"/charts/production.yaml", productionImage)
-	case "default":
+	case "kustomize":
 		return setDeploymentContainerImage(dest+"/overlays/production/deployment.yaml", productionImage)
 	}
+	case "default":
+		return setDeploymentContainerImage(dest+"/manifests/deployment.yaml", productionImage)
+	
 	return nil
 }
 

--- a/pkg/workflows/workflows.go
+++ b/pkg/workflows/workflows.go
@@ -69,10 +69,9 @@ func updateProductionDeployments(deployType, dest string, config *WorkflowConfig
 		return setHelmContainerImage(dest+"/charts/production.yaml", productionImage)
 	case "kustomize":
 		return setDeploymentContainerImage(dest+"/overlays/production/deployment.yaml", productionImage)
-	}
 	case "default":
 		return setDeploymentContainerImage(dest+"/manifests/deployment.yaml", productionImage)
-	
+	}
 	return nil
 }
 


### PR DESCRIPTION
update the image tag for manifests. For kustomize and helm we use a production override which has the image modified however, we do not do this for regular k8s manifests. This PR changes that.