### PR TITLE
add `--variable` flag to `draft update` command

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -27,7 +27,7 @@ jobs:
           path: ./draft
           if-no-files-found: error
 
-  gomodule-helm:
+  gomodule-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -49,6 +49,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gomodule/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -85,7 +86,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  gomodule-kustomize:
+  gomodule-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -107,6 +108,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gomodule/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -223,7 +225,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  python-helm:
+  python-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -245,6 +247,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/python/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -281,7 +284,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  python-kustomize:
+  python-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -303,6 +306,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/python/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -419,7 +423,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  rust-helm:
+  rust-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -441,6 +445,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/rust/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -477,7 +482,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  rust-kustomize:
+  rust-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -499,6 +504,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/rust/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -615,7 +621,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  javascript-helm:
+  javascript-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -637,6 +643,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/javascript/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -673,7 +680,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  javascript-kustomize:
+  javascript-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -695,6 +702,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/javascript/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -811,7 +819,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  ruby-helm:
+  ruby-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -833,6 +841,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/ruby/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -869,7 +878,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  ruby-kustomize:
+  ruby-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -891,6 +900,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/ruby/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1007,7 +1017,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  csharp-helm:
+  csharp-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1029,6 +1039,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/csharp/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1065,7 +1076,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  csharp-kustomize:
+  csharp-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1087,6 +1098,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/csharp/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1203,7 +1215,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  java-helm:
+  java-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1225,6 +1237,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/java/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1261,7 +1274,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  java-kustomize:
+  java-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1283,6 +1296,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/java/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1399,7 +1413,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  gradle-helm:
+  gradle-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1421,6 +1435,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gradle/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1457,7 +1472,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  gradle-kustomize:
+  gradle-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1479,6 +1494,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gradle/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1595,7 +1611,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  swift-helm:
+  swift-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1617,6 +1633,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/swift/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1653,7 +1670,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  swift-kustomize:
+  swift-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1675,6 +1692,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/swift/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1791,7 +1809,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  erlang-helm:
+  erlang-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1813,6 +1831,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/erlang/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1849,7 +1868,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  erlang-kustomize:
+  erlang-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1871,6 +1890,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/erlang/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1987,7 +2007,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
-  clojure-helm:
+  clojure-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -2009,6 +2029,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/clojure/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -2045,7 +2066,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  clojure-kustomize:
+  clojure-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -2067,6 +2088,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/clojure/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-gomodule-ingress-manifests
+  gomodule-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -376,7 +376,7 @@ gomodule-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-python-ingress-manifests
+  python-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -571,7 +571,7 @@ python-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-rust-ingress-manifests
+  rust-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -766,7 +766,7 @@ rust-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-javascript-ingress-manifests
+  javascript-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -961,7 +961,7 @@ javascript-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-ruby-ingress-manifests
+  ruby-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1156,7 +1156,7 @@ ruby-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-csharp-ingress-manifests
+  csharp-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1351,7 +1351,7 @@ csharp-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-java-ingress-manifests
+  java-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1546,7 +1546,7 @@ java-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-gradle-ingress-manifests
+  gradle-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1741,7 +1741,7 @@ gradle-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-swift-ingress-manifests
+  swift-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1936,7 +1936,7 @@ swift-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-erlang-ingress-manifests
+  erlang-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -2131,7 +2131,7 @@ erlang-ingress-manifests
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-clojure-ingress-manifests
+  clojure-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  gomodule-ingress-manifests
+  gomodule-ingress-manifests:
     needs: gomodule-manifests
     runs-on: ubuntu-latest
     services:
@@ -189,7 +189,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -377,7 +376,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  python-ingress-manifests
+  python-ingress-manifests:
     needs: python-manifests
     runs-on: ubuntu-latest
     services:
@@ -385,7 +384,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -573,7 +571,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  rust-ingress-manifests
+  rust-ingress-manifests:
     needs: rust-manifests
     runs-on: ubuntu-latest
     services:
@@ -581,7 +579,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -769,7 +766,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  javascript-ingress-manifests
+  javascript-ingress-manifests:
     needs: javascript-manifests
     runs-on: ubuntu-latest
     services:
@@ -777,7 +774,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -965,7 +961,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  ruby-ingress-manifests
+  ruby-ingress-manifests:
     needs: ruby-manifests
     runs-on: ubuntu-latest
     services:
@@ -973,7 +969,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -1161,7 +1156,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  csharp-ingress-manifests
+  csharp-ingress-manifests:
     needs: csharp-manifests
     runs-on: ubuntu-latest
     services:
@@ -1169,7 +1164,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -1357,7 +1351,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  java-ingress-manifests
+  java-ingress-manifests:
     needs: java-manifests
     runs-on: ubuntu-latest
     services:
@@ -1365,7 +1359,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -1553,7 +1546,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  gradle-ingress-manifests
+  gradle-ingress-manifests:
     needs: gradle-manifests
     runs-on: ubuntu-latest
     services:
@@ -1561,7 +1554,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -1749,7 +1741,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  swift-ingress-manifests
+  swift-ingress-manifests:
     needs: swift-manifests
     runs-on: ubuntu-latest
     services:
@@ -1757,7 +1749,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -1945,7 +1936,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  erlang-ingress-manifests
+  erlang-ingress-manifests:
     needs: erlang-manifests
     runs-on: ubuntu-latest
     services:
@@ -1953,7 +1944,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -2141,7 +2131,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  clojure-ingress-manifests
+  clojure-ingress-manifests:
     needs: clojure-manifests
     runs-on: ubuntu-latest
     services:
@@ -2149,7 +2139,6 @@ jobs:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -49,7 +49,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gomodule/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -108,7 +108,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gomodule/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -201,7 +201,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: gomodule-manifests-create
@@ -251,7 +251,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/python/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -310,7 +310,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/python/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -403,7 +403,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: python-manifests-create
@@ -453,7 +453,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/rust/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -512,7 +512,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/rust/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -605,7 +605,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: rust-manifests-create
@@ -655,7 +655,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/javascript/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -714,7 +714,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/javascript/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -807,7 +807,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: javascript-manifests-create
@@ -857,7 +857,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/ruby/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -916,7 +916,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/ruby/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1009,7 +1009,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: ruby-manifests-create
@@ -1059,7 +1059,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/csharp/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1118,7 +1118,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/csharp/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1211,7 +1211,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: csharp-manifests-create
@@ -1261,7 +1261,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/java/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1320,7 +1320,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/java/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1413,7 +1413,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: java-manifests-create
@@ -1463,7 +1463,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gradle/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1522,7 +1522,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gradle/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1615,7 +1615,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: gradle-manifests-create
@@ -1665,7 +1665,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/swift/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1724,7 +1724,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/swift/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1817,7 +1817,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: swift-manifests-create
@@ -1867,7 +1867,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/erlang/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1926,7 +1926,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/erlang/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -2019,7 +2019,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: erlang-manifests-create
@@ -2069,7 +2069,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/clojure/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -2128,7 +2128,7 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/clojure/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -2221,7 +2221,7 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: clojure-manifests-create

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -202,7 +202,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gomodule/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -397,7 +397,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/python/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -592,7 +592,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/rust/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -787,7 +787,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/javascript/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -982,7 +982,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/ruby/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1177,7 +1177,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/csharp/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1372,7 +1372,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/java/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1567,7 +1567,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gradle/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1762,7 +1762,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/swift/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1957,7 +1957,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/erlang/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -2152,7 +2152,7 @@ jobs:
           path: ./langtest
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/clojure/manifest.yaml -d ./langtest/
-      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -181,6 +181,46 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
+gomodule-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: gambtho/go_echo
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/gomodule/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
 
   python-helm:
     runs-on: ubuntu-latest
@@ -318,6 +358,46 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/python/manifest.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -d ./langtest/ -b main -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+python-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/flask-hello-world
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/python/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -491,6 +571,46 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
+rust-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/tiny-http-hello-world
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/rust/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
 
   javascript-helm:
     runs-on: ubuntu-latest
