### PR TITLE
gradle specific version in dockerfile

### DIFF
--- a/test/integration/gradle/helm.yaml
+++ b/test/integration/gradle/helm.yaml
@@ -14,6 +14,6 @@ languageVariables:
   - name: "VERSION"
     value: "11-jre"
   - name: "BUILDERVERSION"
-    value: "jdk11"
+    value: "7-jdk11"
   - name: "PORT"
     value: "8080"

--- a/test/integration/gradle/kustomize.yaml
+++ b/test/integration/gradle/kustomize.yaml
@@ -14,6 +14,6 @@ languageVariables:
   - name: "VERSION"
     value: "11-jre"
   - name: "BUILDERVERSION"
-    value: "jdk11"
+    value: "7-jdk11"
   - name: "PORT"
     value: "8080"

--- a/test/integration/gradle/manifest.yaml
+++ b/test/integration/gradle/manifest.yaml
@@ -14,6 +14,6 @@ languageVariables:
   - name: "VERSION"
     value: "11-jre"
   - name: "BUILDERVERSION"
-    value: "jdk11"
+    value: "7-jdk11"
   - name: "PORT"
     value: "8080"

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -62,7 +62,7 @@
     "builderversion": "7-jdk11",
     "port": "8080",
     "serviceport": 80,
-    "repo": "davidgamero/simple-gradle-server"
+    "repo": "imiller31/simple-gradle-server"
   },
   {
     "language": "swift",

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -59,10 +59,10 @@
   {
     "language": "gradle",
     "version": "11-jre",
-    "builderversion": "jdk11",
+    "builderversion": "7-jdk11",
     "port": "8080",
     "serviceport": 80,
-    "repo": "imiller31/simple-gradle-server"
+    "repo": "davidgamero/simple-gradle-server"
   },
   {
     "language": "swift",


### PR DESCRIPTION
# Description

Specify gradle version in the image tag with jdk

A previous image change updated the default tag to use the image `gradle` with tag `jdk11`, which doesn't specify a gradle version. Our demo repo uses gradle 7, so we need to specify this in the docker image tag by changing it to `7-jdk11`.

Long-term it could be beneficial to add better parsing to draft that allows us to detect which version of gradle a repo is using, since using the wrong version of gradle will prevent the image from building
The image tag can take a both values in the format  `<GRADLE VERSION>-jdk<JDK-VERSION>`

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing integration tests now pass with the updated image


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

