### PR TITLE
bump node12 actions

### DIFF
--- a/.github/workflows/e2e-info.yml
+++ b/.github/workflows/e2e-info.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18.2
       - name: make

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -1,3 +1,4 @@
+# this file is generated using gen_integration.sh
 name: draft Linux Integrations
 
 on:
@@ -9,19 +10,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.18.2
       - name: make
         run: make
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: helm-skaffold
           path: ./test/skaffold.yaml
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: draft-binary
           path: ./draft
@@ -31,13 +32,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: gambtho/go_echo
             path: ./langtest
@@ -58,13 +59,13 @@ jobs:
           - 5000:5000
     needs: gomodule-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: gambtho/go_echo
           path: ./langtest
@@ -112,13 +113,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: gambtho/go_echo
           path: ./langtest
@@ -139,13 +140,13 @@ jobs:
           - 5000:5000
     needs: gomodule-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: gambtho/go_echo
           path: ./langtest
@@ -191,13 +192,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: gambtho/go_echo
             path: ./langtest
@@ -218,13 +219,13 @@ jobs:
           - 5000:5000
     needs: gomodule-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: gambtho/go_echo
           path: ./langtest
@@ -249,7 +250,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: gomodule-manifests-create
           path: ./langtest
@@ -262,12 +263,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: gomodule-manifests-create
           path: ./langtest/
@@ -295,13 +296,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: OliverMKing/flask-hello-world
             path: ./langtest
@@ -322,13 +323,13 @@ jobs:
           - 5000:5000
     needs: python-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
@@ -376,13 +377,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
@@ -403,13 +404,13 @@ jobs:
           - 5000:5000
     needs: python-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
@@ -455,13 +456,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: OliverMKing/flask-hello-world
             path: ./langtest
@@ -482,13 +483,13 @@ jobs:
           - 5000:5000
     needs: python-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
@@ -513,7 +514,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: python-manifests-create
           path: ./langtest
@@ -526,12 +527,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: python-manifests-create
           path: ./langtest/
@@ -559,13 +560,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: OliverMKing/tiny-http-hello-world
             path: ./langtest
@@ -586,13 +587,13 @@ jobs:
           - 5000:5000
     needs: rust-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
@@ -640,13 +641,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
@@ -667,13 +668,13 @@ jobs:
           - 5000:5000
     needs: rust-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
@@ -719,13 +720,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: OliverMKing/tiny-http-hello-world
             path: ./langtest
@@ -746,13 +747,13 @@ jobs:
           - 5000:5000
     needs: rust-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
@@ -777,7 +778,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: rust-manifests-create
           path: ./langtest
@@ -790,12 +791,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: rust-manifests-create
           path: ./langtest/
@@ -823,13 +824,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: davidgamero/express-hello-world
             path: ./langtest
@@ -850,13 +851,13 @@ jobs:
           - 5000:5000
     needs: javascript-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: davidgamero/express-hello-world
           path: ./langtest
@@ -904,13 +905,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: davidgamero/express-hello-world
           path: ./langtest
@@ -931,13 +932,13 @@ jobs:
           - 5000:5000
     needs: javascript-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: davidgamero/express-hello-world
           path: ./langtest
@@ -983,13 +984,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: davidgamero/express-hello-world
             path: ./langtest
@@ -1010,13 +1011,13 @@ jobs:
           - 5000:5000
     needs: javascript-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: davidgamero/express-hello-world
           path: ./langtest
@@ -1041,7 +1042,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: javascript-manifests-create
           path: ./langtest
@@ -1054,12 +1055,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: javascript-manifests-create
           path: ./langtest/
@@ -1087,13 +1088,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: OliverMKing/ruby-hello-world
             path: ./langtest
@@ -1114,13 +1115,13 @@ jobs:
           - 5000:5000
     needs: ruby-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
@@ -1168,13 +1169,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
@@ -1195,13 +1196,13 @@ jobs:
           - 5000:5000
     needs: ruby-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
@@ -1247,13 +1248,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: OliverMKing/ruby-hello-world
             path: ./langtest
@@ -1274,13 +1275,13 @@ jobs:
           - 5000:5000
     needs: ruby-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
@@ -1305,7 +1306,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ruby-manifests-create
           path: ./langtest
@@ -1318,12 +1319,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: ruby-manifests-create
           path: ./langtest/
@@ -1351,13 +1352,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: imiller31/csharp-simple-web-app
             path: ./langtest
@@ -1378,13 +1379,13 @@ jobs:
           - 5000:5000
     needs: csharp-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
