### PR TITLE
helm and kustomize aggregate summary steps

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -2930,3 +2930,17 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
+
+  helm-integrations-summary:
+      runs-on: ubuntu-latest
+      needs: [ gomodule-helm-update,python-helm-update,rust-helm-update,javascript-helm-update,ruby-helm-update,csharp-helm-update,java-helm-update,gradle-helm-update,swift-helm-update,erlang-helm-update,clojure-helm-update ]
+      steps:
+        - run: echo helm integrations passed
+
+
+  kustomize-integrations-summary:
+      runs-on: ubuntu-latest
+      needs: [ gomodule-kustomize-create-update,python-kustomize-create-update,rust-kustomize-create-update,javascript-kustomize-create-update,ruby-kustomize-create-update,csharp-kustomize-create-update,java-kustomize-create-update,gradle-kustomize-create-update,swift-kustomize-create-update,erlang-kustomize-create-update,clojure-kustomize-create-update ]
+      steps:
+        - run: echo kustomize integrations passed
+

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -253,7 +253,7 @@ jobs:
         with:
           name: gomodule-manifests-create
           path: ./langtest
-  gomodule-manifests-update:
+  gomodule-manifest-update:
     needs: gomodule-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -517,7 +517,7 @@ jobs:
         with:
           name: python-manifests-create
           path: ./langtest
-  python-manifests-update:
+  python-manifest-update:
     needs: python-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -781,7 +781,7 @@ jobs:
         with:
           name: rust-manifests-create
           path: ./langtest
-  rust-manifests-update:
+  rust-manifest-update:
     needs: rust-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -1045,7 +1045,7 @@ jobs:
         with:
           name: javascript-manifests-create
           path: ./langtest
-  javascript-manifests-update:
+  javascript-manifest-update:
     needs: javascript-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -1309,7 +1309,7 @@ jobs:
         with:
           name: ruby-manifests-create
           path: ./langtest
-  ruby-manifests-update:
+  ruby-manifest-update:
     needs: ruby-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -1573,7 +1573,7 @@ jobs:
         with:
           name: csharp-manifests-create
           path: ./langtest
-  csharp-manifests-update:
+  csharp-manifest-update:
     needs: csharp-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -1837,7 +1837,7 @@ jobs:
         with:
           name: java-manifests-create
           path: ./langtest
-  java-manifests-update:
+  java-manifest-update:
     needs: java-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -2101,7 +2101,7 @@ jobs:
         with:
           name: gradle-manifests-create
           path: ./langtest
-  gradle-manifests-update:
+  gradle-manifest-update:
     needs: gradle-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -2365,7 +2365,7 @@ jobs:
         with:
           name: swift-manifests-create
           path: ./langtest
-  swift-manifests-update:
+  swift-manifest-update:
     needs: swift-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -2629,7 +2629,7 @@ jobs:
         with:
           name: erlang-manifests-create
           path: ./langtest
-  erlang-manifests-update:
+  erlang-manifest-update:
     needs: erlang-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -2893,7 +2893,7 @@ jobs:
         with:
           name: clojure-manifests-create
           path: ./langtest
-  clojure-manifests-update:
+  clojure-manifest-update:
     needs: clojure-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -2933,7 +2933,7 @@ jobs:
 
   helm-integrations-summary:
       runs-on: ubuntu-latest
-      needs: [ gomodule-helm-update,python-helm-update,rust-helm-update,javascript-helm-update,ruby-helm-update,csharp-helm-update,java-helm-update,gradle-helm-update,swift-helm-update,erlang-helm-update,clojure-helm-update ]
+      needs: [ gomodule-helm-create-update,python-helm-create-update,rust-helm-create-update,javascript-helm-create-update,ruby-helm-create-update,csharp-helm-create-update,java-helm-create-update,gradle-helm-create-update,swift-helm-create-update,erlang-helm-create-update,clojure-helm-create-update ]
       steps:
         - run: echo helm integrations passed
 
@@ -2943,4 +2943,11 @@ jobs:
       needs: [ gomodule-kustomize-create-update,python-kustomize-create-update,rust-kustomize-create-update,javascript-kustomize-create-update,ruby-kustomize-create-update,csharp-kustomize-create-update,java-kustomize-create-update,gradle-kustomize-create-update,swift-kustomize-create-update,erlang-kustomize-create-update,clojure-kustomize-create-update ]
       steps:
         - run: echo kustomize integrations passed
