### PR TITLE
Erinborders/operationportsupport

### DIFF
--- a/template/deployments/helm/charts/production.yaml
+++ b/template/deployments/helm/charts/production.yaml
@@ -5,4 +5,4 @@ imageKey:
 service:
   annotations: {}
   type: LoadBalancer
-  port: 80
+  port: "{{SERVICEPORT}}"

--- a/template/deployments/helm/charts/values.yaml
+++ b/template/deployments/helm/charts/values.yaml
@@ -33,7 +33,7 @@ securityContext: {}
 service:
   annotations: {}
   type: LoadBalancer
-  port: 80
+  port: {{SERVICEPORT}}
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/template/deployments/helm/draft.yaml
+++ b/template/deployments/helm/draft.yaml
@@ -3,6 +3,10 @@ variables:
     description: "the port exposed in the application"
   - name: "APPNAME"
     description: "the name of the application"
+  - name: "SERVICEPORT"
+    description: "the port the service uses to make the application accessible from outside the cluster"
 variableDefaults:
   - name: "PORT"
+    value: 80
+  - name: "SERVICEPORT"
     value: 80

--- a/template/deployments/kustomize/base/service.yaml
+++ b/template/deployments/kustomize/base/service.yaml
@@ -8,5 +8,5 @@ spec:
     app: {{APPNAME}}
   ports:
     - protocol: TCP
-      port: 80
+      port: {{SERVICEPORT}}
       targetPort: {{PORT}}

--- a/template/deployments/kustomize/draft.yaml
+++ b/template/deployments/kustomize/draft.yaml
@@ -1,5 +1,12 @@
 variables:
   - name: "PORT"
-    description: "the port exposed in the application"
+    description: "the container port exposed in the application"
   - name: "APPNAME"
     description: "the name of the application"
+  - name: "SERVICEPORT"
+    description: "the port used by the service to make the application accessible outside the cluster"
+variableDefaults:
+  - name: "PORT"
+    value: 80
+  - name: "SERVICEPORT"
+    value: 80

--- a/template/deployments/manifests/draft.yaml
+++ b/template/deployments/manifests/draft.yaml
@@ -3,6 +3,10 @@ variables:
     description: "the port exposed in the application"
   - name: "APPNAME"
     description: "the name of the application"
+  - name: "SERVICEPORT"
+    description: "the port the service uses to make the application accessible from outside the cluster"
 variableDefaults:
   - name: "PORT"
+    value: 80
+  - name: "SERVICEPORT"
     value: 80

--- a/template/deployments/manifests/manifests/service.yaml
+++ b/template/deployments/manifests/manifests/service.yaml
@@ -8,5 +8,5 @@ spec:
     app: {{APPNAME}}
   ports:
     - protocol: TCP
-      port: 80
+      port: {{SERVICEPORT}}
       targetPort: {{PORT}}

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -80,6 +80,7 @@ do
     version=$(echo $test | jq '.version' -r)
     builderversion=$(echo $test | jq '.builderversion' -r)
     port=$(echo $test | jq '.port' -r)
+    serviceport=$(echo $test | jq '.serviceport' -r)
     repo=$(echo $test | jq '.repo' -r)
     echo "Adding $lang with port $port"
 
@@ -92,6 +93,8 @@ languageType: \"$lang\"
 deployVariables:
   - name: \"PORT\"
     value: \"$port\"
+  - name: \"SERVICEPORT\"
+    value: \"$serviceport\"
   - name: \"APPNAME\"
     value: \"testapp\"
 languageVariables:
@@ -109,6 +112,8 @@ languageType: \"$lang\"
 deployVariables:
   - name: \"PORT\"
     value: \"$port\"
+  - name: \"SERVICEPORT\"
+    value: \"$serviceport\"
   - name: \"APPNAME\"
     value: \"testapp\"
 languageVariables:
@@ -126,6 +131,8 @@ languageType: \"$lang\"
 deployVariables:
   - name: \"PORT\"
     value: \"$port\"
