### PR TITLE
add referenceVar default support and namespace

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -357,12 +357,26 @@ func init() {
 
 func validateConfigInputsToPrompts(required []config.BuilderVar, provided []config.UserInputs, defaults []config.BuilderVarDefault) (map[string]string, error) {
 	customInputs := make(map[string]string)
-	for _, variableDefault := range defaults {
-		customInputs[variableDefault.Name] = variableDefault.Value
-	}
 
+	// set inputs to provided values
 	for _, variable := range provided {
 		customInputs[variable.Name] = variable.Value
+	}
+
+	// fill in missing vars using variable default references
+	for _, variableDefault := range defaults {
+		if customInputs[variableDefault.Name] == "" && variableDefault.ReferenceVar != "" {
+			log.Debugf("variable %s is empty, using default referenceVar value from %s", variableDefault.Name, variableDefault.ReferenceVar)
+			customInputs[variableDefault.Name] = customInputs[variableDefault.ReferenceVar]
+		}
+	}
+
+	// fill in missing vars using variable default values
+	for _, variableDefault := range defaults {
+		if customInputs[variableDefault.Name] == "" && variableDefault.Value != "" {
+			log.Debugf("setting default value for %s to %s", variableDefault.Name, variableDefault.Value)
+			customInputs[variableDefault.Name] = variableDefault.Value
+		}
 	}
 
 	for _, variable := range required {

--- a/pkg/config/draftconfig.go
+++ b/pkg/config/draftconfig.go
@@ -25,8 +25,9 @@ type BuilderVar struct {
 }
 
 type BuilderVarDefault struct {
-	Name  string `yaml:"name"`
-	Value string `yaml:"value"`
+	Name         string `yaml:"name"`
+	Value        string `yaml:"value"`
+	ReferenceVar string `yaml:"referenceVar"`
 }
 
 func (d *DraftConfig) initNameOverrideMap() {

--- a/template/deployments/helm/charts/templates/deployment.yaml
+++ b/template/deployments/helm/charts/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "{{APPNAME}}.selectorLabels" . | nindent 8 }}
+      namespace: {{ .Values.namespace }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/template/deployments/helm/charts/templates/namespace.yaml
+++ b/template/deployments/helm/charts/templates/namespace.yaml
@@ -1,7 +1,7 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: default
+  name: {{ .Values.namespace }}
   labels:
     {{- include "{{APPNAME}}.labels" . | nindent 4 }}
     openservicemesh.io/monitored-by: osm

--- a/template/deployments/helm/charts/templates/service.yaml
+++ b/template/deployments/helm/charts/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "{{APPNAME}}.labels" . | nindent 4 }}
   annotations:
     {{ toYaml .Values.service.annotations | nindent 4 }}
+  namespace: {{ .Values.namespace }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/template/deployments/helm/charts/values.yaml
+++ b/template/deployments/helm/charts/values.yaml
@@ -4,7 +4,7 @@
 
 replicaCount: 1
 
-namespace: {{namespace}}
+namespace: {{NAMESPACE}}
 
 containerPort: {{PORT}}
 

--- a/template/deployments/helm/charts/values.yaml
+++ b/template/deployments/helm/charts/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+namespace: {{namespace}}
+
 containerPort: {{PORT}}
 
 imageKey:

--- a/template/deployments/helm/draft.yaml
+++ b/template/deployments/helm/draft.yaml
@@ -5,8 +5,12 @@ variables:
     description: "the name of the application"
   - name: "SERVICEPORT"
     description: "the port the service uses to make the application accessible from outside the cluster"
+  - name: "NAMESPACE"
+    description: " the namespace to place new resources in"
 variableDefaults:
   - name: "PORT"
     value: 80
   - name: "SERVICEPORT"
-    value: 80
+    referenceVar: "PORT"
+  - name: "NAMESPACE"
+    referenceVar: "APPNAME"

--- a/template/deployments/helm/draft.yaml
+++ b/template/deployments/helm/draft.yaml
@@ -13,4 +13,4 @@ variableDefaults:
   - name: "SERVICEPORT"
     referenceVar: "PORT"
   - name: "NAMESPACE"
-    referenceVar: "APPNAME"
+    value: default

--- a/template/deployments/kustomize/base/deployment.yaml
+++ b/template/deployments/kustomize/base/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{APPNAME}}
   labels:
     app: {{APPNAME}}
+  namespace: {{NAMESPACE}}
 spec:
   replicas: 1
   selector:

--- a/template/deployments/kustomize/base/namespace.yaml
+++ b/template/deployments/kustomize/base/namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: {{NAMESPACE}}

--- a/template/deployments/kustomize/base/service.yaml
+++ b/template/deployments/kustomize/base/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{APPNAME}}
+  namespace: {{NAMESPACE}}
 spec:
   type: LoadBalancer
   selector:

