### PR TITLE
fix subscription validation logic

### DIFF
--- a/pkg/providers/providersutils.go
+++ b/pkg/providers/providersutils.go
@@ -102,7 +102,7 @@ func IsSubscriptionIdValid(subscriptionId string) error {
 		return err
 	}
 
-	if azSubscription != "" {
+	if azSubscription == "" {
 		return errors.New("subscription not found")
 	}
 


### PR DESCRIPTION
The updated error message added in #105  was incorrect for the check.  Changing the check to look for an empty subscription id returns the behavior to the previous and includes the improved error message.