### PR TITLE
[fix] Ensure last prompt gets default value

### DIFF
--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -66,12 +66,6 @@ func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error)
 		if err != nil {
 			return nil, err
 		}
-		// Substitute the default value for variables where the user didn't enter anything
-		for _, variableDefault := range config.VariableDefaults {
-			if inputs[variableDefault.Name] == "" {
-				inputs[variableDefault.Name] = variableDefault.Value
-			}
-		}
 		inputs[prompt.OverrideString] = input
 	}
 
@@ -80,13 +74,14 @@ func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error)
 		if err != nil {
 			return nil, err
 		}
-		// Substitute the default value for variables where the user didn't enter anything
-		for _, variableDefault := range config.VariableDefaults {
-			if inputs[variableDefault.Name] == "" {
-				inputs[variableDefault.Name] = variableDefault.Value
-			}
-		}
 		inputs[prompt.OverrideString] = input
+	}
+
+	// Substitute the default value for variables where the user didn't enter anything
+	for _, variableDefault := range config.VariableDefaults {
+		if inputs[variableDefault.Name] == "" {
+			inputs[variableDefault.Name] = variableDefault.Value
+		}
 	}
 
 	return inputs, nil


### PR DESCRIPTION
If the user does not provide a value for the last prompt for a given config, the default value is not set for that variable. 

Minimal Repro:
```
pip install Django
django-admin startproject mysite && cd mysite
draft create --dockerfile-only
# enter on each prompt
```
Actual Behavior:
Dockerfile starts with `FROM python:`

Expected behavior:
Dockerfile starts with `FROM python:3`.