--- a/template/deployments/kustomize/draft.yaml
+++ b/template/deployments/kustomize/draft.yaml
@@ -13,4 +13,4 @@ variableDefaults:
   - name: "SERVICEPORT"
     referenceVar: "PORT"
   - name: "NAMESPACE"
-    referenceVar: "APPNAME"
+    value: default

--- a/template/deployments/kustomize/draft.yaml
+++ b/template/deployments/kustomize/draft.yaml
@@ -1,12 +1,16 @@
 variables:
   - name: "PORT"
-    description: "the container port exposed in the application"
+    description: "the port exposed in the application"
   - name: "APPNAME"
     description: "the name of the application"
   - name: "SERVICEPORT"
-    description: "the port used by the service to make the application accessible outside the cluster"
+    description: "the port the service uses to make the application accessible from outside the cluster"
+  - name: "NAMESPACE"
+    description: " the namespace to place new resources in"
 variableDefaults:
   - name: "PORT"
     value: 80
   - name: "SERVICEPORT"
-    value: 80
+    referenceVar: "PORT"
+  - name: "NAMESPACE"
+    referenceVar: "APPNAME"

--- a/template/deployments/kustomize/overlays/production/deployment.yaml
+++ b/template/deployments/kustomize/overlays/production/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{APPNAME}}
   labels:
     app: {{APPNAME}}
+  namespace: {{NAMESPACE}}
 spec:
   selector:
     matchLabels:

--- a/template/deployments/kustomize/overlays/production/kustomization.yaml
+++ b/template/deployments/kustomize/overlays/production/kustomization.yaml
@@ -1,4 +1,5 @@
 namePrefix: production-
+namespace: {{NAMESPACE}}
 resources:
   - ../../base
 patchesStrategicMerge:

--- a/template/deployments/kustomize/overlays/production/service.yaml
+++ b/template/deployments/kustomize/overlays/production/service.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{APPNAME}}
+  namespace: {{NAMESPACE}}
 spec:
   type: LoadBalancer

--- a/template/deployments/manifests/draft.yaml
+++ b/template/deployments/manifests/draft.yaml
@@ -5,8 +5,12 @@ variables:
     description: "the name of the application"
   - name: "SERVICEPORT"
     description: "the port the service uses to make the application accessible from outside the cluster"
+  - name: "NAMESPACE"
+    description: " the namespace to place new resources in"
 variableDefaults:
   - name: "PORT"
     value: 80
   - name: "SERVICEPORT"
-    value: 80
+    referenceVar: "PORT"
+  - name: "NAMESPACE"
+    referenceVar: "APPNAME"

--- a/template/deployments/manifests/draft.yaml
+++ b/template/deployments/manifests/draft.yaml
@@ -13,4 +13,4 @@ variableDefaults:
   - name: "SERVICEPORT"
     referenceVar: "PORT"
   - name: "NAMESPACE"
-    referenceVar: "APPNAME"
+    value: "default"

--- a/template/deployments/manifests/manifests/deployment.yaml
+++ b/template/deployments/manifests/manifests/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{APPNAME}}
   labels:
     app: {{APPNAME}}
+  namespace: {{NAMESPACE}}
 spec:
   replicas: 1
   selector:

--- a/template/deployments/manifests/manifests/service.yaml
+++ b/template/deployments/manifests/manifests/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{APPNAME}}
+  namespace: {{NAMESPACE}}
 spec:
   type: LoadBalancer
   selector:


### PR DESCRIPTION
# Description

add builderVarDefault support for a referenceVar field that allows the default for a prompt to be a previously supplied value from a previous prompt in the same series of prompts.

add namespace support across the deployment templates instead of just using the APPNAME or the default namespace every time

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [x] Linux Integration Tests
- [x] Windows Integration Tests


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