+  - name: \"SERVICEPORT\"
+    value: \"$serviceport\"
   - name: \"APPNAME\"
     value: \"testapp\"
 languageVariables:

--- a/test/integration/clojure/helm.yaml
+++ b/test/integration/clojure/helm.yaml
@@ -4,6 +4,8 @@ languageType: "clojure"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/clojure/kustomize.yaml
+++ b/test/integration/clojure/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "clojure"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/clojure/manifest.yaml
+++ b/test/integration/clojure/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "clojure"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/csharp/helm.yaml
+++ b/test/integration/csharp/helm.yaml
@@ -4,6 +4,8 @@ languageType: "csharp"
 deployVariables:
   - name: "PORT"
     value: "80"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/csharp/kustomize.yaml
+++ b/test/integration/csharp/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "csharp"
 deployVariables:
   - name: "PORT"
     value: "80"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/csharp/manifest.yaml
+++ b/test/integration/csharp/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "csharp"
 deployVariables:
   - name: "PORT"
     value: "80"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/erlang/helm.yaml
+++ b/test/integration/erlang/helm.yaml
@@ -4,6 +4,8 @@ languageType: "erlang"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/erlang/kustomize.yaml
+++ b/test/integration/erlang/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "erlang"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/erlang/manifest.yaml
+++ b/test/integration/erlang/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "erlang"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/gomodule/helm.yaml
+++ b/test/integration/gomodule/helm.yaml
@@ -4,6 +4,8 @@ languageType: "gomodule"
 deployVariables:
   - name: "PORT"
     value: "1323"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/gomodule/kustomize.yaml
+++ b/test/integration/gomodule/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "gomodule"
 deployVariables:
   - name: "PORT"
     value: "1323"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/gomodule/manifest.yaml
+++ b/test/integration/gomodule/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "gomodule"
 deployVariables:
   - name: "PORT"
     value: "1323"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/gradle/helm.yaml
+++ b/test/integration/gradle/helm.yaml
@@ -4,6 +4,8 @@ languageType: "gradle"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/gradle/kustomize.yaml
+++ b/test/integration/gradle/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "gradle"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/gradle/manifest.yaml
+++ b/test/integration/gradle/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "gradle"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/java/helm.yaml
+++ b/test/integration/java/helm.yaml
@@ -4,6 +4,8 @@ languageType: "java"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/java/kustomize.yaml
+++ b/test/integration/java/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "java"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/java/manifest.yaml
+++ b/test/integration/java/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "java"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/javascript/helm.yaml
+++ b/test/integration/javascript/helm.yaml
@@ -4,6 +4,8 @@ languageType: "javascript"
 deployVariables:
   - name: "PORT"
     value: "1313"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/javascript/kustomize.yaml
+++ b/test/integration/javascript/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "javascript"
 deployVariables:
   - name: "PORT"
     value: "1313"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/javascript/manifest.yaml
+++ b/test/integration/javascript/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "javascript"
 deployVariables:
   - name: "PORT"
     value: "1313"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/python/helm.yaml
+++ b/test/integration/python/helm.yaml
@@ -4,6 +4,8 @@ languageType: "python"
 deployVariables:
   - name: "PORT"
     value: "5000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/python/kustomize.yaml
+++ b/test/integration/python/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "python"
 deployVariables:
   - name: "PORT"
     value: "5000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/python/manifest.yaml
+++ b/test/integration/python/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "python"
 deployVariables:
   - name: "PORT"
     value: "5000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/ruby/helm.yaml
+++ b/test/integration/ruby/helm.yaml
@@ -4,6 +4,8 @@ languageType: "ruby"
 deployVariables:
   - name: "PORT"
     value: "8000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/ruby/kustomize.yaml
+++ b/test/integration/ruby/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "ruby"
 deployVariables:
   - name: "PORT"
     value: "8000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/ruby/manifest.yaml
+++ b/test/integration/ruby/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "ruby"
 deployVariables:
   - name: "PORT"
     value: "8000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/rust/helm.yaml
