### PR TITLE
add win 386 arch  to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,15 @@ build:
 	GO111MODULE=on go build -v -o .
 
 .PHONY: build-all
-build-all: go-generate vendor build-windows-amd64 build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64
+build-all: go-generate vendor build-windows-amd64 build-windows-386 build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64
 
 .PHONY: build-windows-amd64
 build-windows-amd64:
 	GOOS=windows GOARCH=amd64 go build -ldflags "-X github.com/Azure/draft/cmd.VERSION=${DRAFT_VERSION}" -v -o ./bin/draft-windows-amd64.exe
+
+.PHONY: build-windows-386
+build-windows-386:
+	GOOS=windows GOARCH=386 go build -ldflags "-X github.com/Azure/draft/cmd.VERSION=${DRAFT_VERSION}" -v -o ./bin/draft-windows-386.exe
 
 .PHONY: build-linux-amd64
 build-linux-amd64:


### PR DESCRIPTION
# Description
Draft doesn't currently build for win32, which we needed in a github action runner test, so let's add it as a build target

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [x] Existing unit tests pass


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