@@ -628,6 +748,46 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/javascript/manifest.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -d ./langtest/ -b main -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+javascript-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: davidgamero/express-hello-world
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/javascript/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -801,6 +961,46 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
+ruby-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/ruby-hello-world
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/ruby/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
 
   csharp-helm:
     runs-on: ubuntu-latest
@@ -938,6 +1138,46 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/csharp/manifest.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -d ./langtest/ -b main -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+csharp-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/csharp-simple-web-app
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/csharp/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1111,6 +1351,46 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
+java-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/simple-java-server
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/java/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
 
   gradle-helm:
     runs-on: ubuntu-latest
@@ -1248,6 +1528,46 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/gradle/manifest.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -d ./langtest/ -b main -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+gradle-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/simple-gradle-server
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/gradle/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1421,6 +1741,46 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
+swift-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/swift-hello-world
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/swift/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
 
   erlang-helm:
     runs-on: ubuntu-latest
@@ -1576,6 +1936,46 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
+erlang-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: bfoley13/ErlangExample
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/erlang/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
 
   clojure-helm:
     runs-on: ubuntu-latest
@@ -1713,6 +2113,46 @@ jobs:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/clojure/manifest.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -d ./langtest/ -b main -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+clojure-ingress-manifests
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/clojure-simple-http
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/clojure/manifest.yaml -d ./langtest/
+      - run: ./draft -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -201,15 +201,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: gomodule-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: gomodule-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -403,15 +399,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: python-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: python-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -605,15 +597,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: rust-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: rust-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -807,15 +795,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: javascript-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: javascript-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1009,15 +993,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: ruby-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: ruby-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1211,15 +1191,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: csharp-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: csharp-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1413,15 +1389,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: java-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: java-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1615,15 +1587,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: gradle-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: gradle-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1817,15 +1785,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: swift-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: swift-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -2019,15 +1983,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: erlang-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: erlang-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -2221,15 +2181,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
-        with:
-          name: clojure-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: clojure-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -141,7 +141,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  gomodule-manifests:
+  gomodule-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -181,8 +181,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  gomodule-ingress-manifests:
-    needs: gomodule-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: gomodule-manifests-create
+          path: ./langtest
+  gomodule-manifests-update:
+    needs: gomodule-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -195,14 +199,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: gambtho/go_echo
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/gomodule/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: gomodule-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -336,7 +337,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  python-manifests:
+  python-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -376,8 +377,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  python-ingress-manifests:
-    needs: python-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: python-manifests-create
+          path: ./langtest
+  python-manifests-update:
+    needs: python-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -390,14 +395,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: OliverMKing/flask-hello-world
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/python/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: python-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -531,7 +533,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  rust-manifests:
+  rust-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -571,8 +573,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  rust-ingress-manifests:
-    needs: rust-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: rust-manifests-create
+          path: ./langtest
+  rust-manifests-update:
+    needs: rust-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -585,14 +591,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: OliverMKing/tiny-http-hello-world
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/rust/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: rust-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -726,7 +729,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  javascript-manifests:
+  javascript-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -766,8 +769,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  javascript-ingress-manifests:
-    needs: javascript-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: javascript-manifests-create
+          path: ./langtest
+  javascript-manifests-update:
+    needs: javascript-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -780,14 +787,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: davidgamero/express-hello-world
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/javascript/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: javascript-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -921,7 +925,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  ruby-manifests:
+  ruby-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -961,8 +965,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  ruby-ingress-manifests:
-    needs: ruby-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ruby-manifests-create
+          path: ./langtest
+  ruby-manifests-update:
+    needs: ruby-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -975,14 +983,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: OliverMKing/ruby-hello-world
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/ruby/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: ruby-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1116,7 +1121,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  csharp-manifests:
+  csharp-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1156,8 +1161,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  csharp-ingress-manifests:
-    needs: csharp-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: csharp-manifests-create
+          path: ./langtest
+  csharp-manifests-update:
+    needs: csharp-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1170,14 +1179,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: imiller31/csharp-simple-web-app
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/csharp/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: csharp-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1311,7 +1317,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  java-manifests:
+  java-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1351,8 +1357,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  java-ingress-manifests:
-    needs: java-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: java-manifests-create
+          path: ./langtest
+  java-manifests-update:
+    needs: java-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1365,14 +1375,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: imiller31/simple-java-server
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/java/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: java-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1506,7 +1513,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  gradle-manifests:
+  gradle-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1546,8 +1553,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  gradle-ingress-manifests:
-    needs: gradle-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: gradle-manifests-create
+          path: ./langtest
+  gradle-manifests-update:
+    needs: gradle-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1560,14 +1571,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: imiller31/simple-gradle-server
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/gradle/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: gradle-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1701,7 +1709,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  swift-manifests:
+  swift-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1741,8 +1749,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  swift-ingress-manifests:
-    needs: swift-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: swift-manifests-create
+          path: ./langtest
+  swift-manifests-update:
+    needs: swift-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1755,14 +1767,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: OliverMKing/swift-hello-world
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/swift/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: swift-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -1896,7 +1905,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  erlang-manifests:
+  erlang-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1936,8 +1945,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  erlang-ingress-manifests:
-    needs: erlang-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: erlang-manifests-create
+          path: ./langtest
+  erlang-manifests-update:
+    needs: erlang-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1950,14 +1963,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: bfoley13/ErlangExample
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/erlang/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: erlang-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -2091,7 +2101,7 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: exit 6
 
-  clojure-manifests:
+  clojure-manifests-create:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -2131,8 +2141,12 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  clojure-ingress-manifests:
-    needs: clojure-manifests
+      - uses: actions/upload-artifact@v2
+        with:
+          name: clojure-manifests-create
+          path: ./langtest
+  clojure-manifests-update:
+    needs: clojure-manifests-create
     runs-on: ubuntu-latest
     services:
       registry:
@@ -2145,14 +2159,11 @@ jobs:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
-        with:
-          repository: imiller31/clojure-simple-http
-          path: ./langtest
-      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
-      - run: ./draft -v create -c ./test/integration/clojure/manifest.yaml -d ./langtest/
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: clojure-manifests-create
+          path: ./langtest/
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -205,6 +205,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: gomodule-manifests-create
+          path: ./langtest
+      - uses: actions/download-artifact@v2
+        with:
+          name: gomodule-manifests-create
           path: ./langtest/
       - name: start minikube
         id: minikube
@@ -400,6 +404,10 @@ jobs:
           name: draft-binary
       - run: chmod +x ./draft
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: python-manifests-create
+          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: python-manifests-create
@@ -601,6 +609,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: rust-manifests-create
+          path: ./langtest
+      - uses: actions/download-artifact@v2
+        with:
+          name: rust-manifests-create
           path: ./langtest/
       - name: start minikube
         id: minikube
@@ -796,6 +808,10 @@ jobs:
           name: draft-binary
       - run: chmod +x ./draft
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: javascript-manifests-create
+          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: javascript-manifests-create
@@ -997,6 +1013,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: ruby-manifests-create
+          path: ./langtest
+      - uses: actions/download-artifact@v2
+        with:
+          name: ruby-manifests-create
           path: ./langtest/
       - name: start minikube
         id: minikube
@@ -1192,6 +1212,10 @@ jobs:
           name: draft-binary
       - run: chmod +x ./draft
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: csharp-manifests-create
+          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: csharp-manifests-create
@@ -1393,6 +1417,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: java-manifests-create
+          path: ./langtest
+      - uses: actions/download-artifact@v2
+        with:
+          name: java-manifests-create
           path: ./langtest/
       - name: start minikube
         id: minikube
@@ -1588,6 +1616,10 @@ jobs:
           name: draft-binary
       - run: chmod +x ./draft
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: gradle-manifests-create
+          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: gradle-manifests-create
@@ -1789,6 +1821,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: swift-manifests-create
+          path: ./langtest
+      - uses: actions/download-artifact@v2
+        with:
+          name: swift-manifests-create
           path: ./langtest/
       - name: start minikube
         id: minikube
