### PR TITLE
Fix variable defaulting resolution bug/ remove deprecated overridestring/ enhance testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ langtest
 .vscode/
 /pkg/languages/builders
 test/temp/
+bin/

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -3,9 +3,10 @@ package prompts
 import (
 	"fmt"
 
-	"github.com/Azure/draft/pkg/config"
 	"github.com/manifoldco/promptui"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/Azure/draft/pkg/config"
 )
 
 type TemplatePrompt struct {
@@ -56,9 +57,10 @@ func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []stri
 			inputs[newSelect.OverrideString] = input
 		} else {
 			defaultString := ""
+			defaultValue := ""
 			for _, variableDefault := range config.VariableDefaults {
 				if variableDefault.Name == customPrompt.Name {
-					defaultValue := variableDefault.Value
+					defaultValue = variableDefault.Value
 					if variableDefault.ReferenceVar != "" {
 						defaultValue = inputs[variableDefault.ReferenceVar]
 						log.Debugf("setting default value for %s to %s from referenceVar %s", customPrompt.Name, defaultValue, variableDefault.ReferenceVar)
@@ -89,6 +91,10 @@ func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []stri
 			input, err := newPrompt.Prompt.Run()
 			if err != nil {
 				return nil, err
+			}
+			// Variable-level substitution, we need to get defaults so later references can be resolved in this loop
+			if input == "" && defaultString != "" {
+				input = defaultValue
 			}
 			inputs[newPrompt.OverrideString] = input
 		}

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -68,7 +68,7 @@ func GetVariableDefaultValue(variableName string, variableDefaults []config.Buil
 		if variableDefault.Name == variableName {
 			defaultValue = variableDefault.Value
 			log.Debugf("setting default value for %s to %s from variable default rule", variableName, defaultValue)
-			if variableDefault.ReferenceVar != "" {
+			if variableDefault.ReferenceVar != "" && inputs[variableDefault.ReferenceVar] != "" {
 				defaultValue = inputs[variableDefault.ReferenceVar]
 				log.Debugf("setting default value for %s to %s from referenceVar %s", variableName, defaultValue, variableDefault.ReferenceVar)
 			}

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -2,6 +2,7 @@ package prompts
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/manifoldco/promptui"
 	log "github.com/sirupsen/logrus"
@@ -9,21 +10,15 @@ import (
 	"github.com/Azure/draft/pkg/config"
 )
 
-type TemplatePrompt struct {
-	Prompt         *promptui.Prompt
-	OverrideString string
-}
-
-type TemplateSelect struct {
-	Select         *promptui.Select
-	OverrideString string
-}
-
 func RunPromptsFromConfig(config *config.DraftConfig) (map[string]string, error) {
 	return RunPromptsFromConfigWithSkips(config, []string{})
 }
 
 func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []string) (map[string]string, error) {
+	return RunPromptsFromConfigWithSkipsIO(config, varsToSkip, nil, nil)
+}
+
+func RunPromptsFromConfigWithSkipsIO(config *config.DraftConfig, varsToSkip []string, Stdin io.ReadCloser, Stdout io.WriteCloser) (map[string]string, error) {
 	skipMap := make(map[string]interface{})
 	for _, v := range varsToSkip {
 		skipMap[v] = interface{}(nil)
@@ -32,6 +27,7 @@ func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []stri
 	inputs := make(map[string]string)
 
 	for _, customPrompt := range config.Variables {
+		promptVariableName := customPrompt.Name
 		if _, ok := skipMap[customPrompt.Name]; ok {
 			log.Debugf("Skipping prompt for %s", customPrompt.Name)
 			continue
@@ -39,64 +35,19 @@ func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []stri
 
 		log.Debugf("constructing prompt for: %s", customPrompt)
 		if customPrompt.VarType == "bool" {
-			prompt := &promptui.Select{
-				Label: "Please select " + customPrompt.Description,
-				Items: []bool{true, false},
-			}
-
-			// TODO: we probably don't need this struct anymore since we are getting rid of override strings
-			newSelect := &TemplateSelect{
-				Select:         prompt,
-				OverrideString: customPrompt.Name,
-			}
-
-			_, input, err := newSelect.Select.Run()
+			input, err := RunBoolPrompt(customPrompt, Stdin, Stdout)
 			if err != nil {
 				return nil, err
 			}
-			inputs[newSelect.OverrideString] = input
+			inputs[promptVariableName] = input
 		} else {
-			defaultString := ""
-			defaultValue := ""
-			for _, variableDefault := range config.VariableDefaults {
-				if variableDefault.Name == customPrompt.Name {
-					defaultValue = variableDefault.Value
-					if variableDefault.ReferenceVar != "" {
-						defaultValue = inputs[variableDefault.ReferenceVar]
-						log.Debugf("setting default value for %s to %s from referenceVar %s", customPrompt.Name, defaultValue, variableDefault.ReferenceVar)
-					}
-					defaultString = " (default: " + defaultValue + ")"
-				}
-			}
+			defaultValue := GetVariableDefaultValue(promptVariableName, config.VariableDefaults, inputs)
 
-			prompt := &promptui.Prompt{
-				Label: "Please enter " + customPrompt.Description + defaultString,
-				Validate: func(s string) error {
-					// Allow blank input for variables with defaults
-					if defaultString != "" {
-						return nil
-					}
-					if len(s) <= 0 {
-						return fmt.Errorf("input must be greater than 0")
-					}
-					return nil
-				},
-			}
-
-			// TODO: we probably don't need this struct anymore since we are getting rid of override strings
-			newPrompt := &TemplatePrompt{
-				Prompt:         prompt,
-				OverrideString: customPrompt.Name,
-			}
-			input, err := newPrompt.Prompt.Run()
+			stringInput, err := RunStringPrompt(customPrompt, defaultValue, Stdin, Stdout)
 			if err != nil {
 				return nil, err
 			}
-			// Variable-level substitution, we need to get defaults so later references can be resolved in this loop
-			if input == "" && defaultString != "" {
-				input = defaultValue
-			}
-			inputs[newPrompt.OverrideString] = input
+			inputs[promptVariableName] = stringInput
 		}
 	}
 
@@ -108,6 +59,71 @@ func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []stri
 	}
 
 	return inputs, nil
+}
+
+// GetVariableDefaultValue returns the default value for a variable, if one is set in variableDefaults from a ReferenceVar or literal VariableDefault.Value in that order.
+func GetVariableDefaultValue(variableName string, variableDefaults []config.BuilderVarDefault, inputs map[string]string) string {
+	defaultValue := ""
+	for _, variableDefault := range variableDefaults {
+		if variableDefault.Name == variableName {
+			defaultValue = variableDefault.Value
+			log.Debugf("setting default value for %s to %s from variable default rule", variableName, defaultValue)
+			if variableDefault.ReferenceVar != "" {
+				defaultValue = inputs[variableDefault.ReferenceVar]
+				log.Debugf("setting default value for %s to %s from referenceVar %s", variableName, defaultValue, variableDefault.ReferenceVar)
+			}
+		}
+	}
+	return defaultValue
+}
+
+func RunBoolPrompt(customPrompt config.BuilderVar, Stdin io.ReadCloser, Stdout io.WriteCloser) (string, error) {
+	newSelect := &promptui.Select{
+		Label:  "Please select " + customPrompt.Description,
+		Items:  []bool{true, false},
+		Stdin:  Stdin,
+		Stdout: Stdout,
+	}
+
+	_, input, err := newSelect.Run()
+	if err != nil {
+		return "", err
+	}
+	return input, nil
+}
+
+// RunStringPrompt runs a prompt for a string variable, returning the user string input for the prompt
+func RunStringPrompt(customPrompt config.BuilderVar, defaultValue string, Stdin io.ReadCloser, Stdout io.WriteCloser) (string, error) {
+	defaultString := ""
+	if defaultValue != "" {
+		defaultString = " (default: " + defaultValue + ")"
+	}
+
+	prompt := &promptui.Prompt{
+		Label: "Please enter " + customPrompt.Description + defaultString,
+		Validate: func(s string) error {
+			// Allow blank input for variables with defaults
+			if defaultString != "" {
+				return nil
+			}
+			if len(s) <= 0 {
+				return fmt.Errorf("input must be greater than 0")
+			}
+			return nil
+		},
+		Stdin:  Stdin,
+		Stdout: Stdout,
+	}
+
+	input, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+	// Variable-level substitution, we need to get defaults so later references can be resolved in this loop
+	if input == "" && defaultString != "" {
+		input = defaultValue
+	}
+	return input, nil
 }
 
 func GetInputFromPrompt(desiredInput string) string {

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -28,8 +28,8 @@ func RunPromptsFromConfigWithSkipsIO(config *config.DraftConfig, varsToSkip []st
 
 	for _, customPrompt := range config.Variables {
 		promptVariableName := customPrompt.Name
-		if _, ok := skipMap[customPrompt.Name]; ok {
-			log.Debugf("Skipping prompt for %s", customPrompt.Name)
+		if _, ok := skipMap[promptVariableName]; ok {
+			log.Debugf("Skipping prompt for %s", promptVariableName)
 			continue
 		}
 

--- a/pkg/prompts/prompts_test.go
+++ b/pkg/prompts/prompts_test.go
@@ -126,14 +126,14 @@ func TestRunStringPrompt(t *testing.T) {
 					t.Errorf("Error closing inWriter: %v", err)
 				}
 			}()
-			got, err := RunStringPrompt(tt.prompt, tt.defaultValue, inReader, nil)
+			got, err := RunDefaultableStringPrompt(tt.prompt, tt.defaultValue, nil, inReader, nil)
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("RunStringPrompt() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("RunDefaultableStringPrompt() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("RunStringPrompt() = %v, want %v", got, tt.want)
+				t.Errorf("RunDefaultableStringPrompt() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/prompts/prompts_test.go
+++ b/pkg/prompts/prompts_test.go
@@ -1,0 +1,63 @@
+package prompts
+
+import (
+	"testing"
+
+	"github.com/Azure/draft/pkg/config"
+)
+
+func TestGetVariableDefaultValue(t *testing.T) {
+	tests := []struct {
+		testName         string
+		variableName     string
+		variableDefaults []config.BuilderVarDefault
+		inputs           map[string]string
+		want             string
+	}{
+		{
+			testName:     "basicLiteralExtractDefault",
+			variableName: "var1",
+			variableDefaults: []config.BuilderVarDefault{
+				{
+					Name:  "var1",
+					Value: "default-value-1",
+				},
+				{
+					Name:  "var2",
+					Value: "default-value-2",
+				},
+			},
+			inputs: map[string]string{},
+			want:   "default-value-1",
+		},
+		{
+			testName:         "noDefaultIsEmptyString",
+			variableName:     "var1",
+			variableDefaults: []config.BuilderVarDefault{},
+			inputs:           map[string]string{},
+			want:             "",
+		},
+		{
+			testName:     "referenceTakesPrecedenceOverLiteral",
+			variableName: "var1",
+			variableDefaults: []config.BuilderVarDefault{
+				{
+					Name:         "var1",
+					Value:        "not-this-value",
+					ReferenceVar: "var2",
+				},
+			},
+			inputs: map[string]string{
+				"var2": "this-value",
+			},
+			want: "this-value",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if got := GetVariableDefaultValue(tt.variableName, tt.variableDefaults, tt.inputs); got != tt.want {
+				t.Errorf("GetVariableDefaultValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/prompts/prompts_test.go
+++ b/pkg/prompts/prompts_test.go
@@ -52,6 +52,21 @@ func TestGetVariableDefaultValue(t *testing.T) {
 				"var2": "this-value",
 			},
 			want: "this-value",
+		}, {
+			testName:     "forwardReferencesAreIgnored",
+			variableName: "beforeVar",
+			variableDefaults: []config.BuilderVarDefault{
+				{
+					Name:         "beforeVar",
+					Value:        "before-default-value",
+					ReferenceVar: "afterVar",
+				}, {
+					Name:  "afterVar",
+					Value: "not-this-value",
+				},
+			},
+			inputs: map[string]string{},
+			want:   "before-default-value",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/prompts/prompts_test.go
+++ b/pkg/prompts/prompts_test.go
@@ -1,6 +1,7 @@
 package prompts
 
 import (
+	"io"
 	"testing"
 
 	"github.com/Azure/draft/pkg/config"
@@ -57,6 +58,67 @@ func TestGetVariableDefaultValue(t *testing.T) {
 		t.Run(tt.testName, func(t *testing.T) {
 			if got := GetVariableDefaultValue(tt.variableName, tt.variableDefaults, tt.inputs); got != tt.want {
 				t.Errorf("GetVariableDefaultValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunStringPrompt(t *testing.T) {
+	tests := []struct {
+		testName     string
+		prompt       config.BuilderVar
+		userInputs   []string
+		defaultValue string
+		want         string
+		wantErr      bool
+	}{
+		{
+			testName: "basicPrompt",
+			prompt: config.BuilderVar{
+				Name:        "var1",
+				Description: "var1 description",
+			},
+			userInputs:   []string{"value-1\n"},
+			defaultValue: "input",
+			want:         "value-1",
+			wantErr:      false,
+		},
+		{
+			testName: "promptWithDefault",
+			prompt: config.BuilderVar{
+				Name:        "var1",
+				Description: "var1 description",
+			},
+			userInputs:   []string{"\n"},
+			defaultValue: "defaultValue",
+			want:         "defaultValue",
+			wantErr:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			inReader, inWriter := io.Pipe()
+
+			go func() {
+				for _, input := range tt.userInputs {
+					_, err := inWriter.Write([]byte(input))
+					if err != nil {
+						t.Errorf("Error writing to inWriter: %v", err)
+					}
+				}
+				err := inWriter.Close()
+				if err != nil {
+					t.Errorf("Error closing inWriter: %v", err)
+				}
+			}()
+			got, err := RunStringPrompt(tt.prompt, tt.defaultValue, inReader, nil)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RunStringPrompt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("RunStringPrompt() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Description

Fixes a current bug where variable defaults are not resolved properly for references

Added unit tests for prompting logic and default resolution to avoid this issue in the future

Refactor prompt package to allow better testing by adding parameters for Stdin and Stdout with defaults on nil to follow `promptui` library convention

Remove deprecated overridestring structs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x]  Existing tests pass
- [x] Added unit tests for string prompting
- [x]  Added unit tests for variable defaulting resolution

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

