### PR TITLE
abstract filesystem and directory operations from templating logic

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/draft/pkg/osutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
@@ -26,6 +27,7 @@ func TestRun(t *testing.T) {
 	mockAppNameInput := config.UserInputs{Name: "APPNAME", Value: "testingCreateCommand"}
 	mockCC.createConfig.DeployVariables = append(mockCC.createConfig.DeployVariables, mockPortInput, mockAppNameInput)
 	mockCC.createConfig.LanguageVariables = append(mockCC.createConfig.LanguageVariables, mockPortInput)
+	mockCC.templateWriter = &osutil.LocalFSWriter{}
 
 	oldDockerfile, _ := ioutil.ReadFile("./../Dockerfile")
 	oldDockerignore, _ := ioutil.ReadFile("./../.dockerignore")

--- a/pkg/deployments/deployments.go
+++ b/pkg/deployments/deployments.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"io/fs"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
 	"github.com/Azure/draft/pkg/config"
 	"github.com/Azure/draft/pkg/embedutils"
 	"github.com/Azure/draft/pkg/osutil"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 //go:generate cp -r ../../deployTypes ./deployTypes
@@ -28,7 +29,7 @@ type Deployments struct {
 	dest    string
 }
 
-func (d *Deployments) CopyDeploymentFiles(deployType string, customInputs map[string]string) error {
+func (d *Deployments) CopyDeploymentFiles(deployType string, customInputs map[string]string, templateWriter osutil.TemplateWriter) error {
 	val, ok := d.deploys[deployType]
 	if !ok {
 		return fmt.Errorf("deployment type: %s is not currently supported", deployType)
@@ -41,7 +42,7 @@ func (d *Deployments) CopyDeploymentFiles(deployType string, customInputs map[st
 		config = nil
 	}
 
-	if err := osutil.CopyDir(deployTypes, srcDir, d.dest, config, customInputs); err != nil {
+	if err := osutil.CopyDir(deployTypes, srcDir, d.dest, config, customInputs, templateWriter); err != nil {
 		return err
 	}
 

--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"io/fs"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+
 	"github.com/Azure/draft/pkg/config"
 	"github.com/Azure/draft/pkg/embedutils"
 	"github.com/Azure/draft/pkg/osutil"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 )
 
 //go:generate cp -r ../../builders ./builders
@@ -32,7 +33,7 @@ func (l *Languages) ContainsLanguage(lang string) bool {
 	return ok
 }
 
-func (l *Languages) CreateDockerfileForLanguage(lang string, customInputs map[string]string) error {
+func (l *Languages) CreateDockerfileForLanguage(lang string, customInputs map[string]string, templateWriter osutil.TemplateWriter) error {
 	val, ok := l.langs[lang]
 	if !ok {
 		return fmt.Errorf("language %s is not supported", lang)
@@ -45,7 +46,7 @@ func (l *Languages) CreateDockerfileForLanguage(lang string, customInputs map[st
 		config = nil
 	}
 
-	if err := osutil.CopyDir(builders, srcDir, l.dest, config, customInputs); err != nil {
+	if err := osutil.CopyDir(builders, srcDir, l.dest, config, customInputs, templateWriter); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Introduce new `TemplateWriter` interface with the following methods:
```
WriteFile(string, []byte, os.FileMode) error
EnsureDirectory(string) error
```

This allows templates to be generated for arbitrary use cases independent of the local filesystem (ex: in-memory template generation)

Refactor dockerfile and deployment generation to use new interface, and added existing os filesystem write methods into the `LocalFSWriter` struct

Add `TemplateWrite` property to `CreateCommand` and set to the `LocalFSWriter` to maintain existing functionality