@@ -1987,6 +2023,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: erlang-manifests-create
+          path: ./langtest
+      - uses: actions/download-artifact@v2
+        with:
+          name: erlang-manifests-create
           path: ./langtest/
       - name: start minikube
         id: minikube
@@ -2182,6 +2222,10 @@ jobs:
           name: draft-binary
       - run: chmod +x ./draft
       - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: clojure-manifests-create
+          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: clojure-manifests-create

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -181,7 +181,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  gomodule-ingress-manifests:
+  gomodule-ingress-manifests
+    needs: gomodule-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -376,7 +377,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  python-ingress-manifests:
+  python-ingress-manifests
+    needs: python-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -571,7 +573,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  rust-ingress-manifests:
+  rust-ingress-manifests
+    needs: rust-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -766,7 +769,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  javascript-ingress-manifests:
+  javascript-ingress-manifests
+    needs: javascript-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -961,7 +965,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  ruby-ingress-manifests:
+  ruby-ingress-manifests
+    needs: ruby-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1156,7 +1161,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  csharp-ingress-manifests:
+  csharp-ingress-manifests
+    needs: csharp-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1351,7 +1357,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  java-ingress-manifests:
+  java-ingress-manifests
+    needs: java-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1546,7 +1553,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  gradle-ingress-manifests:
+  gradle-ingress-manifests
+    needs: gradle-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1741,7 +1749,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  swift-ingress-manifests:
+  swift-ingress-manifests
+    needs: swift-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1936,7 +1945,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  erlang-ingress-manifests:
+  erlang-ingress-manifests
+    needs: erlang-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -2131,7 +2141,8 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  clojure-ingress-manifests:
+  clojure-ingress-manifests
+    needs: clojure-manifests
     runs-on: ubuntu-latest
     services:
       registry:

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  gomodule-ingress-manifests
+  gomodule-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -376,7 +376,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  python-ingress-manifests
+  python-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -571,7 +571,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  rust-ingress-manifests
+  rust-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -766,7 +766,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  javascript-ingress-manifests
+  javascript-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -961,7 +961,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  ruby-ingress-manifests
+  ruby-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1156,7 +1156,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  csharp-ingress-manifests
+  csharp-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1351,7 +1351,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  java-ingress-manifests
+  java-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1546,7 +1546,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  gradle-ingress-manifests
+  gradle-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1741,7 +1741,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  swift-ingress-manifests
+  swift-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -1936,7 +1936,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  erlang-ingress-manifests
+  erlang-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -2131,7 +2131,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  clojure-ingress-manifests
+  clojure-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -28,8 +28,18 @@ jobs:
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
+          name: check_windows_addon_helm
+          path: ./test/check_windows_addon_helm.ps1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
           name: check_windows_kustomize
           path: ./test/check_windows_kustomize.ps1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: check_windows_addon_kustomize
+          path: ./test/check_windows_addon_kustomize.ps1
           if-no-files-found: error
 
   gomodule-helm:

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -113,6 +113,10 @@ jobs:
         with:
           repository: gambtho/go_echo
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/gomodule/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -204,6 +208,10 @@ jobs:
         with:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/python/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -295,6 +303,10 @@ jobs:
         with:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/rust/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -386,6 +398,10 @@ jobs:
         with:
           repository: davidgamero/express-hello-world
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/javascript/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -477,6 +493,10 @@ jobs:
         with:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/ruby/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -568,6 +588,10 @@ jobs:
         with:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/csharp/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -659,6 +683,10 @@ jobs:
         with:
           repository: imiller31/simple-java-server
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/java/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -750,6 +778,10 @@ jobs:
         with:
           repository: imiller31/simple-gradle-server
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/gradle/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -841,6 +873,10 @@ jobs:
         with:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/swift/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -932,6 +968,10 @@ jobs:
         with:
           repository: bfoley13/ErlangExample
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/erlang/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -1023,6 +1063,10 @@ jobs:
         with:
           repository: imiller31/clojure-simple-http
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/clojure/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -69,7 +69,7 @@ jobs:
           repository: gambtho/go_echo
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -114,7 +114,7 @@ jobs:
           repository: gambtho/go_echo
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -160,7 +160,7 @@ jobs:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -205,7 +205,7 @@ jobs:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -251,7 +251,7 @@ jobs:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -296,7 +296,7 @@ jobs:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -342,7 +342,7 @@ jobs:
           repository: davidgamero/express-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -387,7 +387,7 @@ jobs:
           repository: davidgamero/express-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -433,7 +433,7 @@ jobs:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -478,7 +478,7 @@ jobs:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -524,7 +524,7 @@ jobs:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -569,7 +569,7 @@ jobs:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -615,7 +615,7 @@ jobs:
           repository: imiller31/simple-java-server
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -660,7 +660,7 @@ jobs:
           repository: imiller31/simple-java-server
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -706,7 +706,7 @@ jobs:
           repository: imiller31/simple-gradle-server
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -751,7 +751,7 @@ jobs:
           repository: imiller31/simple-gradle-server
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -797,7 +797,7 @@ jobs:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -842,7 +842,7 @@ jobs:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -888,7 +888,7 @@ jobs:
           repository: bfoley13/ErlangExample
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -933,7 +933,7 @@ jobs:
           repository: bfoley13/ErlangExample
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -979,7 +979,7 @@ jobs:
           repository: imiller31/clojure-simple-http
           path: ./langtest
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -1024,7 +1024,7 @@ jobs:
           repository: imiller31/clojure-simple-http
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -81,7 +81,7 @@ jobs:
         working-directory: ./langtest/
   gomodule-ingress-kustomize:
     runs-on: windows-latest
-    needs: gomodule-customize 
+    needs: gomodule-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -151,7 +151,7 @@ jobs:
         working-directory: ./langtest/
   python-ingress-kustomize:
     runs-on: windows-latest
-    needs: python-customize 
+    needs: python-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -221,7 +221,7 @@ jobs:
         working-directory: ./langtest/
   rust-ingress-kustomize:
     runs-on: windows-latest
-    needs: rust-customize 
+    needs: rust-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -291,7 +291,7 @@ jobs:
         working-directory: ./langtest/
   javascript-ingress-kustomize:
     runs-on: windows-latest
-    needs: javascript-customize 
+    needs: javascript-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -361,7 +361,7 @@ jobs:
         working-directory: ./langtest/
   ruby-ingress-kustomize:
     runs-on: windows-latest
-    needs: ruby-customize 
+    needs: ruby-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -431,7 +431,7 @@ jobs:
         working-directory: ./langtest/
   csharp-ingress-kustomize:
     runs-on: windows-latest
-    needs: csharp-customize 
+    needs: csharp-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -501,7 +501,7 @@ jobs:
         working-directory: ./langtest/
   java-ingress-kustomize:
     runs-on: windows-latest
-    needs: java-customize 
+    needs: java-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -571,7 +571,7 @@ jobs:
         working-directory: ./langtest/
   gradle-ingress-kustomize:
     runs-on: windows-latest
-    needs: gradle-customize 
+    needs: gradle-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -641,7 +641,7 @@ jobs:
         working-directory: ./langtest/
   swift-ingress-kustomize:
     runs-on: windows-latest
-    needs: swift-customize 
+    needs: swift-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -711,7 +711,7 @@ jobs:
         working-directory: ./langtest/
   erlang-ingress-kustomize:
     runs-on: windows-latest
-    needs: erlang-customize 
+    needs: erlang-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -781,7 +781,7 @@ jobs:
         working-directory: ./langtest/
   clojure-ingress-kustomize:
     runs-on: windows-latest
-    needs: clojure-customize 
+    needs: clojure-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -87,7 +87,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  gomodule-kustomize:
+  gomodule-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -110,23 +110,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  gomodule-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gomodule-kustomize-create
+          path: ./langtest
+  gomodule-kustomize-update:
     needs: gomodule-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: gambtho/go_echo
+          name: gomodule-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/gomodule/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -182,7 +180,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  python-kustomize:
+  python-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -205,23 +203,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  python-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: python-kustomize-create
+          path: ./langtest
+  python-kustomize-update:
     needs: python-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: OliverMKing/flask-hello-world
