### PR TITLE
Add badges for CI and other key things visible upfront at repo level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
     <a href="https://github.com/Azure/draft/issues">Report Bug</a>
     ·
     <a href="https://github.com/Azure/draft/issues">Request Feature</a>
+  
+  [![Draft Unit Tests](https://github.com/Azure/draft/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/Azure/draft/actions/workflows/unit-tests.yml)
+  [![GoDoc](https://godoc.org/github.com/Azure/draft?status.svg)](https://godoc.org/github.com/Azure/draft)
+  [![Go Report Card](https://goreportcard.com/badge/github.com/Azure/draft)](https://goreportcard.com/report/github.com/Azure/draft)
+  [![CodeQL](https://github.com/Azure/draft/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Azure/draft/actions/workflows/codeql-analysis.yml)
+  [![Draft Linux Integrations](https://github.com/Azure/draft/actions/workflows/integration-linux.yml/badge.svg)](https://github.com/Azure/draft/actions/workflows/integration-linux.yml)
+  [![Draft Releases](https://github.com/Azure/draft/actions/workflows/releases.yml/badge.svg)](https://github.com/Azure/draft/actions/workflows/releases.yml)
   </p>
 </div>
 


### PR DESCRIPTION
This PR enables the visibility of key attributes this project has under the hood and the quality check in place.

It also benefit as one stop shop of all the test visibility and the failures as these badges will update in case of failure etc. 

I've also added the `go report` and `go docs` along with workflows in place.

Thanks heaps. ❤️🙏☕️ cc: @karenychen, @imiller31, @gambtho 

it will look shiny like this, along with other quality goodness which will come along and also when we improve the got-report it will move to A+ 

![image](https://user-images.githubusercontent.com/6233295/174686549-9be2d043-cf79-412f-883e-b28f9c547ea4.png)
