### PR TITLE
release for draft info and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
 # Change Log
+All notable changes to this project will be documented in this file.
 
-## For help: please refer: ./docs/maintenance/README.md (Please delete this line)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.26] - 2022-11-16
+
+### Added
+
+- The new `draft info` command from #157 prints supported language and field information in json format.
+- An integration test was added for the installation shell script to better ensure that the script works as expected.
+
+### Fixed
+
+- File path output for root locations had a bug with string-formatted paths. The `path.Join` method has been substituted to fix this.
+
+### Changed
+
+- Remaining uses of the `viper` library have been migrated to `gopkg.in/yaml.v3` for consistency.
+- Unused files in the `web` package have been removed.
+- Minor reorganization across the `config` and `addons` packages to reduce the number of exported functions and types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,4 @@
 # Change Log
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.0.26] - 2022-11-16
 


### PR DESCRIPTION
# Description

### Added

- The new `draft info` command from #157 prints supported language and field information in json format.
- An integration test was added for the installation shell script to better ensure that the script works as expected.

### Fixed

- File path output for root locations had a bug with string-formatted paths. The `path.Join` method has been substituted to fix this.

### Changed

- Remaining uses of the `viper` library have been migrated to `gopkg.in/yaml.v3` for consistency.
- Unused files in the `web` package have been removed.
- Minor reorganization across the `config` and `addons` packages to reduce the number of exported functions and types.

## Type of change

Release

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

