### PR TITLE
replace hard coded path joins with path.join

### DIFF
--- a/pkg/deployments/deployments.go
+++ b/pkg/deployments/deployments.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"path"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
@@ -39,7 +40,7 @@ func (d *Deployments) CopyDeploymentFiles(deployType string, customInputs map[st
 		return fmt.Errorf("deployment type: %s is not currently supported", deployType)
 	}
 
-	srcDir := parentDirName + "/" + val.Name()
+	srcDir := path.Join(parentDirName, val.Name())
 
 	deployConfig, ok := d.configs[deployType]
 	if !ok {
@@ -59,7 +60,7 @@ func (d *Deployments) loadConfig(lang string) (*config.DraftConfig, error) {
 		return nil, fmt.Errorf("language %s unsupported", lang)
 	}
 
-	configPath := fmt.Sprintf("%s/%s/%s", parentDirName, val.Name(), configFileName)
+	configPath := path.Join(parentDirName, val.Name(), configFileName)
 	configBytes, err := fs.ReadFile(d.deploymentTemplates, configPath)
 	if err != nil {
 		return nil, err

--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"path"
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
@@ -43,7 +44,7 @@ func (l *Languages) CreateDockerfileForLanguage(lang string, customInputs map[st
 		return fmt.Errorf("language %s is not supported", lang)
 	}
 
-	srcDir := parentDirName + "/" + val.Name()
+	srcDir := path.Join(parentDirName, val.Name())
 
 	draftConfig, ok := l.configs[lang]
 	if !ok {
@@ -63,7 +64,7 @@ func (l *Languages) loadConfig(lang string) (*config.DraftConfig, error) {
 		return nil, fmt.Errorf("language %s unsupported", lang)
 	}
 
-	configPath := parentDirName + "/" + val.Name() + "/draft.yaml"
+	configPath := path.Join(parentDirName, val.Name(), "/draft.yaml")
 	configBytes, err := fs.ReadFile(l.dockerfileTemplates, configPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

a couple sections of the deployment and dockerfile generation use hard-coded strings to create paths with string formatting, with causes issues with the root directory as a target.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [X] Generating outputs for the root directory yields urls with a double slash, which is invalid.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

