### PR TITLE
Auto run changelog release

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -34,9 +34,6 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.18.2
-    # Build Binaries
-    - name: Build Draft Release Binaries
-      run: make build-all
     # Check if the newest tag already exists
     - uses: mukunku/tag-exists-action@v1.0.0
       id: check-tag-exists
@@ -44,6 +41,10 @@ jobs:
         tag:  "v${{ steps.changelog_reader.outputs.version }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Build Binaries if this is a new release
+    - name: Build Draft Release Binaries
+      run: make build-all
+      if: ${{ steps.check-tag-exists.outputs.exists == 'false' }}
     # If the tag already exists, we don't upload release artifacts
     - name: Update Draft Release Body
       if: ${{ steps.check-tag-exists.outputs.exists == 'true' }}

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -1,5 +1,10 @@
 name: Draft Release & Publish
-on: [workflow_dispatch]
+on: 
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'CHANGELOG.md'
 
 jobs:
   Release-Artifacts:
@@ -32,8 +37,26 @@ jobs:
     # Build Binaries
     - name: Build Draft Release Binaries
       run: make build-all
-    # Create Release
+    # Check if the newest tag already exists
+    - uses: mukunku/tag-exists-action@v1.0.0
+      id: check-tag-exists
+      with: 
+        tag:  "v${{ steps.changelog_reader.outputs.version }}"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # If the tag already exists, we don't upload release artifacts
+    - name: Update Draft Release Body
+      if: ${{ steps.check-tag-exists.outputs.exists == 'true' }}
+      uses: softprops/action-gh-release@v1
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+      with:
+        tag_name : "v${{ steps.changelog_reader.outputs.version }}"
+        name: "v${{ steps.changelog_reader.outputs.version }}"
+        body: ${{ steps.changelog_reader.outputs.changes }}
+    # Create Release with artifacts
     - name: Create Draft Release
+      if: ${{ steps.check-tag-exists.outputs.exists == 'false'}}
       uses: softprops/action-gh-release@v1
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
# Description

- Automatically run the release and publish workflow using the `path` field on the `push` trigger for the workflow
- Also allows the most recent release description to be updated by simply updating the CHANGELOG.md without re-releasing binaries
- More closely follow the CHANGELOG is the single source of truth

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [x] the workflow was executed on my fork to verify that the the workflow only executes when the CHANGELOG file is edited via pull request
- [x] when the changelog is updated, but no new release was added, the body of the newest release is updated to match the changelog, without re-uploading artifact files 
https://github.com/davidgamero/draft/actions/runs/3244275984/jobs/5320229671

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

