### PR TITLE
add go dockerfile test and no modules

### DIFF
--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -292,6 +292,270 @@ jobs:
         if: steps.deploy.outcome != 'success'
         run: kubectl get po
 
+  go-helm-dry-run:
+      runs-on: ubuntu-latest
+      needs: build
+      steps:
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
+          with:
+            name: draft-binary
+        - run: chmod +x ./draft
+        - run: mkdir ./langtest
+        - uses: actions/checkout@v3
+          with:
+            repository: davidgamero/go-echo-no-mod
+            path: ./langtest
+        - name: Execute Dry Run
+          run: |
+            mkdir -p test/temp
+            ./draft --dry-run --dry-run-file test/temp/dry-run.json             create -c ./test/integration/go/helm.yaml             -d ./langtest/ --skip-file-detection
+        - name: Validate JSON
+          run: |
+            npm install -g ajv-cli@5.0.0
+            ajv validate -s test/dry_run_schema.json -d test/temp/dry-run.json
+  go-helm-create-update:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: go-helm-dry-run
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v3
+        with:
+          repository: davidgamero/go-echo-no-mod
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/go/helm.yaml -d ./langtest/
+      - run: ./draft -b main -v generate-workflow -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Runs Helm to create manifest files
+      - name: Bake deployment
+        uses: azure/k8s-bake@v2.1
+        with:
+          renderEngine: 'helm'
+          helmChart: ./langtest/charts
+          overrideFiles: ./langtest/charts/values.yaml
+          overrides: |
+            replicas:2
+          helm-version: 'latest'
+        id: bake
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        uses: Azure/k8s-deploy@v3.0
+        continue-on-error: true
+        id: deploy
+        with:
+          action: deploy
+          manifests: ${{ steps.bake.outputs.manifestsBundle }}
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+      - name: Fail if any error
+        if: steps.deploy.outcome != 'success'
+        run: exit 6
+
+  go-kustomize-dry-run:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v3
+        with:
+          repository: davidgamero/go-echo-no-mod
+          path: ./langtest
+      - name: Execute Dry Run
+        run: |
+          mkdir -p test/temp
+          ./draft --dry-run --dry-run-file test/temp/dry-run.json           create -c ./test/integration/go/kustomize.yaml           -d ./langtest/ --skip-file-detection
+      - name: Validate JSON
+        run: |
+          npm install -g ajv-cli@5.0.0
+          ajv validate -s test/dry_run_schema.json -d test/temp/dry-run.json
+  go-kustomize-create-update:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: go-kustomize-dry-run
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v3
+        with:
+          repository: davidgamero/go-echo-no-mod
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/go/kustomize.yaml -d ./langtest/
+      - run: ./draft -v generate-workflow -b main -d ./langtest/ -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Bake deployment
+        uses: azure/k8s-bake@v2.1
+        with:
+          renderEngine: 'kustomize'
+          kustomizationPath: ./langtest/base
+          kubectl-version: 'latest'
+        id: bake
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp:curr ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        uses: Azure/k8s-deploy@v3.0
+        continue-on-error: true
+        id: deploy
+        with:
+          action: deploy
+          manifests: ${{ steps.bake.outputs.manifestsBundle }}
+          images: |
+            testapp:curr
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+      - name: Fail if any error
+        if: steps.deploy.outcome != 'success'
+        run: exit 6
+
+  go-manifest-dry-run:
+      runs-on: ubuntu-latest
+      needs: build
+      steps:
+        - uses: actions/checkout@v3
+        - uses: actions/download-artifact@v3
+          with:
+            name: draft-binary
+        - run: chmod +x ./draft
+        - run: mkdir ./langtest
+        - uses: actions/checkout@v3
+          with:
+            repository: davidgamero/go-echo-no-mod
+            path: ./langtest
+        - name: Execute Dry Run
+          run: |
+            mkdir -p test/temp
+            ./draft --dry-run --dry-run-file test/temp/dry-run.json             create -c ./test/integration/go/manifest.yaml             -d ./langtest/ --skip-file-detection
+        - name: Validate JSON
+          run: |
+            npm install -g ajv-cli@5.0.0
+            ajv validate -s test/dry_run_schema.json -d test/temp/dry-run.json
+  go-manifests-create:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    needs: go-manifest-dry-run
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v3
+        with:
+          repository: davidgamero/go-echo-no-mod
+          path: ./langtest
+      - run: rm -rf ./langtest/manifests && rm -f ./langtest/Dockerfile ./langtest/.dockerignore
+      - run: ./draft -v create -c ./test/integration/go/manifest.yaml -d ./langtest/
+      - run: ./draft -v generate-workflow -d ./langtest/ -b main -c someAksCluster -r someRegistry -g someResourceGroup --container-name someContainer
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+      - uses: actions/upload-artifact@v3
+        with:
+          name: go-manifests-create
+          path: ./langtest
+  go-manifest-update:
+    needs: go-manifests-create
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - run: chmod +x ./draft
+      - uses: actions/download-artifact@v3
+        with:
+          name: go-manifests-create
+          path: ./langtest/
+      - run: ./draft -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - name: start minikube
+        id: minikube
+        uses: medyagh/setup-minikube@master
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          eval $(minikube -p minikube docker-env)
+          docker build -f ./langtest/Dockerfile -t testapp ./langtest/
+          echo -n verifying images:
+          docker images
+      # Deploys application based on manifest files from previous step
+      - name: Deploy application
+        run: kubectl apply -f ./langtest/manifests/
+        continue-on-error: true
+        id: deploy
+      - name: Check default namespace
+        if: steps.deploy.outcome != 'success'
+        run: kubectl get po
+
   python-helm-dry-run:
       runs-on: ubuntu-latest
       needs: build