+++ b/test/integration/rust/helm.yaml
@@ -4,6 +4,8 @@ languageType: "rust"
 deployVariables:
   - name: "PORT"
     value: "8000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/rust/kustomize.yaml
+++ b/test/integration/rust/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "rust"
 deployVariables:
   - name: "PORT"
     value: "8000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/rust/manifest.yaml
+++ b/test/integration/rust/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "rust"
 deployVariables:
   - name: "PORT"
     value: "8000"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/swift/helm.yaml
+++ b/test/integration/swift/helm.yaml
@@ -4,6 +4,8 @@ languageType: "swift"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/swift/kustomize.yaml
+++ b/test/integration/swift/kustomize.yaml
@@ -4,6 +4,8 @@ languageType: "swift"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration/swift/manifest.yaml
+++ b/test/integration/swift/manifest.yaml
@@ -4,6 +4,8 @@ languageType: "swift"
 deployVariables:
   - name: "PORT"
     value: "8080"
+  - name: "SERVICEPORT"
+    value: "80"
   - name: "APPNAME"
     value: "testapp"
 languageVariables:

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -1,33 +1,38 @@
 [
-  { "language": "gomodule", "version": "1.18", "port": "1323", "repo": "gambtho/go_echo" },
+  { "language": "gomodule", "version": "1.18", "port": "1323", "serviceport": 80, "repo": "gambtho/go_echo" },
   {
     "language": "python",
     "version": "3",
     "port": "5000",
+    "serviceport": 80,
     "repo": "OliverMKing/flask-hello-world"
   },
   {
     "language": "rust",
     "version": "1.58.0",
     "port": "8000",
+    "serviceport": 80,
     "repo": "OliverMKing/tiny-http-hello-world"
   },
   {
     "language": "javascript",
     "version": "14",
     "port": "1313",
+    "serviceport": 80,
     "repo": "davidgamero/express-hello-world"
   },
   {
     "language": "ruby",
     "version": "3.1.2",
     "port": "8000",
+    "serviceport": 80,
     "repo": "OliverMKing/ruby-hello-world"
   },
   {
     "language": "csharp",
     "version": "5.0",
     "port": "80",
+    "serviceport": 80,
     "repo": "imiller31/csharp-simple-web-app"
   },
   {
@@ -35,6 +40,7 @@
     "version": "11-jre-slim",
     "builderversion": "3-jdk-11",
     "port": "8080",
+    "serviceport": 80,
     "repo": "imiller31/simple-java-server"
   },
   {
@@ -42,12 +48,14 @@
     "version": "11-jre-slim",
     "builderversion": "jdk11",
     "port": "8080",
+    "serviceport": 80,
     "repo": "imiller31/simple-gradle-server"
   },
   {
     "language": "swift",
     "version": "5.5",
     "port": "8080",
+    "serviceport": 80,
     "repo": "OliverMKing/swift-hello-world"
   },
   {
@@ -55,12 +63,14 @@
     "version": "3.15",
     "builderversion": "24.2-alpine",
     "port": "8080",
+    "serviceport": 80,
     "repo": "bfoley13/ErlangExample"
   },
   {
     "language": "clojure",
     "version": "8-jdk-alpine",
     "port": "8080",
+    "serviceport": 80,
     "repo": "imiller31/clojure-simple-http"
   }
 ]

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -1,5 +1,11 @@
 [
-  { "language": "gomodule", "version": "1.18", "port": "1323", "serviceport": 80, "repo": "gambtho/go_echo" },
+  { 
+    "language": "gomodule", 
+    "version": "1.18", 
+    "port": "1323", 
+    "serviceport": 80, 
+    "repo": "gambtho/go_echo" 
+  },
   {
     "language": "python",
     "version": "3",


### PR DESCRIPTION
currently deployTypes generate a loadbalancer with a static port 80
this change makes this a parameter we can supply to configure for all deployTypes (manifest, helm, kustomize)