### PR TITLE
Enable draft installer

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Draft CLI installer
+#
+# ######                                 #####  #       ### 
+# #     # #####    ##   ###### #####    #     # #        #  
+# #     # #    #  #  #  #        #      #       #        #  
+# #     # #    # #    # #####    #      #       #        #  
+# #     # #####  ###### #        #      #       #        #  
+# #     # #   #  #    # #        #      #     # #        #  
+# ######  #    # #    # #        #       #####  ####### ###    
+#                                                               
+# usage: 
+#    curl -fsSL ./scripts/install.sh | sh
+set -e
+set -o pipefail
+set -f
+
+log() {
+    local level=$1
+    shift
+    echo "$(date -u $now) - $level - $*"
+}
+
+# dump uname immediately
+uname -ar
+
+log INFO "Information logged for Draft CLI."
+
+# Try to get os release vars
+# https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html
+# https://stackoverflow.com/questions/394230/how-to-detect-the-os-from-a-bash-script
+if [ -e /etc/os-release ]; then
+    . /etc/os-release
+    DISTRIB_ID=$ID
+else
+    if [ -e /etc/lsb-release ]; then
+        . /etc/lsb-release
+    fi
+fi
+
+if [ -z "${DISTRIB_ID}" ]; then
+    log INFO "Trying to identify using OSTYPE var $OSTYPE "
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        DISTRIB_ID="$OSTYPE"
+        B2KOS="linux"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        DISTRIB_ID="$OSTYPE"
+        B2KOS="osx"
+    elif [[ "$OSTYPE" == "cygwin" ]]; then
+        DISTRIB_ID="$OSTYPE"
+    elif [[ "$OSTYPE" == "msys" ]]; then
+       DISTRIB_ID="$OSTYPE"
+    elif [[ "$OSTYPE" == "win32" ]]; then
+        DISTRIB_ID="$OSTYPE"
+        B2KOS="win"
+    elif [[ "$OSTYPE" == "freebsd"* ]]; then
+        DISTRIB_ID="$OSTYPE"
+    else
+        log ERROR "Unknown DISTRIB_ID or DISTRIB_RELEASE."
+        exit 1
+    fi
+fi
+
+if [ -z "${DISTRIB_ID}" ]; then
+    log ERROR "Unknown DISTRIB_ID or DISTRIB_RELEASE."
+    exit 1
+fi
+
+log INFO "Distro Information as $DISTRIB_ID"
+
+# set distribution specific vars
+PACKAGER=
+SYSTEMD_PATH=/lib/systemd/system
+if [ "$DISTRIB_ID" == "ubuntu" ]; then
+    PACKAGER=apt
+elif [ "$DISTRIB_ID" == "debian" ]; then
+    PACKAGER=apt
+elif [[ $DISTRIB_ID == centos* ]] || [ "$DISTRIB_ID" == "rhel" ]; then
+    PACKAGER=yum
+elif [[ "$DISTRIB_ID" == "darwin"* ]]; then
+    PACKAGER=brew
+else
+    PACKAGER=zypper
+    SYSTEMD_PATH=/usr/lib/systemd/system
+fi
+if [ "$PACKAGER" == "apt" ]; then
+    export DEBIAN_FRONTEND=noninteractive
+fi
+
+# Check JQ Processor and download if not present
+check_jq_processor_present(){
+  log INFO "Checking locally installed JQ Processor version"
+  jqversion=$(jq --version)
+  log INFO "Locally installed JQ Processor version is $jqversion"
+  if [ -z "${jqversion}" ]; then
+    $PACKAGER install jq
+  fi
+}
+
+
+# Download draft cli stable version.
+download_draft_cli_stable_version(){
+  FILENAME="draft-$OS-$ARCH"
+  log INFO "Starting Draft CLI Download for $FILENAME"
+  DRAFTCLIVERSION=$(curl -L -s https://api.github.com/repos/Azure/draft/releases/latest | jq -r '.tag_name')
+  log INFO "Starting Draft CLI Version $DRAFTCLIVERSION"
+  DRAFTCLIURL="https://github.com/Azure/draft/releases/download/$DRAFTCLIVERSION/$FILENAME"
+  curl -o /tmp/draftcli -fLO $DRAFTCLIURL
+  chmod +x /tmp/draftcli
+  log INFO "Finished Draft CLI download complete."
+}
+
+file_issue_prompt() {
+  echo "If you wish us to support your platform, please file an issue"
+  echo "https://github.com/Azure/draft/issues/new/choose"
+  exit 1
+}
+
+copy_draft_files() {
+  if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+      if [ ! -d "$HOME/.local/bin" ]; then
+        mkdir -p "$HOME/.local/bin"
+      fi
+      mv /tmp/draftcli "$HOME/.local/bin/draftcli"
+  else
+      echo "installation target directory is write protected, run as root to override"
+      sudo mv /tmp/draftcli /usr/local/bin/draftcli
+  fi
+}
+
+install() {
+  ARCH=$(uname -m);
+  OS=
+  if [[ "$OSTYPE" == "linux"* ]]; then
+      OS="linux"
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+      OS="darwin"
+  elif [[ "$OSTYPE" == "win32" ]]; then
+      OS="win"
+  else
+      echo "Draft cli isn't supported for your platform - $OSTYPE"
+      file_issue_prompt
+      exit 1
+  fi
+
+  if [[ "$ARCH" != "x86_64" ]]; then
+       echo "Draft cli is only available for linux x86_64 architecture"
+       file_issue_prompt
+       exit 1
+  fi
+
+  if [[ "$ARCH" == "x86_64" ]]; then
+      ARCH="amd64"
+  fi
+
+  check_jq_processor_present
+  download_draft_cli_stable_version
+  copy_draft_files
+  echo "Draft CLI kubernetes installed."
+}
+
+install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,7 @@
 # ######  #    # #    # #        #       #####  ####### ###    
 #                                                               
 # usage: 
-#    curl -fsSL ./scripts/install.sh | sh
+#    curl -fsSL https://raw.githubusercontent.com/Tatsinnit/draft/feature/draft-installer/scripts/install.sh | sh
 set -e
 set -o pipefail
 set -f

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,7 +12,6 @@
 # usage: 
 #    curl -fsSL https://raw.githubusercontent.com/Tatsinnit/draft/feature/draft-installer/scripts/install.sh | sh
 set -e
-set -o pipefail
 set -f
 
 log() {
@@ -94,6 +93,11 @@ check_jq_processor_present(){
   log INFO "Locally installed JQ Processor version is $jqversion"
   if [ -z "${jqversion}" ]; then
     $PACKAGER install jq
+  fi
+  jqversion=$(jq --version)
+  if [ -z "${jqversion}" ]; then
+    echo "Your machine donot have JQ processor installed, plaese make sure JQ Processor is installed."
+    exit 1
   fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,7 +10,7 @@
 # ######  #    # #    # #        #       #####  ####### ###    
 #                                                               
 # usage: 
-#    curl -fsSL https://raw.githubusercontent.com/Tatsinnit/draft/feature/draft-installer/scripts/install.sh | sh
+#    curl -fsSL https://raw.githubusercontent.com/Azure/draft/scripts/install.sh | bash
 set -e
 set -f
 
@@ -88,6 +88,7 @@ fi
 
 # Check JQ Processor and download if not present
 check_jq_processor_present(){
+  set +e
   log INFO "Checking locally installed JQ Processor version"
   jqversion=$(jq --version)
   log INFO "Locally installed JQ Processor version is $jqversion"
@@ -95,8 +96,9 @@ check_jq_processor_present(){
     $PACKAGER install jq
   fi
   jqversion=$(jq --version)
+  set -e
   if [ -z "${jqversion}" ]; then
-    echo "Your machine donot have JQ processor installed, plaese make sure JQ Processor is installed."
+    echo "Your machine donot have JQ processor installed, plaese make sure JQ Processor is installed. \n please perform $PACKAGER update and retry running scripts"
     exit 1
   fi
 }


### PR DESCRIPTION
# Description

This PR enables the `DRAFT CLI Installer` which means user no longer need to go download the cli binary based on their operating system, that all can be taken care of by this.

This enhancement will also take care of https://github.com/Azure/draft/issues/143 which asks for `JQ processor installation`. 🎊🚀🥷

As we develop: this just need minor readme update. like cli location will be `usr/local/bin/...` and its easily callable. cc: @qpetraroia thanks. (Also for windows user Installation a note like various other tools that - `Windows isn't currently supported (you can use WSL)`)

Thank you so much all. ❤️☕️🚀 **cc**: @bfoley13, @hsubramanianaks , @davidgamero , @qpetraroia, @sabbour  **fyi**:  @gambtho 

**Simple usage will looks like:**

```*.sh
# usage: 
    curl -fsSL https://raw.githubusercontent.com/Tatsinnit/draft/feature/draft-installer/scripts/install.sh | sh
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] I have tested this on my Mac, ~will test in for wsl today~ Now tested on windows which should be sweet with ubuntu intern. (Screenshots below)


<img width="1516" alt="Screen Shot 2022-10-02 at 8 59 46 PM" src="https://user-images.githubusercontent.com/6233295/193478575-5cfd5ef0-b1c6-4804-ae3d-36be36b3849c.png">

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/6233295/193478648-10af8307-20e0-41ee-8135-8d4eb61d04a1.png)


![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/6233295/193478686-dd61d794-f063-4600-8f2c-9de327dab0cb.png)