@@ -1432,13 +1433,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
@@ -1459,13 +1460,13 @@ jobs:
           - 5000:5000
     needs: csharp-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
@@ -1511,13 +1512,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: imiller31/csharp-simple-web-app
             path: ./langtest
@@ -1538,13 +1539,13 @@ jobs:
           - 5000:5000
     needs: csharp-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
@@ -1569,7 +1570,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: csharp-manifests-create
           path: ./langtest
@@ -1582,12 +1583,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: csharp-manifests-create
           path: ./langtest/
@@ -1615,13 +1616,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: imiller31/simple-java-server
             path: ./langtest
@@ -1642,13 +1643,13 @@ jobs:
           - 5000:5000
     needs: java-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-java-server
           path: ./langtest
@@ -1696,13 +1697,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-java-server
           path: ./langtest
@@ -1723,13 +1724,13 @@ jobs:
           - 5000:5000
     needs: java-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-java-server
           path: ./langtest
@@ -1775,13 +1776,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: imiller31/simple-java-server
             path: ./langtest
@@ -1802,13 +1803,13 @@ jobs:
           - 5000:5000
     needs: java-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-java-server
           path: ./langtest
@@ -1833,7 +1834,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: java-manifests-create
           path: ./langtest
@@ -1846,12 +1847,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: java-manifests-create
           path: ./langtest/
@@ -1879,13 +1880,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: imiller31/simple-gradle-server
             path: ./langtest
@@ -1906,13 +1907,13 @@ jobs:
           - 5000:5000
     needs: gradle-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-gradle-server
           path: ./langtest
@@ -1960,13 +1961,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-gradle-server
           path: ./langtest
@@ -1987,13 +1988,13 @@ jobs:
           - 5000:5000
     needs: gradle-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-gradle-server
           path: ./langtest
@@ -2039,13 +2040,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: imiller31/simple-gradle-server
             path: ./langtest
@@ -2066,13 +2067,13 @@ jobs:
           - 5000:5000
     needs: gradle-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-gradle-server
           path: ./langtest
@@ -2097,7 +2098,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: gradle-manifests-create
           path: ./langtest
@@ -2110,12 +2111,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: gradle-manifests-create
           path: ./langtest/
@@ -2143,13 +2144,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: OliverMKing/swift-hello-world
             path: ./langtest
@@ -2170,13 +2171,13 @@ jobs:
           - 5000:5000
     needs: swift-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
@@ -2224,13 +2225,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
@@ -2251,13 +2252,13 @@ jobs:
           - 5000:5000
     needs: swift-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
@@ -2303,13 +2304,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: OliverMKing/swift-hello-world
             path: ./langtest
@@ -2330,13 +2331,13 @@ jobs:
           - 5000:5000
     needs: swift-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
@@ -2361,7 +2362,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: swift-manifests-create
           path: ./langtest
@@ -2374,12 +2375,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: swift-manifests-create
           path: ./langtest/
@@ -2407,13 +2408,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: bfoley13/ErlangExample
             path: ./langtest
@@ -2434,13 +2435,13 @@ jobs:
           - 5000:5000
     needs: erlang-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: bfoley13/ErlangExample
           path: ./langtest
@@ -2488,13 +2489,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: bfoley13/ErlangExample
           path: ./langtest
@@ -2515,13 +2516,13 @@ jobs:
           - 5000:5000
     needs: erlang-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: bfoley13/ErlangExample
           path: ./langtest
@@ -2567,13 +2568,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: bfoley13/ErlangExample
             path: ./langtest
@@ -2594,13 +2595,13 @@ jobs:
           - 5000:5000
     needs: erlang-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: bfoley13/ErlangExample
           path: ./langtest
@@ -2625,7 +2626,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: erlang-manifests-create
           path: ./langtest
@@ -2638,12 +2639,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: erlang-manifests-create
           path: ./langtest/
@@ -2671,13 +2672,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: imiller31/clojure-simple-http
             path: ./langtest
@@ -2698,13 +2699,13 @@ jobs:
           - 5000:5000
     needs: clojure-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/clojure-simple-http
           path: ./langtest
@@ -2752,13 +2753,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/clojure-simple-http
           path: ./langtest
@@ -2779,13 +2780,13 @@ jobs:
           - 5000:5000
     needs: clojure-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/clojure-simple-http
           path: ./langtest
@@ -2831,13 +2832,13 @@ jobs:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: imiller31/clojure-simple-http
             path: ./langtest
