### PR TITLE
Fix badge for release.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   [![Go Report Card](https://goreportcard.com/badge/github.com/Azure/draft)](https://goreportcard.com/report/github.com/Azure/draft)
   [![CodeQL](https://github.com/Azure/draft/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Azure/draft/actions/workflows/codeql-analysis.yml)
   [![Draft Linux Integrations](https://github.com/Azure/draft/actions/workflows/integration-linux.yml/badge.svg)](https://github.com/Azure/draft/actions/workflows/integration-linux.yml)
-  [![Draft Releases](https://github.com/Azure/draft/actions/workflows/releases.yml/badge.svg)](https://github.com/Azure/draft/actions/workflows/releases.yml)
+  [![Draft Release & Publish](https://github.com/Azure/draft/actions/workflows/release-and-publish.yml/badge.svg)](https://github.com/Azure/draft/actions/workflows/release-and-publish.yml)
   </p>
 </div>
 


### PR DESCRIPTION
# Description

This PR fixes the Readme Badge for this tool. Currently in main it is appearing as missing image because the workflow was old and removed.

I noticed this while helping for a release. Thanks. ☕️❤️🙏 

Please refer to the screenshot below and compare with current `main` version:

<img width="1019" alt="Screenshot 2022-11-17 at 7 23 07 PM" src="https://user-images.githubusercontent.com/6233295/202372012-187ecac6-bcc6-4fd8-aa3b-f41e93304d65.png">


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

