### PR TITLE
bump tag-exists-action version

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         go-version: 1.18.2
     # Check if the newest tag already exists
-    - uses: mukunku/tag-exists-action@v1.0.0
+    - uses: mukunku/tag-exists-action@v1.1.0
       id: check-tag-exists
       with: 
         tag:  "v${{ steps.changelog_reader.outputs.version }}"


### PR DESCRIPTION
# Description

This change bumps the tag-exists-action version to v1.1.0 which should get rid of deprecation warnings such as:
![image](https://user-images.githubusercontent.com/4502154/198739281-eaa6b046-17c1-4a15-8f55-7d6f741ea637.png)