@@ -2858,13 +2859,13 @@ jobs:
           - 5000:5000
     needs: clojure-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/clojure-simple-http
           path: ./langtest
@@ -2889,7 +2890,7 @@ jobs:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: clojure-manifests-create
           path: ./langtest
@@ -2902,12 +2903,12 @@ jobs:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: clojure-manifests-create
           path: ./langtest/

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -9,34 +9,34 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.18
       - name: make
         run: make
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: draft-binary
           path: ./draft.exe
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: check_windows_helm
           path: ./test/check_windows_helm.ps1
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./test/check_windows_addon_helm.ps1
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./test/check_windows_kustomize.ps1
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./test/check_windows_addon_kustomize.ps1
@@ -46,12 +46,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: gambtho/go_echo
           path: ./langtest
@@ -59,7 +59,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/gomodule/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -73,8 +73,8 @@ jobs:
     needs: gomodule-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -83,7 +83,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -94,12 +94,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: gambtho/go_echo
           path: ./langtest
@@ -107,7 +107,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/gomodule/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -121,7 +121,7 @@ jobs:
     needs: gomodule-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -130,7 +130,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -142,12 +142,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
@@ -155,7 +155,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/python/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -169,8 +169,8 @@ jobs:
     needs: python-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -179,7 +179,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -190,12 +190,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/flask-hello-world
           path: ./langtest
@@ -203,7 +203,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/python/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -217,7 +217,7 @@ jobs:
     needs: python-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -226,7 +226,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -238,12 +238,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
@@ -251,7 +251,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/rust/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -265,8 +265,8 @@ jobs:
     needs: rust-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -275,7 +275,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -286,12 +286,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/tiny-http-hello-world
           path: ./langtest
@@ -299,7 +299,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/rust/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -313,7 +313,7 @@ jobs:
     needs: rust-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -322,7 +322,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -334,12 +334,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: davidgamero/express-hello-world
           path: ./langtest
@@ -347,7 +347,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/javascript/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -361,8 +361,8 @@ jobs:
     needs: javascript-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -371,7 +371,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -382,12 +382,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: davidgamero/express-hello-world
           path: ./langtest
@@ -395,7 +395,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/javascript/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -409,7 +409,7 @@ jobs:
     needs: javascript-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -418,7 +418,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -430,12 +430,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
@@ -443,7 +443,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/ruby/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -457,8 +457,8 @@ jobs:
     needs: ruby-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -467,7 +467,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -478,12 +478,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/ruby-hello-world
           path: ./langtest
@@ -491,7 +491,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/ruby/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -505,7 +505,7 @@ jobs:
     needs: ruby-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -514,7 +514,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -526,12 +526,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
@@ -539,7 +539,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/csharp/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -553,8 +553,8 @@ jobs:
     needs: csharp-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -563,7 +563,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -574,12 +574,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/csharp-simple-web-app
           path: ./langtest
@@ -587,7 +587,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/csharp/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -601,7 +601,7 @@ jobs:
     needs: csharp-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -610,7 +610,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -622,12 +622,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-java-server
           path: ./langtest
@@ -635,7 +635,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/java/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -649,8 +649,8 @@ jobs:
     needs: java-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -659,7 +659,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -670,12 +670,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-java-server
           path: ./langtest
@@ -683,7 +683,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/java/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -697,7 +697,7 @@ jobs:
     needs: java-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -706,7 +706,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -718,12 +718,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-gradle-server
           path: ./langtest
@@ -731,7 +731,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/gradle/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -745,8 +745,8 @@ jobs:
     needs: gradle-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -755,7 +755,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -766,12 +766,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/simple-gradle-server
           path: ./langtest
@@ -779,7 +779,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/gradle/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -793,7 +793,7 @@ jobs:
     needs: gradle-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -802,7 +802,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -814,12 +814,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
@@ -827,7 +827,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/swift/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -841,8 +841,8 @@ jobs:
     needs: swift-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -851,7 +851,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -862,12 +862,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: OliverMKing/swift-hello-world
           path: ./langtest
@@ -875,7 +875,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/swift/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -889,7 +889,7 @@ jobs:
     needs: swift-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -898,7 +898,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -910,12 +910,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: bfoley13/ErlangExample
           path: ./langtest
@@ -923,7 +923,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/erlang/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -937,8 +937,8 @@ jobs:
     needs: erlang-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -947,7 +947,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -958,12 +958,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: bfoley13/ErlangExample
           path: ./langtest
