### PR TITLE
no prompt support for buildervars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.18-alpine
 
 WORKDIR /draft
-COPY . ./
 
 RUN apk add build-base
 RUN apk add py3-pip
@@ -10,6 +9,7 @@ RUN pip install --upgrade pip
 RUN pip install azure-cli
 RUN apk add github-cli
 
+COPY . ./
 RUN make go-generate
 
 RUN go mod vendor

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -28,7 +28,6 @@ func GenerateAddon(addons embed.FS, provider, addon, dest string, userInputs map
 	if err != nil {
 		return err
 	}
-	log.Debugf("addOnConfig is: %s", addOnConfig)
 
 	selectedAddonPath, err := GetAddonPath(addons, provider, addon)
 	if err != nil {
@@ -70,7 +69,10 @@ func GetAddonConfig(addons embed.FS, provider, addon string) (AddonConfig, error
 		return AddonConfig{}, err
 	}
 
-	configBytes, err := fs.ReadFile(addons, path.Join(selectedAddonPath, "draft.yaml"))
+	addOnConfigPath := path.Join(selectedAddonPath, "draft.yaml")
+	log.Debugf("addOnConfig is: %s", addOnConfigPath)
+
+	configBytes, err := fs.ReadFile(addons, addOnConfigPath)
 	if err != nil {
 		return AddonConfig{}, err
 	}

--- a/pkg/config/draftconfig.go
+++ b/pkg/config/draftconfig.go
@@ -20,11 +20,11 @@ type FileNameOverride struct {
 }
 
 type BuilderVar struct {
-	Name          string   `yaml:"name"`
-	Description   string   `yaml:"description"`
-	VarType       string   `yaml:"type"`
-	ExampleValues []string `yaml:"exampleValues"`
-	NoPrompt      bool     `yaml:"noPrompt"`
+	Name             string   `yaml:"name"`
+	Description      string   `yaml:"description"`
+	VarType          string   `yaml:"type"`
+	ExampleValues    []string `yaml:"exampleValues"`
+	IsPromptDisabled bool     `yaml:"disablePrompt"`
 }
 
 type BuilderVarDefault struct {

--- a/pkg/config/draftconfig.go
+++ b/pkg/config/draftconfig.go
@@ -4,7 +4,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//TODO: remove Name Overrides since we don't need them anymore
+// TODO: remove Name Overrides since we don't need them anymore
 type DraftConfig struct {
 	DisplayName      string              `yaml:"displayName"`
 	NameOverrides    []FileNameOverride  `yaml:"nameOverrides"`
@@ -24,6 +24,7 @@ type BuilderVar struct {
 	Description   string   `yaml:"description"`
 	VarType       string   `yaml:"type"`
 	ExampleValues []string `yaml:"exampleValues"`
+	NoPrompt      bool     `yaml:"noPrompt"`
 }
 
 type BuilderVarDefault struct {

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -19,7 +19,7 @@ func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []stri
 }
 
 // RunPromptsFromConfigWithSkipsIO runs the prompts for the given config
-// skipping any variables in varsToSkip or where the BuilderVar.NoPrompt is true.
+// skipping any variables in varsToSkip or where the BuilderVar.IsPromptDisabled is true.
 // If Stdin or Stdout are nil, the default values will be used.
 func RunPromptsFromConfigWithSkipsIO(config *config.DraftConfig, varsToSkip []string, Stdin io.ReadCloser, Stdout io.WriteCloser) (map[string]string, error) {
 	skipMap := make(map[string]interface{})
@@ -36,10 +36,10 @@ func RunPromptsFromConfigWithSkipsIO(config *config.DraftConfig, varsToSkip []st
 			continue
 		}
 		if customPrompt.IsPromptDisabled {
-			log.Debugf("Skipping prompt for %s as it has NoPrompt=true", promptVariableName)
+			log.Debugf("Skipping prompt for %s as it has IsPromptDisabled=true", promptVariableName)
 			noPromptDefaultValue := GetVariableDefaultValue(promptVariableName, config.VariableDefaults, inputs)
 			if noPromptDefaultValue == "" {
-				return nil, fmt.Errorf("NoPrompt is true for %s but no default value was found", promptVariableName)
+				return nil, fmt.Errorf("IsPromptDisabled is true for %s but no default value was found", promptVariableName)
 			}
 			log.Debugf("Using default value %s for %s", noPromptDefaultValue, promptVariableName)
 			inputs[promptVariableName] = noPromptDefaultValue

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -35,7 +35,7 @@ func RunPromptsFromConfigWithSkipsIO(config *config.DraftConfig, varsToSkip []st
 			log.Debugf("Skipping prompt for %s", promptVariableName)
 			continue
 		}
-		if customPrompt.NoPrompt {
+		if customPrompt.IsPromptDisabled {
 			log.Debugf("Skipping prompt for %s as it has NoPrompt=true", promptVariableName)
 			noPromptDefaultValue := GetVariableDefaultValue(promptVariableName, config.VariableDefaults, inputs)
 			if noPromptDefaultValue == "" {

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -18,6 +18,9 @@ func RunPromptsFromConfigWithSkips(config *config.DraftConfig, varsToSkip []stri
 	return RunPromptsFromConfigWithSkipsIO(config, varsToSkip, nil, nil)
 }
 
+// RunPromptsFromConfigWithSkipsIO runs the prompts for the given config
+// skipping any variables in varsToSkip or where the BuilderVar.NoPrompt is true.
+// If Stdin or Stdout are nil, the default values will be used.
 func RunPromptsFromConfigWithSkipsIO(config *config.DraftConfig, varsToSkip []string, Stdin io.ReadCloser, Stdout io.WriteCloser) (map[string]string, error) {
 	skipMap := make(map[string]interface{})
 	for _, v := range varsToSkip {
@@ -32,8 +35,18 @@ func RunPromptsFromConfigWithSkipsIO(config *config.DraftConfig, varsToSkip []st
 			log.Debugf("Skipping prompt for %s", promptVariableName)
 			continue
 		}
+		if customPrompt.NoPrompt {
+			log.Debugf("Skipping prompt for %s as it has NoPrompt=true", promptVariableName)
+			noPromptDefaultValue := GetVariableDefaultValue(promptVariableName, config.VariableDefaults, inputs)
+			if noPromptDefaultValue == "" {
+				return nil, fmt.Errorf("NoPrompt is true for %s but no default value was found", promptVariableName)
+			}
+			log.Debugf("Using default value %s for %s", noPromptDefaultValue, promptVariableName)
+			inputs[promptVariableName] = noPromptDefaultValue
+			continue
+		}
 
-		log.Debugf("constructing prompt for: %s", customPrompt)
+		log.Debugf("constructing prompt for: %s", promptVariableName)
 		if customPrompt.VarType == "bool" {
 			input, err := RunBoolPrompt(customPrompt, Stdin, Stdout)
 			if err != nil {

--- a/pkg/prompts/prompts_test.go
+++ b/pkg/prompts/prompts_test.go
@@ -152,9 +152,9 @@ func TestRunPromptsFromConfigWithSkipsIO(t *testing.T) {
 			config: config.DraftConfig{
 				Variables: []config.BuilderVar{
 					{
-						Name:        "var1",
-						Description: "var1 description",
-						NoPrompt:    true,
+						Name:             "var1",
+						Description:      "var1 description",
+						IsPromptDisabled: true,
 					},
 				},
 				VariableDefaults: []config.BuilderVarDefault{
@@ -174,16 +174,16 @@ func TestRunPromptsFromConfigWithSkipsIO(t *testing.T) {
 			config: config.DraftConfig{
 				Variables: []config.BuilderVar{
 					{
-						Name:        "var1-no-prompt",
-						Description: "var1 has NoPrompt and should skip prompt and use default value",
-						NoPrompt:    true,
+						Name:             "var1-no-prompt",
+						Description:      "var1 has IsPromptDisabled and should skip prompt and use default value",
+						IsPromptDisabled: true,
 					}, {
 						Name:        "var2-default",
 						Description: "var2 has a default value and will receive an empty value, so it should use the default value",
 					}, {
-						Name:        "var3-no-prompt",
-						Description: "var3 has NoPrompt and should skip prompt and use default value",
-						NoPrompt:    true,
+						Name:             "var3-no-prompt",
+						Description:      "var3 has IsPromptDisabled and should skip prompt and use default value",
+						IsPromptDisabled: true,
 					}, {
 						Name:        "var4",
 						Description: "var4 has a default value, but has a value entered, so it should use the entered value",

--- a/pkg/prompts/prompts_test.go
+++ b/pkg/prompts/prompts_test.go
@@ -138,3 +138,111 @@ func TestRunStringPrompt(t *testing.T) {
 		})
 	}
 }
+func TestRunPromptsFromConfigWithSkipsIO(t *testing.T) {
+	tests := []struct {
+		testName     string
+		config       config.DraftConfig
+		userInputs   []string
+		defaultValue string
+		want         map[string]string
+		wantErr      bool
+	}{
+		{
+			testName: "onlyNoPrompt",
+			config: config.DraftConfig{
+				Variables: []config.BuilderVar{
+					{
+						Name:        "var1",
+						Description: "var1 description",
+						NoPrompt:    true,
+					},
+				},
+				VariableDefaults: []config.BuilderVarDefault{
+					{
+						Name:  "var1",
+						Value: "defaultValue",
+					},
+				},
+			},
+			userInputs: []string{""},
+			want: map[string]string{
+				"var1": "defaultValue",
+			},
+			wantErr: false,
+		}, {
+			testName: "twoPromptTwoNoPrompt",
+			config: config.DraftConfig{
+				Variables: []config.BuilderVar{
+					{
+						Name:        "var1-no-prompt",
+						Description: "var1 has NoPrompt and should skip prompt and use default value",
+						NoPrompt:    true,
+					}, {
+						Name:        "var2-default",
+						Description: "var2 has a default value and will receive an empty value, so it should use the default value",
+					}, {
+						Name:        "var3-no-prompt",
+						Description: "var3 has NoPrompt and should skip prompt and use default value",
+						NoPrompt:    true,
+					}, {
+						Name:        "var4",
+						Description: "var4 has a default value, but has a value entered, so it should use the entered value",
+					},
+				},
+				VariableDefaults: []config.BuilderVarDefault{
+					{
+						Name:  "var1-no-prompt",
+						Value: "defaultValueNoPrompt1",
+					}, {
+						Name:  "var2-default",
+						Value: "defaultValue2",
+					}, {
+						Name:  "var3-no-prompt",
+						Value: "defaultValueNoPrompt3",
+					}, {
+						Name:  "var4",
+						Value: "defaultValue4",
+					},
+				},
+			},
+			userInputs: []string{"\n", "entered-value-for-4\n"},
+			want: map[string]string{
+				"var1-no-prompt": "defaultValueNoPrompt1",
+				"var2-default":   "defaultValue2",
+				"var3-no-prompt": "defaultValueNoPrompt3",
+				"var4":           "entered-value-for-4",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			inReader, inWriter := io.Pipe()
+
+			go func() {
+				for _, input := range tt.userInputs {
+					_, err := inWriter.Write([]byte(input))
+					if err != nil {
+						t.Errorf("Error writing to inWriter: %v", err)
+					}
+				}
+				err := inWriter.Close()
+				if err != nil {
+					t.Errorf("Error closing inWriter: %v", err)
+				}
+			}()
+			got, err := RunPromptsFromConfigWithSkipsIO(&tt.config, nil, inReader, nil)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TestRunPromptsFromConfigWithSkipsIO() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for k, v := range got {
+				wantVal := tt.want[k]
+				if v != wantVal {
+					t.Errorf("TestRunPromptsFromConfigWithSkipsIO()  inputs [%s]=%s, want %s", k, v, wantVal)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Add a new boolean field to BuilderVars that allow prompting to be skipped, in which case the default value will be used. The var can still be overridden with a flag since that occurs outside the prompting logic which triggers a skip.

Since this adds a new boolean field, it defaults to false allowing backwards compatibility with all existing templates

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] New iteration testing for inputs with combinations of prompt and noprompts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

