### PR TITLE
added support for multiple dotnet versions and port override

### DIFF
--- a/builders/csharp/Dockerfile
+++ b/builders/csharp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:{{VERSION}} AS builder
 WORKDIR /app
 
 # caches restore result by copying csproj file separately
@@ -11,11 +11,11 @@ RUN sed -n 's:.*<AssemblyName>\(.*\)</AssemblyName>.*:\1:p' *.csproj > __assembl
 RUN if [ ! -s __assemblyname ]; then filename=$(ls *.csproj); echo ${filename%.*} > __assemblyname; fi
 
 # Stage 2
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:{{VERSION}}
 WORKDIR /app
 COPY --from=builder /app .
 
 ENV PORT {{PORT}}
 EXPOSE {{PORT}}
 
-ENTRYPOINT dotnet $(cat /app/__assemblyname).dll
+ENTRYPOINT dotnet $(cat /app/__assemblyname).dll --urls "http://*:{{PORT}}"

--- a/builders/csharp/draft.yaml
+++ b/builders/csharp/draft.yaml
@@ -3,3 +3,6 @@ variables:
   - name: "PORT"
     description: "the port exposed in the application"
     type: int
+  - name: "VERSION"
+    description: "the dotnet SDK version"
+    type: float

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -76,6 +76,7 @@ cat integration_config.json | jq -c '.[]' | while read -r test;
 do 
     # extract from json
     lang=$(echo $test | jq '.language' -r)
+    version=$(echo $test | jq '.version' -r)
     port=$(echo $test | jq '.port' -r)
     repo=$(echo $test | jq '.repo' -r)
     echo "Adding $lang with port $port"
@@ -86,11 +87,15 @@ do
     echo "deployType: \"Helm\"
 languageType: \"$lang\"
 deployVariables:
+  - name: \"VERSION\"
+    value: \"$version\"
   - name: \"PORT\"
     value: \"$port\"
   - name: \"APPNAME\"
     value: \"testapp\"
 languageVariables:
+  - name: \"VERSION\"
+    value: \"$version\"
   - name: \"PORT\"
     value: \"$port\"" > ./integration/$lang/helm.yaml
 
@@ -98,11 +103,15 @@ languageVariables:
     echo "deployType: \"kustomize\"
 languageType: \"$lang\"
 deployVariables:
+  - name: \"VERSION\"
+    value: \"$version\"
   - name: \"PORT\"
     value: \"$port\"
   - name: \"APPNAME\"
     value: \"testapp\"
 languageVariables:
+  - name: \"VERSION\"
+    value: \"$version\"
   - name: \"PORT\"
     value: \"$port\"" > ./integration/$lang/kustomize.yaml
 
@@ -110,11 +119,15 @@ languageVariables:
     echo "deployType: \"manifests\"
 languageType: \"$lang\"
 deployVariables:
+  - name: \"VERSION\"
+    value: \"$version\" 
   - name: \"PORT\"
     value: \"$port\"
   - name: \"APPNAME\"
     value: \"testapp\"
 languageVariables:
+  - name: \"VERSION\"
+    value: \"$version\"
   - name: \"PORT\"
     value: \"$port\"" > ./integration/$lang/manifest.yaml
 

--- a/test/integration/clojure/helm.yaml
+++ b/test/integration/clojure/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "clojure"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/clojure/kustomize.yaml
+++ b/test/integration/clojure/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "clojure"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/clojure/manifest.yaml
+++ b/test/integration/clojure/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "clojure"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/csharp/helm.yaml
+++ b/test/integration/csharp/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "csharp"
 deployVariables:
+  - name: "VERSION"
+    value: "5.0"
   - name: "PORT"
     value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "5.0"
   - name: "PORT"
     value: "80"

--- a/test/integration/csharp/kustomize.yaml
+++ b/test/integration/csharp/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "csharp"
 deployVariables:
+  - name: "VERSION"
+    value: "5.0"
   - name: "PORT"
     value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "5.0"
   - name: "PORT"
     value: "80"

