### PR TITLE
Fix logger output split

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Azure/draft/pkg/web"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+	log "github.com/sirupsen/logrus"
 )
 
 func newUpdateCmd() *cobra.Command {
@@ -24,6 +25,9 @@ will be able to receive external requests.`,
 			if err := web.UpdateServiceFile(sa, dest); err != nil {
 				return err
 			}
+
+			log.Info("Draft has successfully updated your yaml files so that your application will be able to receive external requests 😃")
+
 			return nil
 		},
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 	log "github.com/sirupsen/logrus"
@@ -13,13 +14,18 @@ type CustomFormatter struct {}
 
 func (f *CustomFormatter) Format(entry *log.Entry) ([]byte, error) {
     cyan := color.New(color.Bold, color.FgCyan).SprintFunc()
+	red := color.New(color.Bold, color.FgRed).SprintFunc()
+	level := strings.Title(entry.Level.String())
+	if (level == "Error" || level == "Fatal" || level == "Panic") {
+		return []byte(fmt.Sprintf("%s: %s\n",red(level), entry.Message)), nil
+	}
     return []byte(fmt.Sprintf("%s %s\n",cyan("[Draft]"), entry.Message)), nil
 }
 
 type OutputSplitter struct{}
 
 func (splitter *OutputSplitter) Write(p []byte) (n int, err error) {
-	if bytes.Contains(p, []byte("level=error")) ||  bytes.Contains(p, []byte("level=fatal")) || bytes.Contains(p, []byte("level=panic")) {
+	if bytes.Contains(p, []byte("Error")) ||  bytes.Contains(p, []byte("Fatal")) || bytes.Contains(p, []byte("Panic")) {
 		return os.Stderr.Write(p)
 	}
 	return os.Stdout.Write(p)


### PR DESCRIPTION
small fixes to the logging formatter to correctly split stdout and stderr