@@ -2934,21 +3198,21 @@ jobs:
 
   helm-integrations-summary:
       runs-on: ubuntu-latest
-      needs: [ gomodule-helm-create-update,python-helm-create-update,rust-helm-create-update,javascript-helm-create-update,ruby-helm-create-update,csharp-helm-create-update,java-helm-create-update,gradle-helm-create-update,swift-helm-create-update,erlang-helm-create-update,clojure-helm-create-update ]
+      needs: [ gomodule-helm-create-update,go-helm-create-update,python-helm-create-update,rust-helm-create-update,javascript-helm-create-update,ruby-helm-create-update,csharp-helm-create-update,java-helm-create-update,gradle-helm-create-update,swift-helm-create-update,erlang-helm-create-update,clojure-helm-create-update ]
       steps:
         - run: echo helm integrations passed
 
 
   kustomize-integrations-summary:
       runs-on: ubuntu-latest
-      needs: [ gomodule-kustomize-create-update,python-kustomize-create-update,rust-kustomize-create-update,javascript-kustomize-create-update,ruby-kustomize-create-update,csharp-kustomize-create-update,java-kustomize-create-update,gradle-kustomize-create-update,swift-kustomize-create-update,erlang-kustomize-create-update,clojure-kustomize-create-update ]
+      needs: [ gomodule-kustomize-create-update,go-kustomize-create-update,python-kustomize-create-update,rust-kustomize-create-update,javascript-kustomize-create-update,ruby-kustomize-create-update,csharp-kustomize-create-update,java-kustomize-create-update,gradle-kustomize-create-update,swift-kustomize-create-update,erlang-kustomize-create-update,clojure-kustomize-create-update ]
       steps:
         - run: echo kustomize integrations passed
 
 
   manifest-integrations-summary:
       runs-on: ubuntu-latest
-      needs: [ gomodule-manifest-update,python-manifest-update,rust-manifest-update,javascript-manifest-update,ruby-manifest-update,csharp-manifest-update,java-manifest-update,gradle-manifest-update,swift-manifest-update,erlang-manifest-update,clojure-manifest-update ]
+      needs: [ gomodule-manifest-update,go-manifest-update,python-manifest-update,rust-manifest-update,javascript-manifest-update,ruby-manifest-update,csharp-manifest-update,java-manifest-update,gradle-manifest-update,swift-manifest-update,erlang-manifest-update,clojure-manifest-update ]
       steps:
         - run: echo manifest integrations passed
 

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -138,6 +138,102 @@ jobs:
         working-directory: ./langtest/
       
 
+  go-helm-create:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v3
+        with:
+          repository: davidgamero/go-echo-no-mod
+          path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/go/helm.yaml -d ./langtest/
+      - uses: actions/download-artifact@v3
+        with:
+          name: check_windows_helm
+          path: ./langtest/
+      - run: ./check_windows_helm.ps1
+        working-directory: ./langtest/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: go-helm-create
+          path: ./langtest
+  go-helm-update:
+    needs: go-helm-create
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - uses: actions/download-artifact@v3
+        with:
+          name: go-helm-create
+          path: ./langtest/
+      - run: Remove-Item ./langtest/charts/templates/ingress.yaml -Recurse -Force -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v3
+        with:
+          name: check_windows_addon_helm
+          path: ./langtest/
+      - run: ./check_windows_addon_helm.ps1
+        working-directory: ./langtest/
+
+  go-kustomize-create:
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - run: mkdir ./langtest
+      - uses: actions/checkout@v3
+        with:
+          repository: davidgamero/go-echo-no-mod
+          path: ./langtest
+      - run: Remove-Item ./langtest/manifests -Recurse -Force -ErrorAction Ignore
+      - run: Remove-Item ./langtest/Dockerfile -ErrorAction Ignore
+      - run: Remove-Item ./langtest/.dockerignore -ErrorAction Ignore
+      - run: ./draft.exe -v create -c ./test/integration/go/kustomize.yaml -d ./langtest/
+      - uses: actions/download-artifact@v3
+        with:
+          name: check_windows_kustomize
+          path: ./langtest/
+      - run: ./check_windows_kustomize.ps1
+        working-directory: ./langtest/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: go-kustomize-create
+          path: ./langtest
+  go-kustomize-update:
+    needs: go-kustomize-create 
+    runs-on: windows-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: draft-binary
+      - uses: actions/download-artifact@v3
+        with:
+          name: go-kustomize-create
+          path: ./langtest
+      - run: Remove-Item ./langtest/overlays/production/ingress.yaml -ErrorAction Ignore
+      - run: ./draft.exe -v update -d ./langtest/ -a webapp_routing --variable ingress-tls-cert-keyvault-uri=test.cert.keyvault.uri --variable ingress-use-osm-mtls=true --variable ingress-host=host1
+      - uses: actions/download-artifact@v3
+        with:
+          name: check_windows_addon_kustomize
+          path: ./langtest/
+      - run: ./check_windows_addon_kustomize.ps1
+        working-directory: ./langtest/
+      
+
   python-helm-create:
     runs-on: windows-latest
     needs: build