+          name: python-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/python/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -277,7 +273,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  rust-kustomize:
+  rust-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -300,23 +296,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  rust-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rust-kustomize-create
+          path: ./langtest
+  rust-kustomize-update:
     needs: rust-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: OliverMKing/tiny-http-hello-world
+          name: rust-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/rust/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -372,7 +366,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  javascript-kustomize:
+  javascript-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -395,23 +389,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  javascript-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: javascript-kustomize-create
+          path: ./langtest
+  javascript-kustomize-update:
     needs: javascript-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: davidgamero/express-hello-world
+          name: javascript-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/javascript/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -467,7 +459,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  ruby-kustomize:
+  ruby-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -490,23 +482,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  ruby-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ruby-kustomize-create
+          path: ./langtest
+  ruby-kustomize-update:
     needs: ruby-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: OliverMKing/ruby-hello-world
+          name: ruby-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/ruby/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -562,7 +552,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  csharp-kustomize:
+  csharp-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -585,23 +575,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  csharp-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: csharp-kustomize-create
+          path: ./langtest
+  csharp-kustomize-update:
     needs: csharp-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: imiller31/csharp-simple-web-app
+          name: csharp-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/csharp/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -657,7 +645,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  java-kustomize:
+  java-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -680,23 +668,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  java-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: java-kustomize-create
+          path: ./langtest
+  java-kustomize-update:
     needs: java-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: imiller31/simple-java-server
+          name: java-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/java/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -752,7 +738,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  gradle-kustomize:
+  gradle-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -775,23 +761,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  gradle-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gradle-kustomize-create
+          path: ./langtest
+  gradle-kustomize-update:
     needs: gradle-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: imiller31/simple-gradle-server
+          name: gradle-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/gradle/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -847,7 +831,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  swift-kustomize:
+  swift-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -870,23 +854,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  swift-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: swift-kustomize-create
+          path: ./langtest
+  swift-kustomize-update:
     needs: swift-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: OliverMKing/swift-hello-world
+          name: swift-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/swift/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -942,7 +924,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  erlang-kustomize:
+  erlang-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -965,23 +947,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  erlang-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: erlang-kustomize-create
+          path: ./langtest
+  erlang-kustomize-update:
     needs: erlang-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: bfoley13/ErlangExample
+          name: erlang-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/erlang/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -1037,7 +1017,7 @@ jobs:
       - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
-  clojure-kustomize:
+  clojure-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -1060,23 +1040,21 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  clojure-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: clojure-kustomize-create
+          path: ./langtest
+  clojure-kustomize-update:
     needs: clojure-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: imiller31/clojure-simple-http
+          name: clojure-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/clojure/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -82,7 +82,7 @@ jobs:
           name: gomodule-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -129,7 +129,7 @@ jobs:
           name: gomodule-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -178,7 +178,7 @@ jobs:
           name: python-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -225,7 +225,7 @@ jobs:
           name: python-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -274,7 +274,7 @@ jobs:
           name: rust-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -321,7 +321,7 @@ jobs:
           name: rust-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -370,7 +370,7 @@ jobs:
           name: javascript-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -417,7 +417,7 @@ jobs:
           name: javascript-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -466,7 +466,7 @@ jobs:
           name: ruby-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -513,7 +513,7 @@ jobs:
           name: ruby-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -562,7 +562,7 @@ jobs:
           name: csharp-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -609,7 +609,7 @@ jobs:
           name: csharp-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -658,7 +658,7 @@ jobs:
           name: java-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -705,7 +705,7 @@ jobs:
           name: java-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -754,7 +754,7 @@ jobs:
           name: gradle-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -801,7 +801,7 @@ jobs:
           name: gradle-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -850,7 +850,7 @@ jobs:
           name: swift-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -897,7 +897,7 @@ jobs:
           name: swift-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -946,7 +946,7 @@ jobs:
           name: erlang-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -993,7 +993,7 @@ jobs:
           name: erlang-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize
@@ -1042,7 +1042,7 @@ jobs:
           name: clojure-helm-create
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_helm
@@ -1089,7 +1089,7 @@ jobs:
           name: clojure-kustomize-create
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
-      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
           name: check_windows_addon_kustomize

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -55,6 +55,27 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
+  gomodule-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: gambtho/go_echo
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
+        working-directory: ./langtest/
 
   gomodule-kustomize:
     runs-on: windows-latest
@@ -96,7 +117,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -124,6 +145,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  python-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/flask-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   python-kustomize:
@@ -166,7 +208,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -194,6 +236,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  rust-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/tiny-http-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   rust-kustomize:
@@ -236,7 +299,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -264,6 +327,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  javascript-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: davidgamero/express-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   javascript-kustomize:
@@ -306,7 +390,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -334,6 +418,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  ruby-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/ruby-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   ruby-kustomize:
@@ -376,7 +481,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -404,6 +509,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  csharp-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/csharp-simple-web-app
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   csharp-kustomize:
@@ -446,7 +572,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -474,6 +600,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  java-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/simple-java-server
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   java-kustomize:
@@ -516,7 +663,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -544,6 +691,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  gradle-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/simple-gradle-server
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   gradle-kustomize:
@@ -586,7 +754,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -614,6 +782,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  swift-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/swift-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   swift-kustomize:
@@ -656,7 +845,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -684,6 +873,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  erlang-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: bfoley13/ErlangExample
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   erlang-kustomize:
@@ -726,7 +936,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
@@ -754,6 +964,27 @@ jobs:
           name: check_windows_helm
           path: ./langtest/
       - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+  clojure-ingress-helm:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/clojure-simple-http
+          path: ./langtest
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
         working-directory: ./langtest/
 
   clojure-kustomize:
@@ -796,7 +1027,7 @@ jobs:
       - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
         with:
-          name: check_windows_kustomize
+          name: check_windows_addon_kustomize
           path: ./langtest/
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -56,8 +56,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   gomodule-ingress-helm:
+    needs: gomodule-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -101,8 +101,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   gomodule-ingress-kustomize:
-    runs-on: windows-latest
     needs: gomodule-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -147,8 +147,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   python-ingress-helm:
+    needs: python-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -192,8 +192,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   python-ingress-kustomize:
-    runs-on: windows-latest
     needs: python-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -238,8 +238,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   rust-ingress-helm:
+    needs: rust-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -283,8 +283,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   rust-ingress-kustomize:
-    runs-on: windows-latest
     needs: rust-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -329,8 +329,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   javascript-ingress-helm:
+    needs: javascript-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -374,8 +374,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   javascript-ingress-kustomize:
-    runs-on: windows-latest
     needs: javascript-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -420,8 +420,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   ruby-ingress-helm:
+    needs: ruby-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -465,8 +465,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   ruby-ingress-kustomize:
-    runs-on: windows-latest
     needs: ruby-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -511,8 +511,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   csharp-ingress-helm:
+    needs: csharp-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -556,8 +556,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   csharp-ingress-kustomize:
-    runs-on: windows-latest
     needs: csharp-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -602,8 +602,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   java-ingress-helm:
+    needs: java-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -647,8 +647,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   java-ingress-kustomize:
-    runs-on: windows-latest
     needs: java-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -693,8 +693,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   gradle-ingress-helm:
+    needs: gradle-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -738,8 +738,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   gradle-ingress-kustomize:
-    runs-on: windows-latest
     needs: gradle-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -784,8 +784,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   swift-ingress-helm:
+    needs: swift-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -829,8 +829,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   swift-ingress-kustomize:
-    runs-on: windows-latest
     needs: swift-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -875,8 +875,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   erlang-ingress-helm:
+    needs: erlang-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -920,8 +920,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   erlang-ingress-kustomize:
-    runs-on: windows-latest
     needs: erlang-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -966,8 +966,8 @@ jobs:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   clojure-ingress-helm:
+    needs: clojure-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -1011,8 +1011,8 @@ jobs:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   clojure-ingress-kustomize:
-    runs-on: windows-latest
     needs: clojure-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -115,7 +115,7 @@ jobs:
           name: gomodule-kustomize-create
           path: ./langtest
   gomodule-kustomize-update:
-    needs: gomodule-kustomize 
+    needs: gomodule-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -208,7 +208,7 @@ jobs:
           name: python-kustomize-create
           path: ./langtest
   python-kustomize-update:
-    needs: python-kustomize 
+    needs: python-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -301,7 +301,7 @@ jobs:
           name: rust-kustomize-create
           path: ./langtest
   rust-kustomize-update:
-    needs: rust-kustomize 
+    needs: rust-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -394,7 +394,7 @@ jobs:
           name: javascript-kustomize-create
           path: ./langtest
   javascript-kustomize-update:
-    needs: javascript-kustomize 
+    needs: javascript-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -487,7 +487,7 @@ jobs:
           name: ruby-kustomize-create
           path: ./langtest
   ruby-kustomize-update:
-    needs: ruby-kustomize 
+    needs: ruby-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -580,7 +580,7 @@ jobs:
           name: csharp-kustomize-create
           path: ./langtest
   csharp-kustomize-update:
-    needs: csharp-kustomize 
+    needs: csharp-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -673,7 +673,7 @@ jobs:
           name: java-kustomize-create
           path: ./langtest
   java-kustomize-update:
-    needs: java-kustomize 
+    needs: java-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -766,7 +766,7 @@ jobs:
           name: gradle-kustomize-create
           path: ./langtest
   gradle-kustomize-update:
-    needs: gradle-kustomize 
+    needs: gradle-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -859,7 +859,7 @@ jobs:
           name: swift-kustomize-create
           path: ./langtest
   swift-kustomize-update:
-    needs: swift-kustomize 
+    needs: swift-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -952,7 +952,7 @@ jobs:
           name: erlang-kustomize-create
           path: ./langtest
   erlang-kustomize-update:
-    needs: erlang-kustomize 
+    needs: erlang-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -1045,7 +1045,7 @@ jobs:
           name: clojure-kustomize-create
           path: ./langtest
   clojure-kustomize-update:
-    needs: clojure-kustomize 
+    needs: clojure-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -79,6 +79,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  gomodule-ingress-kustomize:
+    runs-on: windows-latest
+    needs: gomodule-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: gambtho/go_echo
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   python-helm:
     runs-on: windows-latest
@@ -127,6 +149,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  python-ingress-kustomize:
+    runs-on: windows-latest
+    needs: python-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/flask-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   rust-helm:
     runs-on: windows-latest
@@ -175,6 +219,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  rust-ingress-kustomize:
+    runs-on: windows-latest
+    needs: rust-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/tiny-http-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   javascript-helm:
     runs-on: windows-latest
@@ -223,6 +289,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  javascript-ingress-kustomize:
+    runs-on: windows-latest
+    needs: javascript-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: davidgamero/express-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   ruby-helm:
     runs-on: windows-latest
@@ -271,6 +359,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  ruby-ingress-kustomize:
+    runs-on: windows-latest
+    needs: ruby-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/ruby-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   csharp-helm:
     runs-on: windows-latest
@@ -319,6 +429,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  csharp-ingress-kustomize:
+    runs-on: windows-latest
+    needs: csharp-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/csharp-simple-web-app
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   java-helm:
     runs-on: windows-latest
@@ -367,6 +499,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  java-ingress-kustomize:
+    runs-on: windows-latest
+    needs: java-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/simple-java-server
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   gradle-helm:
     runs-on: windows-latest
@@ -415,6 +569,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  gradle-ingress-kustomize:
+    runs-on: windows-latest
+    needs: gradle-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/simple-gradle-server
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   swift-helm:
     runs-on: windows-latest
@@ -463,6 +639,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  swift-ingress-kustomize:
+    runs-on: windows-latest
+    needs: swift-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: OliverMKing/swift-hello-world
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   erlang-helm:
     runs-on: windows-latest
@@ -511,6 +709,28 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  erlang-ingress-kustomize:
+    runs-on: windows-latest
+    needs: erlang-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: bfoley13/ErlangExample
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
 
   clojure-helm:
     runs-on: windows-latest
@@ -559,3 +779,25 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
+  clojure-ingress-kustomize:
+    runs-on: windows-latest
+    needs: clojure-customize 
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v2
+        with:
+          repository: imiller31/clojure-simple-http
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v2
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -42,7 +42,7 @@ jobs:
           path: ./test/check_windows_addon_kustomize.ps1
           if-no-files-found: error
 
-  gomodule-helm:
+  gomodule-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -65,19 +65,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  gomodule-ingress-helm:
-    needs: gomodule-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gomodule-helm-create
+          path: ./langtest
+  gomodule-helm-update:
+    needs: gomodule-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: gambtho/go_echo
-          path: ./langtest
+          name: gomodule-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -135,7 +138,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  python-helm:
+  python-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -158,19 +161,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  python-ingress-helm:
-    needs: python-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: python-helm-create
+          path: ./langtest
+  python-helm-update:
+    needs: python-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: OliverMKing/flask-hello-world
-          path: ./langtest
+          name: python-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -228,7 +234,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  rust-helm:
+  rust-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -251,19 +257,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  rust-ingress-helm:
-    needs: rust-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rust-helm-create
+          path: ./langtest
+  rust-helm-update:
+    needs: rust-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: OliverMKing/tiny-http-hello-world
-          path: ./langtest
+          name: rust-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -321,7 +330,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  javascript-helm:
+  javascript-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -344,19 +353,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  javascript-ingress-helm:
-    needs: javascript-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: javascript-helm-create
+          path: ./langtest
+  javascript-helm-update:
+    needs: javascript-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: davidgamero/express-hello-world
-          path: ./langtest
+          name: javascript-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -414,7 +426,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  ruby-helm:
+  ruby-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -437,19 +449,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  ruby-ingress-helm:
-    needs: ruby-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ruby-helm-create
+          path: ./langtest
+  ruby-helm-update:
+    needs: ruby-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: OliverMKing/ruby-hello-world
-          path: ./langtest
+          name: ruby-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -507,7 +522,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  csharp-helm:
+  csharp-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -530,19 +545,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  csharp-ingress-helm:
-    needs: csharp-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: csharp-helm-create
+          path: ./langtest
+  csharp-helm-update:
+    needs: csharp-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: imiller31/csharp-simple-web-app
-          path: ./langtest
+          name: csharp-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -600,7 +618,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  java-helm:
+  java-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -623,19 +641,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  java-ingress-helm:
-    needs: java-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: java-helm-create
+          path: ./langtest
+  java-helm-update:
+    needs: java-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: imiller31/simple-java-server
-          path: ./langtest
+          name: java-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -693,7 +714,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  gradle-helm:
+  gradle-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -716,19 +737,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  gradle-ingress-helm:
-    needs: gradle-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gradle-helm-create
+          path: ./langtest
+  gradle-helm-update:
+    needs: gradle-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: imiller31/simple-gradle-server
-          path: ./langtest
+          name: gradle-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -786,7 +810,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  swift-helm:
+  swift-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -809,19 +833,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  swift-ingress-helm:
-    needs: swift-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: swift-helm-create
+          path: ./langtest
+  swift-helm-update:
+    needs: swift-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: OliverMKing/swift-hello-world
-          path: ./langtest
+          name: swift-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -879,7 +906,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  erlang-helm:
+  erlang-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -902,19 +929,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  erlang-ingress-helm:
-    needs: erlang-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: erlang-helm-create
+          path: ./langtest
+  erlang-helm-update:
+    needs: erlang-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: bfoley13/ErlangExample
-          path: ./langtest
+          name: erlang-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2
@@ -972,7 +1002,7 @@ jobs:
         working-directory: ./langtest/
       
 
