### PR TITLE
Erinborders/az version enforcer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/fatih/color v1.13.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/hashicorp/go-version v1.6.0
 	github.com/instrumenta/kubeval v0.16.1
 	github.com/ivanpirog/coloredcobra v1.0.1
 	github.com/jbrukh/bayesian v0.0.0-20200318221351-d726b684ca4a

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,8 @@ github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerX
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/pkg/providers/azure.go
+++ b/pkg/providers/azure.go
@@ -111,7 +111,7 @@ func (sc *SetUpCmd) createAzApp() error {
 			return nil
 		}
 
-		return errors.New("app not found")
+		return errors.New("Error: app creation time has exceeded max elapsed time for exponential backoff")
 	}
 
 	backoff := bo.NewExponentialBackOff()

--- a/pkg/providers/azure.go
+++ b/pkg/providers/azure.go
@@ -111,7 +111,7 @@ func (sc *SetUpCmd) createAzApp() error {
 			return nil
 		}
 
-		return errors.New("Error: app creation time has exceeded max elapsed time for exponential backoff")
+		return errors.New("app creation time has exceeded max elapsed time for exponential backoff")
 	}
 
 	backoff := bo.NewExponentialBackOff()


### PR DESCRIPTION
To keep users from trying to use the setup-gh command with an Az cli version older than 2.37.0 (which introduced a breaking change) this update will check the user's az cli version, ask them if they want us to upgrade the cli for them if needed, and proceed with the upgrade if they say yes. Otherwise, it will fail the command before it can start trying to create resources.