### PR TITLE
Set imagePullPolicy to Always

### DIFF
--- a/template/deployments/helm/charts/values.yaml
+++ b/template/deployments/helm/charts/values.yaml
@@ -10,7 +10,7 @@ containerPort: {{PORT}}
 
 imageKey:
   repository: {{IMAGENAME}}
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 
 imagePullSecrets: []

--- a/template/deployments/kustomize/base/deployment.yaml
+++ b/template/deployments/kustomize/base/deployment.yaml
@@ -18,5 +18,6 @@ spec:
       containers:
         - name: {{APPNAME}}
           image: {{IMAGENAME}}
+          imagePullPolicy: Always
           ports:
             - containerPort: {{PORT}}

--- a/template/deployments/manifests/manifests/deployment.yaml
+++ b/template/deployments/manifests/manifests/deployment.yaml
@@ -18,5 +18,6 @@ spec:
       containers:
         - name: {{APPNAME}}
           image: {{IMAGENAME}}
+          imagePullPolicy: Always
           ports:
             - containerPort: {{PORT}}


### PR DESCRIPTION
# Description

Setting the imagePullPolicy in deployment.yaml to Always to ensure that the latest container images are pulled from the registry on pod creation.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

While it might not impact existing tools, the behavior changes the generated files.

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