-  clojure-helm:
+  clojure-helm-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -995,19 +1025,22 @@ jobs:
           path: ./langtest/
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
-  clojure-ingress-helm:
-    needs: clojure-helm 
+      - uses: actions/upload-artifact@v3
+        with:
+          name: clojure-helm-create
+          path: ./langtest
+  clojure-helm-update:
+    needs: clojure-helm-create
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: imiller31/clojure-simple-http
-          path: ./langtest
+          name: clojure-helm-create
+          path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
       - uses: actions/download-artifact@v2

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -40,7 +40,6 @@ type createCmd struct {
 	createConfig     *config.CreateConfig
 
 	supportedLangs *languages.Languages
-	fileMatches    *filematches.FileMatches
 
 	templateWriter templatewriter.TemplateWriter
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -75,11 +75,11 @@ func (uc *updateCmd) run() error {
 		return err
 	}
 
-	addonInputs, err := addons.PromptAddonValues(uc.dest, flagVariablesMap, addonConfig)
+	uc.userInputs, err = addons.PromptAddonValues(uc.dest, flagVariablesMap, addonConfig)
 	if err != nil {
 		return err
 	}
-	log.Debugf("addonInputs is: %s", addonInputs)
+	log.Debugf("addonInputs is: %s", uc.userInputs)
 
 	return addons.GenerateAddon(template.Addons, uc.provider, uc.addon, uc.dest, uc.userInputs, uc.templateWriter)
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,42 +1,87 @@
 package cmd
 
 import (
+	"embed"
+	"fmt"
+	"strings"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/Azure/draft/pkg/addons"
+	"github.com/Azure/draft/pkg/templatewriter"
 	"github.com/Azure/draft/pkg/templatewriter/writers"
 	"github.com/Azure/draft/template"
 )
 
+type updateCmd struct {
+	dest           string
+	provider       string
+	addon          string
+	flagVariables  []string
+	userInputs     map[string]string
+	templateWriter templatewriter.TemplateWriter
+	addonFS        embed.FS
+}
+
 func newUpdateCmd() *cobra.Command {
-	dest := ""
-	provider := ""
-	addon := ""
-	userInputs := make(map[string]string)
-	templateWriter := &writers.LocalFSWriter{}
+	uc := &updateCmd{}
 	// updateCmd represents the update command
 	var cmd = &cobra.Command{
 		Use:   "update",
 		Short: "Updates your application to be internet accessible",
 		Long: `This command automatically updates your yaml files as necessary so that your application
-will be able to receive external requests.`,
+		will be able to receive external requests.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := addons.GenerateAddon(template.Addons, provider, addon, dest, userInputs, templateWriter); err != nil {
+			if err := uc.run(); err != nil {
 				return err
 			}
-
 			log.Info("Draft has successfully updated your yaml files so that your application will be able to receive external requests 😃")
-
 			return nil
 		},
 	}
 	f := cmd.Flags()
-	f.StringVarP(&dest, "destination", "d", ".", "specify the path to the project directory")
-	f.StringVarP(&provider, "provider", "p", "azure", "cloud provider")
-	f.StringVarP(&addon, "addon", "a", "", "addon name")
-	return cmd
+	f.StringVarP(&uc.dest, "destination", "d", ".", "specify the path to the project directory")
+	f.StringVarP(&uc.provider, "provider", "p", "azure", "cloud provider")
+	f.StringVarP(&uc.addon, "addon", "a", "", "addon name")
+	f.StringArrayVarP(&uc.flagVariables, "variable", "", []string{}, "pass a variable non-interactively (ex: --variable foo=bar)")
 
+	uc.templateWriter = &writers.LocalFSWriter{}
+
+	return cmd
+}
+
+func (uc *updateCmd) run() error {
+	flagVariablesMap := make(map[string]string)
+	for _, flagVar := range uc.flagVariables {
+		flagVarName, flagVarValue, ok := strings.Cut(flagVar, "=")
+		if !ok {
+			return fmt.Errorf("invalid variable format: %s", flagVar)
+		}
+		flagVariablesMap[flagVarName] = flagVarValue
+		log.Debugf("flag variable %s=%s", flagVarName, flagVarValue)
+	}
+
+	if uc.addon == "" {
+		addon, err := addons.PromptAddon(template.Addons, uc.provider)
+		if err != nil {
+			return err
+		}
+		uc.addon = addon
+	}
+
+	addonConfig, err := addons.GetAddonConfig(template.Addons, uc.provider, uc.addon)
+	if err != nil {
+		return err
+	}
+
+	addonInputs, err := addons.PromptAddonValues(uc.dest, flagVariablesMap, addonConfig)
+	if err != nil {
+		return err
+	}
+	log.Debugf("addonInputs is: %s", addonInputs)
+
+	return addons.GenerateAddon(template.Addons, uc.provider, uc.addon, uc.dest, uc.userInputs, uc.templateWriter)
 }
 
 func init() {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -109,11 +109,14 @@ func PromptAddonValues(dest string, userInputs map[string]string, addOnConfig co
 
 	inputsToSkip := maps.Keys(userInputs)
 	log.Debugf("inputsToSkip: %s", inputsToSkip)
-	userInputs, err = prompts.RunPromptsFromConfigWithSkips(&addOnConfig.DraftConfig, inputsToSkip)
+	promptInputs, err := prompts.RunPromptsFromConfigWithSkips(&addOnConfig.DraftConfig, inputsToSkip)
 	if err != nil {
 		return nil, err
 	}
 	log.Debug("got user inputs")
+	for k, v := range promptInputs {
+		userInputs[k] = v
+	}
 
 	referenceMap, err := addOnConfig.GetReferenceValueMap(dest)
 	if err != nil {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -25,76 +25,95 @@ var (
 )
 
 func GenerateAddon(addons embed.FS, provider, addon, dest string, userInputs map[string]string, templateWriter templatewriter.TemplateWriter) error {
-	providerPath := filepath.Join(parentDirName, strings.ToLower(provider))
-	addonMap, err := embedutils.EmbedFStoMap(addons, providerPath)
+	addOnConfig, err := GetAddonConfig(addons, provider, addon)
 	if err != nil {
 		return err
 	}
-	if addon == "" {
-		addonNames := maps.Keys(addonMap)
-		prompt := promptui.Select{
-			Label: fmt.Sprintf("Select %s addon", provider),
-			Items: addonNames,
-		}
-		_, addon, err = prompt.Run()
-		if err != nil {
-			return err
-		}
-	}
-
-	var selectedAddon fs.DirEntry
-	var ok bool
-	if selectedAddon, ok = addonMap[addon]; !ok {
-		return errors.New("addon not found")
-	}
-
-	selectedAddonPath := filepath.Join(providerPath, selectedAddon.Name())
-
-	configBytes, err := fs.ReadFile(addons, filepath.Join(selectedAddonPath, "draft.yaml"))
-	if err != nil {
-		return err
-	}
-
-	var addOnConfig config.AddonConfig
-	if err = yaml.Unmarshal(configBytes, &addOnConfig); err != nil {
-		return err
-	}
-
 	log.Debugf("addOnConfig is: %s", addOnConfig)
 
-	addonVals, err := getAddonValues(dest, userInputs, addOnConfig)
+	selectedAddonPath, err := GetAddonPath(addons, provider, addon)
 	if err != nil {
 		return err
 	}
-
-	log.Debugf("addonValues are: %s", addonVals)
 
 	addonDestPath, err := addOnConfig.GetAddonDestPath(dest)
 	if err != nil {
 		return err
 	}
 
-	if err = osutil.CopyDir(addons, selectedAddonPath, addonDestPath, &addOnConfig.DraftConfig, addonVals, templateWriter); err != nil {
+	if err = osutil.CopyDir(addons, selectedAddonPath, addonDestPath, &addOnConfig.DraftConfig, userInputs, templateWriter); err != nil {
 		return err
 	}
 
 	return err
 }
 
-func getAddonValues(dest string, userInputs map[string]string, addOnConfig config.AddonConfig) (map[string]string, error) {
-	log.Debugf("getAddonValues: %s", userInputs)
-	var err error
-	if userInputs == nil {
-		userInputs = make(map[string]string)
+func GetAddonPath(addons embed.FS, provider, addon string) (string, error) {
+	providerPath := filepath.Join(parentDirName, strings.ToLower(provider))
+	addonMap, err := embedutils.EmbedFStoMap(addons, providerPath)
+	if err != nil {
+		return "", err
+	}
+	var selectedAddon fs.DirEntry
+	var ok bool
+	if selectedAddon, ok = addonMap[addon]; !ok {
+		return "", errors.New("addon not found")
 	}
 
-	if len(userInputs) == 0 {
-		userInputs, err = prompts.RunPromptsFromConfig(&addOnConfig.DraftConfig)
-		if err != nil {
-			return nil, err
-		}
-		log.Debug("got user inputs")
+	selectedAddonPath := filepath.Join(providerPath, selectedAddon.Name())
+
+	return selectedAddonPath, nil
+}
+
+func GetAddonConfig(addons embed.FS, provider, addon string) (config.AddonConfig, error) {
+	selectedAddonPath, err := GetAddonPath(addons, provider, addon)
+	if err != nil {
+		return config.AddonConfig{}, err
 	}
+
+	configBytes, err := fs.ReadFile(addons, filepath.Join(selectedAddonPath, "draft.yaml"))
+	if err != nil {
+		return config.AddonConfig{}, err
+	}
+	var addOnConfig config.AddonConfig
+	if err = yaml.Unmarshal(configBytes, &addOnConfig); err != nil {
+		return config.AddonConfig{}, err
+	}
+
+	return addOnConfig, nil
+}
+
+func PromptAddon(addons embed.FS, provider string) (string, error) {
+	providerPath := filepath.Join(parentDirName, strings.ToLower(provider))
+	addonMap, err := embedutils.EmbedFStoMap(addons, providerPath)
+	if err != nil {
+		return "", err
+	}
+
+	addonNames := maps.Keys(addonMap)
+	prompt := promptui.Select{
+		Label: fmt.Sprintf("Select %s addon", provider),
+		Items: addonNames,
+	}
+	_, addon, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return addon, nil
+}
+
+func PromptAddonValues(dest string, userInputs map[string]string, addOnConfig config.AddonConfig) (map[string]string, error) {
+	log.Debugf("getAddonValues: %s", userInputs)
+	var err error
+
+	inputsToSkip := maps.Keys(userInputs)
+	log.Debugf("inputsToSkip: %s", inputsToSkip)
+	userInputs, err = prompts.RunPromptsFromConfigWithSkips(&addOnConfig.DraftConfig, inputsToSkip)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("got user inputs")
 
 	referenceMap, err := addOnConfig.GetReferenceValueMap(dest)
 	if err != nil {

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/manifoldco/promptui"
@@ -49,7 +49,7 @@ func GenerateAddon(addons embed.FS, provider, addon, dest string, userInputs map
 }
 
 func GetAddonPath(addons embed.FS, provider, addon string) (string, error) {
-	providerPath := filepath.Join(parentDirName, strings.ToLower(provider))
+	providerPath := path.Join(parentDirName, strings.ToLower(provider))
 	addonMap, err := embedutils.EmbedFStoMap(addons, providerPath)
 	if err != nil {
 		return "", err
@@ -60,7 +60,7 @@ func GetAddonPath(addons embed.FS, provider, addon string) (string, error) {
 		return "", errors.New("addon not found")
 	}
 
-	selectedAddonPath := filepath.Join(providerPath, selectedAddon.Name())
+	selectedAddonPath := path.Join(providerPath, selectedAddon.Name())
 
 	return selectedAddonPath, nil
 }
@@ -71,7 +71,7 @@ func GetAddonConfig(addons embed.FS, provider, addon string) (config.AddonConfig
 		return config.AddonConfig{}, err
 	}
 
-	configBytes, err := fs.ReadFile(addons, filepath.Join(selectedAddonPath, "draft.yaml"))
+	configBytes, err := fs.ReadFile(addons, path.Join(selectedAddonPath, "draft.yaml"))
 	if err != nil {
 		return config.AddonConfig{}, err
 	}
@@ -84,7 +84,7 @@ func GetAddonConfig(addons embed.FS, provider, addon string) (config.AddonConfig
 }
 
 func PromptAddon(addons embed.FS, provider string) (string, error) {
-	providerPath := filepath.Join(parentDirName, strings.ToLower(provider))
+	providerPath := path.Join(parentDirName, strings.ToLower(provider))
 	addonMap, err := embedutils.EmbedFStoMap(addons, providerPath)
 	if err != nil {
 		return "", err

--- a/pkg/config/addon_config.go
+++ b/pkg/config/addon_config.go
@@ -39,7 +39,9 @@ func (ac *AddonConfig) getDeployType(dest string) (string, error) {
 	if ac.deployType != "" {
 		return ac.deployType, nil
 	}
-	return filematches.FindDraftDeploymentFiles(dest)
+	deploymentType, err := filematches.FindDraftDeploymentFiles(dest)
+	log.Debugf("found deployment type: %s", deploymentType)
+	return deploymentType, err
 }
 
 func (ac *AddonConfig) GetAddonDestPath(dest string) (string, error) {

--- a/pkg/filematches/filematches.go
+++ b/pkg/filematches/filematches.go
@@ -107,7 +107,7 @@ func FindDraftDeploymentFiles(dest string) (deploymentType string, err error) {
 	if _, err := os.Stat(dest + "/charts"); !os.IsNotExist(err) {
 		return "helm", nil
 	}
-	if _, err := os.Stat(dest + "/base"); !os.IsNotExist(err) {
+	if _, err := os.Stat(dest + "/overlays"); !os.IsNotExist(err) {
 		return "kustomize", nil
 	}
 	if _, err := os.Stat(dest + "/manifests"); !os.IsNotExist(err) {

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -19,15 +19,31 @@ type TemplateSelect struct {
 }
 
 func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error) {
+	return RunPromptsFromConfigWithSkips(config, []string{})
+}
+
+func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []string) (map[string]string, error) {
 	templatePrompts := make([]*TemplatePrompt, 0)
 	templateSelects := make([]*TemplateSelect, 0)
+
+	skipMap := make(map[string]interface{})
+	for _, v := range varsToSkip {
+		skipMap[v] = interface{}(nil)
+	}
+
 	for _, customPrompt := range config.Variables {
+		if _, ok := skipMap[customPrompt.Name]; ok {
+			log.Debugf("Skipping prompt for %s", customPrompt.Name)
+			continue
+		}
+
 		log.Debugf("constructing prompt for: %s", customPrompt)
 		if customPrompt.VarType == "bool" {
 			prompt := &promptui.Select{
 				Label: "Please select " + customPrompt.Description,
 				Items: []bool{true, false},
 			}
+
 			templateSelects = append(templateSelects, &TemplateSelect{
 				Select:         prompt,
 				OverrideString: customPrompt.Name,
@@ -39,6 +55,7 @@ func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error)
 					defaultString = " (default: " + variableDefault.Value + ")"
 				}
 			}
+
 			prompt := &promptui.Prompt{
 				Label: "Please enter " + customPrompt.Description + defaultString,
 				Validate: func(s string) error {
@@ -52,6 +69,7 @@ func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error)
 					return nil
 				},
 			}
+
 			templatePrompts = append(templatePrompts, &TemplatePrompt{
 				Prompt:         prompt,
 				OverrideString: customPrompt.Name,

--- a/test/check_windows_addon_helm.ps1
+++ b/test/check_windows_addon_helm.ps1
@@ -1,0 +1,4 @@
+$filesExist=$true
+$filesExist=$filesExist -and (Test-Path -Path ./charts/templates/ingress.yaml -PathType Leaf)
+echo "$file exists: $filesExist"
+if (-not $filesExist) {Exit 1}

--- a/test/check_windows_addon_kustomize.ps1
+++ b/test/check_windows_addon_kustomize.ps1
@@ -1,0 +1,4 @@
+$filesExist=$true
+$filesExist=$filesExist -and (Test-Path -Path ./overlays/production/ingress.yaml -PathType Leaf)
+echo "$file exists: $filesExist"
+if (-not $filesExist) {Exit 1}

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -404,7 +404,7 @@ languageVariables:
 
     # create kustomize workflow
     echo "
-  $lang-kustomize:
+  $lang-kustomize-create:
     runs-on: windows-latest
     needs: build
     steps:
@@ -427,23 +427,21 @@ languageVariables:
           path: ./langtest/
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
-  $lang-ingress-kustomize:
+      - uses: actions/upload-artifact@v3
+        with:
+          name: $lang-kustomize-create
+          path: ./langtest
+  $lang-kustomize-update:
     needs: $lang-kustomize 
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
         with:
           name: draft-binary
-      - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          repository: $repo
+          name: $lang-kustomize-create
           path: ./langtest
-      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
-      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
-      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
-      - run: ./draft.exe -v create -c ./test/integration/$lang/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ $ingress_test_args
       - uses: actions/download-artifact@v2

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -305,7 +305,7 @@ languageVariables:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  $lang-ingress-manifests
+  $lang-ingress-manifests:
     runs-on: ubuntu-latest
     services:
       registry:

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -83,7 +83,7 @@ do
     serviceport=$(echo $test | jq '.serviceport' -r)
     repo=$(echo $test | jq '.repo' -r)
     # addon integration testing vars
-    ingress_test_args="--variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1"
+    ingress_test_args="-a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1"
     echo "Adding $lang with port $port"
 
     mkdir ./integration/$lang

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -305,7 +305,8 @@ languageVariables:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  $lang-ingress-manifests:
+  $lang-ingress-manifests
+    needs: $lang-manifests
     runs-on: ubuntu-latest
     services:
       registry:
@@ -372,8 +373,8 @@ languageVariables:
       - run: ./check_windows_helm.ps1
         working-directory: ./langtest/
   $lang-ingress-helm:
+    needs: $lang-helm 
     runs-on: windows-latest
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -419,8 +420,8 @@ languageVariables:
       - run: ./check_windows_kustomize.ps1
         working-directory: ./langtest/
   $lang-ingress-kustomize:
-    runs-on: windows-latest
     needs: $lang-kustomize 
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -359,7 +359,7 @@ languageVariables:
         working-directory: ./langtest/
   $lang-ingress-kustomize:
     runs-on: windows-latest
-    needs: $lang-customize 
+    needs: $lang-kustomize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -305,7 +305,7 @@ languageVariables:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-  $lang-ingress-manifests
+  $lang-ingress-manifests:
     needs: $lang-manifests
     runs-on: ubuntu-latest
     services:
@@ -313,7 +313,6 @@ languageVariables:
         image: registry:2
         ports:
           - 5000:5000
-    needs: build
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -432,7 +432,7 @@ languageVariables:
           name: $lang-kustomize-create
           path: ./langtest
   $lang-kustomize-update:
-    needs: $lang-kustomize 
+    needs: $lang-kustomize-create 
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -334,15 +334,11 @@ languageVariables:
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - run: ./draft -v update -d ./langtest/ $ingress_test_args
-      - uses: actions/download-artifact@v2
-        with:
-          name: $lang-manifests-create
-          path: ./langtest
       - uses: actions/download-artifact@v2
         with:
           name: $lang-manifests-create
           path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ $ingress_test_args
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -305,7 +305,7 @@ languageVariables:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-$lang-ingress-manifests
+  $lang-ingress-manifests
     runs-on: ubuntu-latest
     services:
       registry:

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -431,6 +431,10 @@ languageVariables:
         with:
           repository: $repo
           path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/$lang/kustomize.yaml -d ./langtest/
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ $ingress_test_args
       - uses: actions/download-artifact@v2

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -65,10 +65,19 @@ jobs:
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
+          name: check_windows_addon_helm
+          path: ./test/check_windows_addon_helm.ps1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
           name: check_windows_kustomize
           path: ./test/check_windows_kustomize.ps1
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: check_windows_addon_kustomize
+          path: ./test/check_windows_addon_kustomize.ps1
           if-no-files-found: error" > ../.github/workflows/integration-windows.yml
-
 
 
 # read config and add integration test for each language

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -83,10 +83,7 @@ do
     serviceport=$(echo $test | jq '.serviceport' -r)
     repo=$(echo $test | jq '.repo' -r)
     # addon integration testing vars
-    ingress_test_args="|
-      --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri |
-      --variable ingress-use-osm-mtls=true |
-      --variable ingress-host=host1"
+    ingress_test_args="--variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1"
     echo "Adding $lang with port $port"
 
     mkdir ./integration/$lang
@@ -362,7 +359,7 @@ languageVariables:
         working-directory: ./langtest/
   $lang-ingress-kustomize:
     runs-on: windows-latest
-    needs: $lange-customize 
+    needs: $lang-customize 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -338,6 +338,10 @@ languageVariables:
       - uses: actions/download-artifact@v2
         with:
           name: $lang-manifests-create
+          path: ./langtest
+      - uses: actions/download-artifact@v2
+        with:
+          name: $lang-manifests-create
           path: ./langtest/
       - name: start minikube
         id: minikube

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -156,7 +156,7 @@ languageVariables:
 
     # create helm workflow
     echo "
-  $lang-helm:
+  $lang-helm-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -178,6 +178,7 @@ languageVariables:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/$lang/helm.yaml -d ./langtest/
       - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ $ingress_test_args
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master
@@ -216,7 +217,7 @@ languageVariables:
 
     # create kustomize workflow
     echo "
-  $lang-kustomize:
+  $lang-kustomize-create-update:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -238,6 +239,7 @@ languageVariables:
       - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
       - run: ./draft -v create -c ./test/integration/$lang/kustomize.yaml -d ./langtest/
       - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ $ingress_test_args
       - name: start minikube
         id: minikube
         uses: medyagh/setup-minikube@master

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -92,7 +92,7 @@ do
     serviceport=$(echo $test | jq '.serviceport' -r)
     repo=$(echo $test | jq '.repo' -r)
     # addon integration testing vars
-    ingress_test_args="-a webapp_routing --variable ingress-tls-cert-keyvault-uri=test-cert-keyvault-uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1"
+    ingress_test_args="-a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1"
     echo "Adding $lang with port $port"
 
     mkdir ./integration/$lang

--- a/test/integration/rust/helm.yaml
+++ b/test/integration/rust/helm.yaml
@@ -10,7 +10,7 @@ deployVariables:
     value: "testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.58.0"
+    value: "1.59.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/kustomize.yaml
+++ b/test/integration/rust/kustomize.yaml
@@ -10,7 +10,7 @@ deployVariables:
     value: "testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.58.0"
+    value: "1.59.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/manifest.yaml
+++ b/test/integration/rust/manifest.yaml
@@ -10,7 +10,7 @@ deployVariables:
     value: "testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.58.0"
+    value: "1.59.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -1,10 +1,10 @@
 [
-  { 
-    "language": "gomodule", 
-    "version": "1.18", 
-    "port": "1323", 
-    "serviceport": 80, 
-    "repo": "gambtho/go_echo" 
+  {
+    "language": "gomodule",
+    "version": "1.18",
+    "port": "1323",
+    "serviceport": 80,
+    "repo": "gambtho/go_echo"
   },
   {
     "language": "python",
@@ -15,7 +15,7 @@
   },
   {
     "language": "rust",
-    "version": "1.58.0",
+    "version": "1.59.0",
     "port": "8000",
     "serviceport": 80,
     "repo": "OliverMKing/tiny-http-hello-world"


### PR DESCRIPTION
# Description
The following PR adds a `--variable` flag for the `draft update` command, which makes it possible to run the command non-interactively.
This makes adding integration tests possible for the command, which this PR also adds.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?
Integration tests have been added for the `update command`

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

Integration tests have been added for the `draft update` command for every existing integration scenario.
For linux helm and kustomize, the upgrade integration test was added to the existing integration test that is validated by confirming successful deployment to minikube.
For the the linux manifets deployment and all the windows deployments integration tests a new dependent job was added to run after the `draft create` integration test that re-uses artifacts and applies the `draft update` command yields files and executes without error.
Template contents verification for the update command isn't included at this time.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