@@ -971,7 +971,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/erlang/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -985,7 +985,7 @@ jobs:
     needs: erlang-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -994,7 +994,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/
@@ -1006,12 +1006,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/clojure-simple-http
           path: ./langtest
@@ -1019,7 +1019,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/clojure/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -1033,8 +1033,8 @@ jobs:
     needs: clojure-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -1043,7 +1043,7 @@ jobs:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -1054,12 +1054,12 @@ jobs:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: imiller31/clojure-simple-http
           path: ./langtest
@@ -1067,7 +1067,7 @@ jobs:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/clojure/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -1081,7 +1081,7 @@ jobs:
     needs: clojure-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -1090,7 +1090,7 @@ jobs:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: make

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -16,7 +16,8 @@ manifest_workflow_names_file=./temp/manifest_workflow_names.txt
 rm $manifest_workflow_names_file
 
 # add build to workflow
-echo "name: draft Linux Integrations
+echo "# this file is generated using gen_integration.sh
+name: draft Linux Integrations
 
 on:
   pull_request:
@@ -27,19 +28,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.18.2
       - name: make
         run: make
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: helm-skaffold
           path: ./test/skaffold.yaml
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: draft-binary
           path: ./draft
@@ -56,34 +57,34 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.18
       - name: make
         run: make
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: draft-binary
           path: ./draft.exe
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: check_windows_helm
           path: ./test/check_windows_helm.ps1
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./test/check_windows_addon_helm.ps1
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./test/check_windows_kustomize.ps1
           if-no-files-found: error
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./test/check_windows_addon_kustomize.ps1
@@ -172,13 +173,13 @@ languageVariables:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: $repo
             path: ./langtest
@@ -201,13 +202,13 @@ languageVariables:
           - 5000:5000
     needs: $lang-helm-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: $repo
           path: ./langtest
@@ -259,13 +260,13 @@ languageVariables:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: $repo
           path: ./langtest
@@ -288,13 +289,13 @@ languageVariables:
           - 5000:5000
     needs: $lang-kustomize-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: $repo
           path: ./langtest
@@ -344,13 +345,13 @@ languageVariables:
       runs-on: ubuntu-latest
       needs: build
       steps:
-        - uses: actions/checkout@v2
-        - uses: actions/download-artifact@v2
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
           with:
             name: draft-binary
         - run: chmod +x ./draft
         - run: mkdir ./langtest
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: $repo
             path: ./langtest
@@ -373,13 +374,13 @@ languageVariables:
           - 5000:5000
     needs: $lang-manifest-dry-run
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: $repo
           path: ./langtest
@@ -404,7 +405,7 @@ languageVariables:
       - name: Check default namespace
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: $lang-manifests-create
           path: ./langtest
@@ -417,12 +418,12 @@ languageVariables:
         ports:
           - 5000:5000
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: chmod +x ./draft
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: $lang-manifests-create
           path: ./langtest/
@@ -454,12 +455,12 @@ languageVariables:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: $repo
           path: ./langtest
@@ -467,7 +468,7 @@ languageVariables:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/$lang/helm.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_helm
           path: ./langtest/
@@ -481,8 +482,8 @@ languageVariables:
     needs: $lang-helm-create
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -491,7 +492,7 @@ languageVariables:
           path: ./langtest/
       - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ $ingress_test_args
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_helm
           path: ./langtest/
@@ -506,12 +507,12 @@ languageVariables:
     runs-on: windows-latest
     needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - run: mkdir ./langtest
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: $repo
           path: ./langtest
@@ -519,7 +520,7 @@ languageVariables:
       - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
       - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
       - run: ./draft.exe -v create -c ./test/integration/$lang/kustomize.yaml -d ./langtest/
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_kustomize
           path: ./langtest/
@@ -533,7 +534,7 @@ languageVariables:
     needs: $lang-kustomize-create 
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: draft-binary
       - uses: actions/download-artifact@v3
@@ -542,7 +543,7 @@ languageVariables:
           path: ./langtest
       - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
       - run: ./draft.exe -v update -d ./langtest/ $ingress_test_args
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: check_windows_addon_kustomize
           path: ./langtest/


### PR DESCRIPTION
# Description

bump our node12 actions to the new v3 node 16 versions as they are deprecated soon

https://github.com/Azure/draft/actions/runs/4195969311

we get a ton of warning at the moment due to this
<img width="378" alt="image" src="https://user-images.githubusercontent.com/4248857/220459205-b1680cd1-7b87-46bf-bb9e-9d64914d0a70.png">


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

