### PR TITLE
add a `--variable` flag to the `update` command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -40,7 +40,6 @@ type createCmd struct {
 	createConfig     *config.CreateConfig
 
 	supportedLangs *languages.Languages
-	fileMatches    *filematches.FileMatches
 
 	templateWriter templatewriter.TemplateWriter
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,42 +1,87 @@
 package cmd
 
 import (
+	"embed"
+	"fmt"
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/Azure/draft/pkg/addons"
+	"github.com/Azure/draft/pkg/templatewriter"
 	"github.com/Azure/draft/pkg/templatewriter/writers"
 	"github.com/Azure/draft/template"
 )
 
+type updateCmd struct {
+	dest           string
+	provider       string
+	addon          string
+	flagVariables  []string
+	userInputs     map[string]string
+	templateWriter templatewriter.TemplateWriter
+	addonFS        embed.FS
+}
+
 func newUpdateCmd() *cobra.Command {
-	dest := ""
-	provider := ""
-	addon := ""
-	userInputs := make(map[string]string)
-	templateWriter := &writers.LocalFSWriter{}
+	uc := &updateCmd{}
 	// updateCmd represents the update command
 	var cmd = &cobra.Command{
 		Use:   "update",
 		Short: "Updates your application to be internet accessible",
 		Long: `This command automatically updates your yaml files as necessary so that your application
-will be able to receive external requests.`,
+		will be able to receive external requests.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := addons.GenerateAddon(template.Addons, provider, addon, dest, userInputs, templateWriter); err != nil {
+			if err := uc.run(); err != nil {
 				return err
 			}
-
 			log.Info("Draft has successfully updated your yaml files so that your application will be able to receive external requests 😃")
-
 			return nil
 		},
 	}
 	f := cmd.Flags()
-	f.StringVarP(&dest, "destination", "d", ".", "specify the path to the project directory")
-	f.StringVarP(&provider, "provider", "p", "azure", "cloud provider")
-	f.StringVarP(&addon, "addon", "a", "", "addon name")
-	return cmd
+	f.StringVarP(&uc.dest, "destination", "d", ".", "specify the path to the project directory")
+	f.StringVarP(&uc.provider, "provider", "p", "azure", "cloud provider")
+	f.StringVarP(&uc.addon, "addon", "a", "", "addon name")
+	f.StringArrayVarP(&uc.flagVariables, "variable", "", []string{}, "pass a variable non-interactively (ex: --variable foo=bar)")
 
+	uc.templateWriter = &writers.LocalFSWriter{}
+
+	return cmd
+}
+
+func (uc *updateCmd) run() error {
+	flagVariablesMap := make(map[string]string)
+	for _, flagVar := range uc.flagVariables {
+		flagVarName, flagVarValue, ok := strings.Cut(flagVar, "=")
+		if !ok {
+			return fmt.Errorf("invalid variable format: %s", flagVar)
+		}
+		flagVariablesMap[flagVarName] = flagVarValue
+		log.Debugf("flag variable %s=%s", flagVarName, flagVarValue)
+	}
+
+	if uc.addon == "" {
+		addon, err := addons.PromptAddon(template.Addons, uc.provider)
+		if err != nil {
+			return err
+		}
+		uc.addon = addon
+	}
+
+	addonConfig, err := addons.GetAddonConfig(template.Addons, uc.provider, uc.addon)
+	if err != nil {
+		return err
+	}
+
+	addonInputs, err := addons.PromptAddonValues(uc.dest, flagVariablesMap, addonConfig)
+	if err != nil {
+		return err
+	}
+	log.Debugf("addonInputs is: %s", addonInputs)
+
+	return addons.GenerateAddon(template.Addons, uc.provider, uc.addon, uc.dest, uc.userInputs, uc.templateWriter)
 }
 
 func init() {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -25,76 +25,95 @@ var (
 )
 
 func GenerateAddon(addons embed.FS, provider, addon, dest string, userInputs map[string]string, templateWriter templatewriter.TemplateWriter) error {
-	providerPath := filepath.Join(parentDirName, strings.ToLower(provider))
-	addonMap, err := embedutils.EmbedFStoMap(addons, providerPath)
+	addOnConfig, err := GetAddonConfig(addons, provider, addon)
 	if err != nil {
 		return err
 	}
-	if addon == "" {
-		addonNames := maps.Keys(addonMap)
-		prompt := promptui.Select{
-			Label: fmt.Sprintf("Select %s addon", provider),
-			Items: addonNames,
-		}
-		_, addon, err = prompt.Run()
-		if err != nil {
-			return err
-		}
-	}
-
-	var selectedAddon fs.DirEntry
-	var ok bool
-	if selectedAddon, ok = addonMap[addon]; !ok {
-		return errors.New("addon not found")
-	}
-
-	selectedAddonPath := filepath.Join(providerPath, selectedAddon.Name())
-
-	configBytes, err := fs.ReadFile(addons, filepath.Join(selectedAddonPath, "draft.yaml"))
-	if err != nil {
-		return err
-	}
-
-	var addOnConfig config.AddonConfig
-	if err = yaml.Unmarshal(configBytes, &addOnConfig); err != nil {
-		return err
-	}
-
 	log.Debugf("addOnConfig is: %s", addOnConfig)
 
-	addonVals, err := getAddonValues(dest, userInputs, addOnConfig)
+	selectedAddonPath, err := GetAddonPath(addons, provider, addon)
 	if err != nil {
 		return err
 	}
-
-	log.Debugf("addonValues are: %s", addonVals)
 
 	addonDestPath, err := addOnConfig.GetAddonDestPath(dest)
 	if err != nil {
 		return err
 	}
 
-	if err = osutil.CopyDir(addons, selectedAddonPath, addonDestPath, &addOnConfig.DraftConfig, addonVals, templateWriter); err != nil {
+	if err = osutil.CopyDir(addons, selectedAddonPath, addonDestPath, &addOnConfig.DraftConfig, userInputs, templateWriter); err != nil {
 		return err
 	}
 
 	return err
 }
 
-func getAddonValues(dest string, userInputs map[string]string, addOnConfig config.AddonConfig) (map[string]string, error) {
-	log.Debugf("getAddonValues: %s", userInputs)
-	var err error
-	if userInputs == nil {
-		userInputs = make(map[string]string)
+func GetAddonPath(addons embed.FS, provider, addon string) (string, error) {
+	providerPath := filepath.Join(parentDirName, strings.ToLower(provider))
+	addonMap, err := embedutils.EmbedFStoMap(addons, providerPath)
+	if err != nil {
+		return "", err
+	}
+	var selectedAddon fs.DirEntry
+	var ok bool
+	if selectedAddon, ok = addonMap[addon]; !ok {
+		return "", errors.New("addon not found")
 	}
 
-	if len(userInputs) == 0 {
-		userInputs, err = prompts.RunPromptsFromConfig(&addOnConfig.DraftConfig)
-		if err != nil {
-			return nil, err
-		}
-		log.Debug("got user inputs")
+	selectedAddonPath := filepath.Join(providerPath, selectedAddon.Name())
+
+	return selectedAddonPath, nil
+}
+
+func GetAddonConfig(addons embed.FS, provider, addon string) (config.AddonConfig, error) {
+	selectedAddonPath, err := GetAddonPath(addons, provider, addon)
+	if err != nil {
+		return config.AddonConfig{}, err
 	}
+
+	configBytes, err := fs.ReadFile(addons, filepath.Join(selectedAddonPath, "draft.yaml"))
+	if err != nil {
+		return config.AddonConfig{}, err
+	}
+	var addOnConfig config.AddonConfig
+	if err = yaml.Unmarshal(configBytes, &addOnConfig); err != nil {
+		return config.AddonConfig{}, err
+	}
+
+	return addOnConfig, nil
+}
+
+func PromptAddon(addons embed.FS, provider string) (string, error) {
+	providerPath := filepath.Join(parentDirName, strings.ToLower(provider))
+	addonMap, err := embedutils.EmbedFStoMap(addons, providerPath)
+	if err != nil {
+		return "", err
+	}
+
+	addonNames := maps.Keys(addonMap)
+	prompt := promptui.Select{
+		Label: fmt.Sprintf("Select %s addon", provider),
+		Items: addonNames,
+	}
+	_, addon, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return addon, nil
+}
+
+func PromptAddonValues(dest string, userInputs map[string]string, addOnConfig config.AddonConfig) (map[string]string, error) {
+	log.Debugf("getAddonValues: %s", userInputs)
+	var err error
+
+	inputsToSkip := maps.Keys(userInputs)
+	log.Debugf("inputsToSkip: %s", inputsToSkip)
+	userInputs, err = prompts.RunPromptsFromConfigWithSkips(&addOnConfig.DraftConfig, inputsToSkip)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("got user inputs")
 
 	referenceMap, err := addOnConfig.GetReferenceValueMap(dest)
 	if err != nil {

--- a/pkg/filematches/filematches.go
+++ b/pkg/filematches/filematches.go
@@ -107,7 +107,7 @@ func FindDraftDeploymentFiles(dest string) (deploymentType string, err error) {
 	if _, err := os.Stat(dest + "/charts"); !os.IsNotExist(err) {
 		return "helm", nil
 	}
-	if _, err := os.Stat(dest + "/base"); !os.IsNotExist(err) {
+	if _, err := os.Stat(dest + "/overlays"); !os.IsNotExist(err) {
 		return "kustomize", nil
 	}
 	if _, err := os.Stat(dest + "/manifests"); !os.IsNotExist(err) {

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -19,15 +19,31 @@ type TemplateSelect struct {
 }
 
 func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error) {
+	return RunPromptsFromConfigWithSkips(config, []string{})
+}
+
+func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []string) (map[string]string, error) {
 	templatePrompts := make([]*TemplatePrompt, 0)
 	templateSelects := make([]*TemplateSelect, 0)
+
+	skipMap := make(map[string]interface{})
+	for _, v := range varsToSkip {
+		skipMap[v] = interface{}(nil)
+	}
+
 	for _, customPrompt := range config.Variables {
+		if _, ok := skipMap[customPrompt.Name]; ok {
+			log.Debugf("Skipping prompt for %s", customPrompt.Name)
+			continue
+		}
+
 		log.Debugf("constructing prompt for: %s", customPrompt)
 		if customPrompt.VarType == "bool" {
 			prompt := &promptui.Select{
 				Label: "Please select " + customPrompt.Description,
 				Items: []bool{true, false},
 			}
+
 			templateSelects = append(templateSelects, &TemplateSelect{
 				Select:         prompt,
 				OverrideString: customPrompt.Name,
@@ -39,6 +55,7 @@ func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error)
 					defaultString = " (default: " + variableDefault.Value + ")"
 				}
 			}
+
 			prompt := &promptui.Prompt{
 				Label: "Please enter " + customPrompt.Description + defaultString,
 				Validate: func(s string) error {
@@ -52,6 +69,7 @@ func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error)
 					return nil
 				},
 			}
+
 			templatePrompts = append(templatePrompts, &TemplatePrompt{
 				Prompt:         prompt,
 				OverrideString: customPrompt.Name,

--- a/test/check_windows_addon_kustomize.ps1
+++ b/test/check_windows_addon_kustomize.ps1
@@ -1,0 +1,4 @@
+$filesExist=$true
+$filesExist=$filesExist -and (Test-Path -Path ./overlays/production/ingress.yaml -PathType Leaf)
+echo "$file exists: $filesExist"
+if (-not $filesExist) {Exit 1}


### PR DESCRIPTION
# Description
The following PR adds a `--variable` flag for the `draft update` command, which makes it possible to run the command non-interactively.
This makes adding integration tests possible for the command, which this PR also adds.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?
Integration tests have been added for the `update command`

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

Integration tests have been added for the `draft update` command for every existing integration scenario.
For linux helm and kustomize, the upgrade integration test was added to the existing integration test that is validated by confirming successful deployment to minikube.
For the the linux manifets deployment and all the windows deployments integration tests a new dependent job was added to run after the `draft create` integration test that re-uses artifacts and applies the `draft update` command yields files and executes without error.
Template contents verification for the update command isn't included at this time.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