--- a/test/integration/csharp/manifest.yaml
+++ b/test/integration/csharp/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "csharp"
 deployVariables:
+  - name: "VERSION"
+    value: "5.0" 
   - name: "PORT"
     value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "5.0"
   - name: "PORT"
     value: "80"

--- a/test/integration/erlang/helm.yaml
+++ b/test/integration/erlang/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "erlang"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/erlang/kustomize.yaml
+++ b/test/integration/erlang/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "erlang"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/erlang/manifest.yaml
+++ b/test/integration/erlang/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "erlang"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/gomodule/helm.yaml
+++ b/test/integration/gomodule/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "gomodule"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1323"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1323"

--- a/test/integration/gomodule/kustomize.yaml
+++ b/test/integration/gomodule/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "gomodule"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1323"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1323"

--- a/test/integration/gomodule/manifest.yaml
+++ b/test/integration/gomodule/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "gomodule"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "1323"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1323"

--- a/test/integration/gradle/helm.yaml
+++ b/test/integration/gradle/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "gradle"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/gradle/kustomize.yaml
+++ b/test/integration/gradle/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "gradle"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/gradle/manifest.yaml
+++ b/test/integration/gradle/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "gradle"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/java/helm.yaml
+++ b/test/integration/java/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "java"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/java/kustomize.yaml
+++ b/test/integration/java/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "java"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/java/manifest.yaml
+++ b/test/integration/java/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "java"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/javascript/helm.yaml
+++ b/test/integration/javascript/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "javascript"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1313"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1313"

--- a/test/integration/javascript/kustomize.yaml
+++ b/test/integration/javascript/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "javascript"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1313"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1313"

--- a/test/integration/javascript/manifest.yaml
+++ b/test/integration/javascript/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "javascript"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "1313"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "1313"

--- a/test/integration/python/helm.yaml
+++ b/test/integration/python/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "python"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "5000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "5000"

--- a/test/integration/python/kustomize.yaml
+++ b/test/integration/python/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "python"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "5000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "5000"

--- a/test/integration/python/manifest.yaml
+++ b/test/integration/python/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "python"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "5000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "5000"

--- a/test/integration/ruby/helm.yaml
+++ b/test/integration/ruby/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "ruby"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"

--- a/test/integration/ruby/kustomize.yaml
+++ b/test/integration/ruby/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "ruby"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"

--- a/test/integration/ruby/manifest.yaml
+++ b/test/integration/ruby/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "ruby"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "8000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"

--- a/test/integration/rust/helm.yaml
+++ b/test/integration/rust/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "rust"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"

--- a/test/integration/rust/kustomize.yaml
+++ b/test/integration/rust/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "rust"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"

--- a/test/integration/rust/manifest.yaml
+++ b/test/integration/rust/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "rust"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "8000"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8000"

--- a/test/integration/swift/helm.yaml
+++ b/test/integration/swift/helm.yaml
@@ -1,10 +1,14 @@
 deployType: "Helm"
 languageType: "swift"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/swift/kustomize.yaml
+++ b/test/integration/swift/kustomize.yaml
@@ -1,10 +1,14 @@
 deployType: "kustomize"
 languageType: "swift"
 deployVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration/swift/manifest.yaml
+++ b/test/integration/swift/manifest.yaml
@@ -1,10 +1,14 @@
 deployType: "manifests"
 languageType: "swift"
 deployVariables:
+  - name: "VERSION"
+    value: "null" 
   - name: "PORT"
     value: "8080"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:
+  - name: "VERSION"
+    value: "null"
   - name: "PORT"
     value: "8080"

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -22,6 +22,7 @@
   },
   {
     "language": "csharp",
+    "version": "5.0",
     "port": "80",
     "repo": "imiller31/csharp-simple-web-app"
   },


### PR DESCRIPTION
- Adds support for .NET Version override (support more than .NET 5.0 I.E 6.0)
- Adds support for PORT override via `--urls` flag

Signed-off-by: jldeen <jessicadeen@me.com>