### PR TITLE
rename helm `imageKey` to `image` to match starter workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ go-generate:
 	GO111MODULE=on go generate ./pkg/workflows/...; \
 	GO111MODULE=on go generate ./pkg/addons/...;
 
+.PHONY: test
+test: run-unit-tests run-e2e-tests-local
+
 .PHONY: run-unit-tests
 run-unit-tests:
 	docker build . -t gotest && docker run -t --rm --name draft-test gotest test ./... -buildvcs=false

--- a/pkg/workflows/service_types.go
+++ b/pkg/workflows/service_types.go
@@ -20,8 +20,8 @@ type ServiceManifest interface {
 }
 
 type HelmProductionYaml struct {
-	ImageKey imageKey `yaml:"imageKey"`
-	Service  service  `yaml:"service"`
+	Image   image   `yaml:"image"`
+	Service service `yaml:"service"`
 }
 
 type service struct {
@@ -30,7 +30,7 @@ type service struct {
 	Port        string            `yaml:"port"`
 }
 
-type imageKey struct {
+type image struct {
 	Repository string `yaml:"repository"`
 	PullPolicy string `yaml:"pullPolicy"`
 	Tag        string `yaml:"tag"`

--- a/pkg/workflows/workflows.go
+++ b/pkg/workflows/workflows.go
@@ -150,7 +150,7 @@ func setHelmContainerImage(filePath, productionImage string) error {
 		return err
 	}
 
-	deploy.ImageKey.Repository = productionImage
+	deploy.Image.Repository = productionImage
 
 	out, err := yaml.Marshal(deploy)
 	if err != nil {

--- a/pkg/workflows/workflows_test.go
+++ b/pkg/workflows/workflows_test.go
@@ -98,7 +98,7 @@ func TestUpdateProductionDeployments(t *testing.T) {
 
 	helmDeploy := &HelmProductionYaml{}
 	assert.Nil(t, helmDeploy.LoadFromFile(helmFileName))
-	assert.Equal(t, "testImage", helmDeploy.ImageKey.Repository)
+	assert.Equal(t, "testImage", helmDeploy.Image.Repository)
 
 	assert.Nil(t, setDeploymentContainerImage(deploymentFileName, "testImage"))
 	decode := scheme.Codecs.UniversalDeserializer().Decode

--- a/template/deployments/helm/charts/production.yaml
+++ b/template/deployments/helm/charts/production.yaml
@@ -1,4 +1,4 @@
-imageKey:
+image:
   repository: "{{APPNAME}}"
   pullPolicy: IfNotPresent
   tag: "latest"

--- a/template/deployments/helm/charts/templates/deployment.yaml
+++ b/template/deployments/helm/charts/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/template/deployments/helm/charts/templates/deployment.yaml
+++ b/template/deployments/helm/charts/templates/deployment.yaml
@@ -31,8 +31,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.imageKey.repository }}"
-          imagePullPolicy: {{ .Values.imageKey.pullPolicy }}
+          image: "{{ .Values.image.repository }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPort }}

--- a/template/deployments/helm/charts/values.yaml
+++ b/template/deployments/helm/charts/values.yaml
@@ -10,7 +10,7 @@ containerPort: {{PORT}}
 
 image:
   repository: {{IMAGENAME}}
-  tag: "latest"
+  tag: {{IMAGETAG}}
   pullPolicy: IfNotPresent
 
 

--- a/template/deployments/helm/charts/values.yaml
+++ b/template/deployments/helm/charts/values.yaml
@@ -8,7 +8,7 @@ namespace: {{NAMESPACE}}
 
 containerPort: {{PORT}}
 
-imageKey:
+image:
   repository: {{IMAGENAME}}
   pullPolicy: IfNotPresent
 

--- a/template/deployments/helm/charts/values.yaml
+++ b/template/deployments/helm/charts/values.yaml
@@ -10,6 +10,7 @@ containerPort: {{PORT}}
 
 image:
   repository: {{IMAGENAME}}
+  tag: "latest"
   pullPolicy: IfNotPresent
 
 

--- a/template/deployments/helm/draft.yaml
+++ b/template/deployments/helm/draft.yaml
@@ -9,6 +9,8 @@ variables:
     description: " the namespace to place new resources in"
   - name: "IMAGENAME"
     description: "the name of the image to use in the deployment"
+  - name: "IMAGETAG"
+    description: "the tag of the image to use in the deployment"
 variableDefaults:
   - name: "PORT"
     value: 80
@@ -18,3 +20,6 @@ variableDefaults:
     value: default
   - name: "IMAGENAME"
     referenceVar: "APPNAME"
+  - name: "IMAGETAG"
+    value: "latest"
+    disablePrompt: true

--- a/template/deployments/kustomize/base/deployment.yaml
+++ b/template/deployments/kustomize/base/deployment.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
         - name: {{APPNAME}}
-          image: {{IMAGENAME}}
+          image: {{IMAGENAME}}:{{IMAGETAG}}
           ports:
             - containerPort: {{PORT}}

--- a/template/deployments/kustomize/draft.yaml
+++ b/template/deployments/kustomize/draft.yaml
@@ -9,6 +9,8 @@ variables:
     description: " the namespace to place new resources in"
   - name: "IMAGENAME"
     description: "the name of the image to use in the deployment"
+  - name: "IMAGETAG"
+    description: "the tag of the image to use in the deployment"
 variableDefaults:
   - name: "PORT"
     value: 80
@@ -18,3 +20,6 @@ variableDefaults:
     value: default
   - name: "IMAGENAME"
     referenceVar: "APPNAME"
+  - name: "IMAGETAG"
+    value: "latest"
+    disablePrompt: true

--- a/template/deployments/kustomize/overlays/production/deployment.yaml
+++ b/template/deployments/kustomize/overlays/production/deployment.yaml
@@ -13,4 +13,4 @@ spec:
     spec:
       containers:
         - name: {{APPNAME}}
-          image: {{IMAGENAME}}
+          image: {{IMAGENAME}}:{{IMAGETAG}}

--- a/template/deployments/manifests/draft.yaml
+++ b/template/deployments/manifests/draft.yaml
@@ -9,6 +9,8 @@ variables:
     description: " the namespace to place new resources in"
   - name: "IMAGENAME"
     description: "the name of the image to use in the deployment"
+  - name: "IMAGETAG"
+    description: "the tag of the image to use in the deployment"
 variableDefaults:
   - name: "PORT"
     value: 80
@@ -18,3 +20,6 @@ variableDefaults:
     value: default
   - name: "IMAGENAME"
     referenceVar: "APPNAME"
+  - name: "IMAGETAG"
+    value: "latest"
+    disablePrompt: true

--- a/template/deployments/manifests/manifests/deployment.yaml
+++ b/template/deployments/manifests/manifests/deployment.yaml
@@ -17,6 +17,6 @@ spec:
     spec:
       containers:
         - name: {{APPNAME}}
-          image: {{IMAGENAME}}
+          image: {{IMAGENAME}}:{{IMAGETAG}}
           ports:
             - containerPort: {{PORT}}

--- a/test/skaffold.yaml
+++ b/test/skaffold.yaml
@@ -12,6 +12,6 @@ deploy:
       - name: my-chart
         chartPath: charts
         artifactOverrides:
-          imageKey: my-app
+          image: my-app
         imageStrategy:
           helm: {}

--- a/test/templates/helm/charts/production.yaml
+++ b/test/templates/helm/charts/production.yaml
@@ -1,4 +1,4 @@
-imageKey:
+image:
   repository: "test"
   pullPolicy: IfNotPresent
   tag: "latest"

--- a/test/templates/helm/charts/templates/deployment.yaml
+++ b/test/templates/helm/charts/templates/deployment.yaml
@@ -30,8 +30,8 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.imageKey.repository }}:{{ .Values.imageKey.tag }}"
-          imagePullPolicy: {{ .Values.imageKey.pullPolicy }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPort }}

--- a/test/templates/helm/charts/values.yaml
+++ b/test/templates/helm/charts/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 containerPort: 8080
 
-imageKey:
+image:
   repository: test
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.

--- a/test/templates/helm_prod_values.yaml
+++ b/test/templates/helm_prod_values.yaml
@@ -1,4 +1,4 @@
-imageKey:
+image:
   repository: "prodImage"
   pullPolicy: IfNotPresent
   tag: "latest"


### PR DESCRIPTION
# Description

The recommended generated key names in draft don't line up with the  keys in the starter workflows, so this PR changes the `imageKey` key to just `image` so that they are all consistent

This is a breaking change for consumers of the `IMAGENAME` variable, as it will no longer can contain both an image name and tag. 

Previously, `alpine:latest` was a valid `IMAGENAME`, but now the `IMAGETAG` variable (which defaults to "latest" following docker and kubernetes convention) should be used to pass a tag.

Usages of `IMAGENAME` that include a tag will now need to use the `IMAGETAG` variable for passing a tag, as passing an image name like `alpine:latest` will result in double-tagging such as `alpine:latest:latest` 

- [x] Breaking Change - new variable `IMAGETAG` and changed usage of `IMAGENAME`
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [x] existing integration tests pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