+
+
+  manifest-integrations-summary:
+      runs-on: ubuntu-latest
+      needs: [ gomodule-manifest-update,python-manifest-update,rust-manifest-update,javascript-manifest-update,ruby-manifest-update,csharp-manifest-update,java-manifest-update,gradle-manifest-update,swift-manifest-update,erlang-manifest-update,clojure-manifest-update ]
+      steps:
+        - run: echo manifest integrations passed
 

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -1097,3 +1097,17 @@ jobs:
       - run: ./check_windows_addon_kustomize.ps1
         working-directory: ./langtest/
       
+
+  helm-win-integrations-summary:
+      runs-on: windows-latest
+      needs: [ gomodule-helm-update,python-helm-update,rust-helm-update,javascript-helm-update,ruby-helm-update,csharp-helm-update,java-helm-update,gradle-helm-update,swift-helm-update,erlang-helm-update,clojure-helm-update ]
+      steps:
+        - run: echo helm integrations passed
+
+
+  kustomize-win-integrations-summary:
+      runs-on: windows-latest
+      needs: [ gomodule-kustomize-update,python-kustomize-update,rust-kustomize-update,javascript-kustomize-update,ruby-kustomize-update,csharp-kustomize-update,java-kustomize-update,gradle-kustomize-update,swift-kustomize-update,erlang-kustomize-update,clojure-kustomize-update ]
+      steps:
+        - run: echo kustomize integrations passed
+

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -4,6 +4,10 @@ rm -rf ./integration/*
 echo "Removing previous integration workflows"
 rm ../.github/workflows/integration-linux.yml
 rm ../.github/workflows/integration-windows.yml
+helm_workflow_names_file=./temp/helm_workflow_names.txt
+rm $helm_workflow_names_file
+kustomize_workflow_names_file=./temp/kustomize_workflow_names.txt
+rm $kustomize_workflow_names_file
 
 # add build to workflow
 echo "name: draft Linux Integrations
@@ -240,6 +244,8 @@ languageVariables:
         run: exit 6" >> ../.github/workflows/integration-linux.yml
 
     # create kustomize workflow
+    kustomize_create_update_job_name=$lang-kustomize-create-update
+    echo $kustomize_create_update_job_name >> $kustomize_workflow_names_file
     echo "
   $lang-kustomize-dry-run:
     runs-on: ubuntu-latest
@@ -265,7 +271,7 @@ languageVariables:
         run: |
           npm install -g ajv-cli@5.0.0
           ajv validate -s test/dry_run_schema.json -d test/temp/dry-run.json
-  $lang-kustomize-create-update:
+  $kustomize_create_update_job_name:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -430,6 +436,8 @@ languageVariables:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po" >> ../.github/workflows/integration-linux.yml
 
+  helm_update_jobname=$lang-helm-update
+  echo $helm_update_jobname >> $helm_workflow_names_file
     # create helm workflow
     echo "
   $lang-helm-create:
@@ -459,7 +467,7 @@ languageVariables:
         with:
           name: $lang-helm-create
           path: ./langtest
-  $lang-helm-update:
+  $helm_update_jobname:
     needs: $lang-helm-create
     runs-on: windows-latest
     steps:
@@ -530,3 +538,19 @@ languageVariables:
         working-directory: ./langtest/
       " >> ../.github/workflows/integration-windows.yml
 done
+
+echo "
+  helm-integrations-summary:
+      runs-on: ubuntu-latest
+      needs: [ $( paste -sd ',' $helm_workflow_names_file) ]
+      steps:
+        - run: echo "helm integrations passed"
+" >> ../.github/workflows/integration-linux.yml
+
+echo "
+  kustomize-integrations-summary:
+      runs-on: ubuntu-latest
+      needs: [ $( paste -sd ',' $kustomize_workflow_names_file) ]
+      steps:
+        - run: echo "kustomize integrations passed"
+" >> ../.github/workflows/integration-linux.yml

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -6,8 +6,14 @@ rm ../.github/workflows/integration-linux.yml
 rm ../.github/workflows/integration-windows.yml
 helm_workflow_names_file=./temp/helm_workflow_names.txt
 rm $helm_workflow_names_file
+helm_win_workflow_names_file=./temp/helm_win_workflow_names.txt
+rm $helm_win_workflow_names_file
 kustomize_workflow_names_file=./temp/kustomize_workflow_names.txt
 rm $kustomize_workflow_names_file
+kustomize_win_workflow_names_file=./temp/kustomize_win_workflow_names.txt
+rm $kustomize_win_workflow_names_file
+manifest_workflow_names_file=./temp/manifest_workflow_names.txt
+rm $manifest_workflow_names_file
 
 # add build to workflow
 echo "name: draft Linux Integrations
@@ -159,6 +165,8 @@ languageVariables:
     value: \"$port\"" > ./integration/$lang/manifest.yaml
 
     # create helm workflow
+    helm_create_update_job_name=$lang-helm-create-update
+    echo $helm_create_update_job_name >> $helm_workflow_names_file
     echo "
   $lang-helm-dry-run:
       runs-on: ubuntu-latest
@@ -184,7 +192,7 @@ languageVariables:
           run: |
             npm install -g ajv-cli@5.0.0
             ajv validate -s test/dry_run_schema.json -d test/temp/dry-run.json
-  $lang-helm-create-update:
+  $helm_create_update_job_name:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -329,6 +337,8 @@ languageVariables:
         run: exit 6" >> ../.github/workflows/integration-linux.yml
 
   # create manifests workflow
+    manifest_update_job_name=$lang-manifest-update
+    echo $manifest_update_job_name >> $manifest_workflow_names_file
     echo "
   $lang-manifest-dry-run:
       runs-on: ubuntu-latest
@@ -398,7 +408,7 @@ languageVariables:
         with:
           name: $lang-manifests-create
           path: ./langtest
-  $lang-manifests-update:
+  $manifest_update_job_name:
     needs: $lang-manifests-create
     runs-on: ubuntu-latest
     services:
@@ -436,8 +446,8 @@ languageVariables:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po" >> ../.github/workflows/integration-linux.yml
 
-  helm_update_jobname=$lang-helm-update
-  echo $helm_update_jobname >> $helm_workflow_names_file
+  helm_update_win_jobname=$lang-helm-update
+  echo $helm_update_win_jobname >> $helm_win_workflow_names_file
     # create helm workflow
     echo "
   $lang-helm-create:
@@ -467,7 +477,7 @@ languageVariables:
         with:
           name: $lang-helm-create
           path: ./langtest
-  $helm_update_jobname:
+  $helm_update_win_jobname:
     needs: $lang-helm-create
     runs-on: windows-latest
     steps:
@@ -489,6 +499,8 @@ languageVariables:
         working-directory: ./langtest/" >> ../.github/workflows/integration-windows.yml
 
     # create kustomize workflow
+    kustomize_win_workflow_name=$lang-kustomize-update
+    echo $kustomize_win_workflow_name >> $kustomize_win_workflow_names_file
     echo "
   $lang-kustomize-create:
     runs-on: windows-latest
@@ -517,7 +529,7 @@ languageVariables:
         with:
           name: $lang-kustomize-create
           path: ./langtest
-  $lang-kustomize-update:
+  $kustomize_win_workflow_name:
     needs: $lang-kustomize-create 
     runs-on: windows-latest
     steps:
@@ -540,6 +552,22 @@ languageVariables:
 done
 
 echo "
+  helm-win-integrations-summary:
+      runs-on: windows-latest
+      needs: [ $( paste -sd ',' $helm_win_workflow_names_file) ]
+      steps:
+        - run: echo "helm integrations passed"
+" >> ../.github/workflows/integration-windows.yml
+
+echo "
+  kustomize-win-integrations-summary:
+      runs-on: windows-latest
+      needs: [ $( paste -sd ',' $kustomize_win_workflow_names_file) ]
+      steps:
+        - run: echo "kustomize integrations passed"
+" >> ../.github/workflows/integration-windows.yml
+
+echo "
   helm-integrations-summary:
       runs-on: ubuntu-latest
       needs: [ $( paste -sd ',' $helm_workflow_names_file) ]
@@ -553,4 +581,12 @@ echo "
       needs: [ $( paste -sd ',' $kustomize_workflow_names_file) ]
       steps:
         - run: echo "kustomize integrations passed"
+" >> ../.github/workflows/integration-linux.yml
+
+echo "
+  manifest-integrations-summary:
+      runs-on: ubuntu-latest
+      needs: [ $( paste -sd ',' $manifest_workflow_names_file) ]
+      steps:
+        - run: echo "manifest integrations passed"
 " >> ../.github/workflows/integration-linux.yml


### PR DESCRIPTION
# Description
github action jobs must be listed by name to be required for PRs to merge, and since we have over 100 in draft across all of the languages and deployment types we can't list them all in a branch protection rule.

creating a new job that needs all of the other jobs would allow us to require just the new "summary" job, blocking PRs until every step has passed.
currently, PRs can be merged while integrations are running as long as approvals are in, even if the tests haven't finished as long as they haven't failed.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [x] tested by running the new steps on this pr branch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