@@ -1100,14 +1196,14 @@ jobs:
 
   helm-win-integrations-summary:
       runs-on: windows-latest
-      needs: [ gomodule-helm-update,python-helm-update,rust-helm-update,javascript-helm-update,ruby-helm-update,csharp-helm-update,java-helm-update,gradle-helm-update,swift-helm-update,erlang-helm-update,clojure-helm-update ]
+      needs: [ gomodule-helm-update,go-helm-update,python-helm-update,rust-helm-update,javascript-helm-update,ruby-helm-update,csharp-helm-update,java-helm-update,gradle-helm-update,swift-helm-update,erlang-helm-update,clojure-helm-update ]
       steps:
         - run: echo helm integrations passed
 
 
   kustomize-win-integrations-summary:
       runs-on: windows-latest
-      needs: [ gomodule-kustomize-update,python-kustomize-update,rust-kustomize-update,javascript-kustomize-update,ruby-kustomize-update,csharp-kustomize-update,java-kustomize-update,gradle-kustomize-update,swift-kustomize-update,erlang-kustomize-update,clojure-kustomize-update ]
+      needs: [ gomodule-kustomize-update,go-kustomize-update,python-kustomize-update,rust-kustomize-update,javascript-kustomize-update,ruby-kustomize-update,csharp-kustomize-update,java-kustomize-update,gradle-kustomize-update,swift-kustomize-update,erlang-kustomize-update,clojure-kustomize-update ]
       steps:
         - run: echo kustomize integrations passed
 

--- a/template/dockerfiles/go/Dockerfile
+++ b/template/dockerfiles/go/Dockerfile
@@ -5,6 +5,7 @@ EXPOSE {{PORT}}
 WORKDIR /go/src/app
 COPY . .
 
+ARG GO111MODULE=off
 RUN go get -d -v ./...
 RUN go build -v -o app ./...
 RUN mv ./app /go/bin/

--- a/test/integration/go/helm.yaml
+++ b/test/integration/go/helm.yaml
@@ -1,0 +1,17 @@
+# this file is generated using gen_integration.sh
+deployType: "Helm"
+languageType: "go"
+deployVariables:
+  - name: "PORT"
+    value: "8080"
+  - name: "SERVICEPORT"
+    value: "8080"
+  - name: "APPNAME"
+    value: "testapp"
+languageVariables:
+  - name: "VERSION"
+    value: "1.20"
+  - name: "BUILDERVERSION"
+    value: "null"
+  - name: "PORT"
+    value: "8080"

--- a/test/integration/go/kustomize.yaml
+++ b/test/integration/go/kustomize.yaml
@@ -1,0 +1,17 @@
+# this file is generated using gen_integration.sh
+deployType: "kustomize"
+languageType: "go"
+deployVariables:
+  - name: "PORT"
+    value: "8080"
+  - name: "SERVICEPORT"
+    value: "8080"
+  - name: "APPNAME"
+    value: "testapp"
+languageVariables:
+  - name: "VERSION"
+    value: "1.20"
+  - name: "BUILDERVERSION"
+    value: "null"
+  - name: "PORT"
+    value: "8080"

--- a/test/integration/go/manifest.yaml
+++ b/test/integration/go/manifest.yaml
@@ -1,0 +1,17 @@
+# this file is generated using gen_integration.sh
+deployType: "manifests"
+languageType: "go"
+deployVariables:
+  - name: "PORT"
+    value: "8080"
+  - name: "SERVICEPORT"
+    value: "8080"
+  - name: "APPNAME"
+    value: "testapp"
+languageVariables:
+  - name: "VERSION"
+    value: "1.20"
+  - name: "BUILDERVERSION"
+    value: "null"
+  - name: "PORT"
+    value: "8080"

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -7,6 +7,13 @@
     "repo": "gambtho/go_echo"
   },
   {
+    "language": "go",
+    "version": "1.20",
+    "port": "8080",
+    "serviceport": 8080,
+    "repo": "davidgamero/go-echo-no-mod"
+  },
+  {
     "language": "python",
     "version": "3",
     "port": "5000",


### PR DESCRIPTION
# Description

add the non-module supporting `go` dockerfile support to an integration test

## Type of change

Please delete options that are not relevant.

- [x] New features

# How Has This Been Tested?

- [x] New integration tests for `go` without modules

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

