### PR TITLE
Updating AZ commands to work after upgrade

### DIFF
--- a/pkg/providers/azure.go
+++ b/pkg/providers/azure.go
@@ -131,12 +131,8 @@ func (sc *SetUpCmd) CreateServicePrincipal() error {
 			return err
 		}
 
+		log.Debug("Checking sp was created...")
 		if sc.ServicePrincipalExists() {
-			var servicePrincipal map[string]interface{}
-			json.Unmarshal(out, &servicePrincipal)
-			objectId := fmt.Sprint(servicePrincipal["objectId"])
-
-			sc.spObjectId = objectId
 			log.Debug("Service principal created successfully!")
 			end := time.Since(start)
 			log.Debug(end)
@@ -275,19 +271,17 @@ func (sc *SetUpCmd) createFederatedCredentials() error {
 
 func (sc *SetUpCmd) getAppObjectId() error {
 	log.Debug("Fetching Azure application object ID")
-	filter := fmt.Sprintf("displayName eq '%s'", sc.AppName)
-	getObjectIdCmd := exec.Command("az", "ad", "app", "list", "--only-show-errors", "--filter", filter, "--query", "[].objectId")
+	getObjectIdCmd := exec.Command("az", "ad", "app", "show", "--only-show-errors", "--id", sc.appId, "--query", "id")
 	out, err := getObjectIdCmd.CombinedOutput()
 	if err != nil {
 		log.Fatalf(string(out))
 		return err
 	}
 
-	var objectId []string
+	var objectId string
 	json.Unmarshal(out, &objectId)
-	objId := objectId[0]
 
-	sc.appObjectId = objId
+	sc.appObjectId = objectId
 
 	return nil
 }

--- a/pkg/providers/azure.go
+++ b/pkg/providers/azure.go
@@ -46,10 +46,8 @@ func InitiateAzureOIDCFlow(sc *SetUpCmd, s spinner.Spinner) error {
 		return err
 	}
 
-	if !sc.ServicePrincipalExists() {
-		if err := sc.CreateServicePrincipal(); err != nil {
-			return err
-		}
+	if err := sc.CreateServicePrincipal(); err != nil {
+		return err
 	}
 
 	if err := sc.getTenantId(); err != nil {

--- a/pkg/providers/providersutils.go
+++ b/pkg/providers/providersutils.go
@@ -150,34 +150,23 @@ func AzAppExists(appName string) bool {
 	var azApp []string
 	json.Unmarshal(out, &azApp)
 	
-	if len(azApp) >= 1 {
-		// TODO: tell user app already exists and ask which one they want to use?
-		return true
-	}
-
-	return false
+	return len(azApp) >= 1
 }
 
 func (sc *SetUpCmd) ServicePrincipalExists() bool {
-	filter := fmt.Sprintf("appId eq '%s'", sc.appId)
-	checkSpExistsCmd := exec.Command("az", "ad", "sp","list", "--only-show-errors", "--filter", filter, "--query", "[].objectId")
+	checkSpExistsCmd := exec.Command("az", "ad", "sp","show", "--only-show-errors", "--id", sc.appId, "--query", "id")
 	out, err := checkSpExistsCmd.CombinedOutput()
 	if err != nil {
-		return true
+		return false
 	}
 
-	var azSp []string
-	json.Unmarshal(out, &azSp)
+	var objectId string
+	json.Unmarshal(out, &objectId)
 	
-	if len(azSp) == 1 {
-		log.Debug("Service principal already exists - skipping service principal creation.")
-		// TODO: tell user sp already exists and ask if they want to use it?
-		objectId := fmt.Sprint(azSp[0])
-		sc.spObjectId = objectId
-		return true
-	}
-
-	return false
+	log.Debug("Service principal exists")
+	// TODO: tell user sp already exists and ask if they want to use it?
+	sc.spObjectId = objectId
+	return true
 }
 
 func AzAcrExists(acrName string) bool {


### PR DESCRIPTION
Following an error Karen and Quentin were experiencing with the setup-gh command, I was able to reproduce it and determined that it was caused by an update to the "az ad sp" and "az ad app" commands. They no longer return "objectId" in the json  response when you create, list or show them, instead they just return "id". That meant that the commands to assign roles and created FICs weren't working either because they rely on the sp and app "objectId"s

Changes:
- changed sp list to sp show since we really don't need to query a list to get one sp
- changed any queries for an "objectId" to an "id"
- removed the first sp exists check since new apps don't automatically have sp's