### PR TITLE
error on unsubstituted vars

### DIFF
--- a/pkg/addons/addons_test.go
+++ b/pkg/addons/addons_test.go
@@ -35,6 +35,9 @@ func TestGenerateHelmAddonSuccess(t *testing.T) {
 		"ingress-tls-cert-keyvault-uri": "test.uri",
 		"ingress-use-osm-mtls":          "false",
 		"ingress-host":                  "host",
+		"service-namespace":             "test-namespace",
+		"service-name":                  "test-service",
+		"service-port":                  "80",
 	}
 	dir, remove, err := setUpTempDir("helm")
 	assert.Nil(t, err)
@@ -51,6 +54,9 @@ func TestGenerateKustomizeAddonSuccess(t *testing.T) {
 		"ingress-tls-cert-keyvault-uri": "test.uri",
 		"ingress-use-osm-mtls":          "false",
 		"ingress-host":                  "host",
+		"service-namespace":             "test-namespace",
+		"service-name":                  "test-service",
+		"service-port":                  "80",
 	}
 	dir, remove, err := setUpTempDir("kustomize")
 	assert.Nil(t, err)

--- a/pkg/languages/languages_test.go
+++ b/pkg/languages/languages_test.go
@@ -13,7 +13,8 @@ func TestLanguagesCreateDockerfileFileMap(t *testing.T) {
 	templateWriter := &writers.FileMapWriter{}
 	l := CreateLanguagesFromEmbedFS(template.Dockerfiles, "/test/dest/dir")
 	err := l.CreateDockerfileForLanguage("go", map[string]string{
-		"PORT": "8080",
+		"PORT":    "8080",
+		"VERSION": "14",
 	}, templateWriter)
 
 	assert.Nil(t, err)

--- a/pkg/osutil/osutil.go
+++ b/pkg/osutil/osutil.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/draft/pkg/templatewriter"
 )
 
+// A draft variable is defined as a string of non-whitespace characters wrapped in double curly braces.
 var draftVariableRegex = regexp.MustCompile("{{\\S+}}")
 
 // Exists returns whether the given file or directory exists or not.

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -99,7 +99,8 @@ func TestAllVariablesSubstituted(t *testing.T) {
 	}{
 		{"{{WITH SPACE}}", false},
 		{"{{ WithEndSpaces }}", false},
-		{"{{.withPeriod}}", true},
+		{"{{.helm.values.style}}", false},
+		{"{{.Values.helm.style}}", false},
 		{"{{VARIABLE1}}", true},
 		{"{{WITH_UNDERSCORE}}", true},
 		{"{{mIxEdCase}}", true},
@@ -109,7 +110,7 @@ func TestAllVariablesSubstituted(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.String, func(t *testing.T) {
-			err := validateAllVariablesSubstituted(test.String)
+			err := checkAllVariablesSubstituted(test.String)
 			didError := err != nil
 			assert.Equal(t, test.ExpectError, didError)
 		})

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -109,8 +109,8 @@ func TestAllVariablesSubstituted(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.String, func(t *testing.T) {
-			actual := validateAllVariablesSubstituted(test.String)
-			didError := actual != nil
+			err := validateAllVariablesSubstituted(test.String)
+			didError := err != nil
 			assert.Equal(t, test.ExpectError, didError)
 		})
 	}

--- a/pkg/osutil/osutil_test.go
+++ b/pkg/osutil/osutil_test.go
@@ -91,3 +91,27 @@ func TestEnsureFile(t *testing.T) {
 
 	os.Remove(invalidFile)
 }
+
+func TestAllVariablesSubstituted(t *testing.T) {
+	tests := []struct {
+		String      string
+		ExpectError bool
+	}{
+		{"{{WITH SPACE}}", false},
+		{"{{ WithEndSpaces }}", false},
+		{"{{.withPeriod}}", true},
+		{"{{VARIABLE1}}", true},
+		{"{{WITH_UNDERSCORE}}", true},
+		{"{{mIxEdCase}}", true},
+		{"{{lowercase}}", true},
+		{"{{snake_case}}", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.String, func(t *testing.T) {
+			actual := validateAllVariablesSubstituted(test.String)
+			didError := actual != nil
+			assert.Equal(t, test.ExpectError, didError)
+		})
+	}
+}

--- a/pkg/templatewriter/writers/filemapwriter_test.go
+++ b/pkg/templatewriter/writers/filemapwriter_test.go
@@ -13,7 +13,8 @@ func TestCopyDirToFileMap(t *testing.T) {
 
 	templatewriter := &FileMapWriter{}
 	err := osutil.CopyDir(template.Dockerfiles, "dockerfiles/javascript", "/test/dir", nil, map[string]string{
-		"PORT": "8080",
+		"PORT":    "8080",
+		"VERSION": "14",
 	}, templatewriter)
 	assert.Nil(t, err)
 	assert.NotNil(t, templatewriter.FileMap)


### PR DESCRIPTION
# Description

When executing a variable substitution via CopyDir, an error should be thrown if a variable is not supplied but exists in the templates.

Doing this validation at a lower level in the os package allows us to gain this protection across all the commands


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [X] Added new unit tests to confirm unsubstituted variable detection is working
- [X] updated existing tests to make sure we don't have missing variables in them as well 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

