### PR TITLE
add reporeader interface and an example extractor for python

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -109,7 +109,6 @@ func (cc *createCmd) initConfig() error {
 
 	//TODO: create a config for the user and save it for subsequent uses
 	cc.createConfig = &CreateConfig{}
-	cc.repoReader = &readers.LocalFSReader{}
 
 	return nil
 }
@@ -134,6 +133,7 @@ func (cc *createCmd) run() error {
 	} else {
 		cc.templateWriter = &writers.LocalFSWriter{}
 	}
+	cc.repoReader = &readers.LocalFSReader{}
 
 	detectedLangDraftConfig, languageName, err := cc.detectLanguage()
 	if err != nil {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -109,6 +109,7 @@ func (cc *createCmd) initConfig() error {
 
 	//TODO: create a config for the user and save it for subsequent uses
 	cc.createConfig = &CreateConfig{}
+	cc.repoReader = &readers.LocalFSReader{}
 
 	return nil
 }
@@ -133,8 +134,6 @@ func (cc *createCmd) run() error {
 	} else {
 		cc.templateWriter = &writers.LocalFSWriter{}
 	}
-
-	cc.repoReader = &readers.LocalFSReader{}
 
 	detectedLangDraftConfig, languageName, err := cc.detectLanguage()
 	if err != nil {

--- a/pkg/filematches/filematches.go
+++ b/pkg/filematches/filematches.go
@@ -2,7 +2,6 @@ package filematches
 
 import (
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -44,7 +43,7 @@ func (f *FileMatches) walkFunc(path string, info os.FileInfo, err error) error {
 
 // TODO: maybe generalize this function in the future
 func isValidK8sFile(filePath string) bool {
-	fileContents, err := ioutil.ReadFile(filePath)
+	fileContents, err := os.ReadFile(filePath)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/languages/defaults/python.go
+++ b/pkg/languages/defaults/python.go
@@ -1,0 +1,34 @@
+package defaults
+
+import (
+	"fmt"
+
+	"github.com/Azure/draft/cmd"
+	"github.com/Azure/draft/pkg/reporeader"
+)
+
+type PythonExtractor struct {
+	cmd.CreateConfig
+}
+
+// ReadDefaults reads the default values for the language from the repo files
+func (p PythonExtractor) ReadDefaults(r reporeader.RepoReader) (map[string]string, error) {
+	extractedValues := make(map[string]string)
+	files, err := r.FindFiles(".", []string{"*.py"}, 2)
+	if err != nil {
+		return nil, fmt.Errorf("error finding python files: %v", err)
+	}
+	if len(files) > 0 {
+		extractedValues["ENTRYPOINT"] = files[0]
+	}
+
+	return extractedValues, nil
+}
+
+func (p PythonExtractor) MatchesLanguage(lowerlang string) bool {
+	return lowerlang == "python"
+}
+
+func (p PythonExtractor) GetName() string { return "python" }
+
+var _ reporeader.VariableExtractor = &PythonExtractor{}

--- a/pkg/languages/defaults/python.go
+++ b/pkg/languages/defaults/python.go
@@ -12,7 +12,7 @@ type PythonExtractor struct {
 // ReadDefaults reads the default values for the language from the repo files
 func (p PythonExtractor) ReadDefaults(r reporeader.RepoReader) (map[string]string, error) {
 	extractedValues := make(map[string]string)
-	files, err := r.FindFiles(".", []string{"*.py"}, 2)
+	files, err := r.FindFiles(".", []string{"*.py"}, 0)
 	if err != nil {
 		return nil, fmt.Errorf("error finding python files: %v", err)
 	}

--- a/pkg/languages/defaults/python.go
+++ b/pkg/languages/defaults/python.go
@@ -3,12 +3,10 @@ package defaults
 import (
 	"fmt"
 
-	"github.com/Azure/draft/cmd"
 	"github.com/Azure/draft/pkg/reporeader"
 )
 
 type PythonExtractor struct {
-	cmd.CreateConfig
 }
 
 // ReadDefaults reads the default values for the language from the repo files

--- a/pkg/languages/defaults/python_test.go
+++ b/pkg/languages/defaults/python_test.go
@@ -1,0 +1,117 @@
+package defaults
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/draft/pkg/reporeader"
+)
+
+func TestPythonExtractor_MatchesLanguage(t *testing.T) {
+	type args struct {
+		lowerlang string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "lowercase python",
+			args: args{
+				lowerlang: "python",
+			},
+			want: true,
+		},
+		{
+			name: "shouldn't match go",
+			args: args{
+				lowerlang: "go",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := PythonExtractor{}
+			if got := p.MatchesLanguage(tt.args.lowerlang); got != tt.want {
+				t.Errorf("MatchesLanguage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPythonExtractor_ReadDefaults(t *testing.T) {
+	type args struct {
+		r reporeader.RepoReader
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "extract first python file as entrypoint",
+			args: args{
+				r: reporeader.TestRepoReader{
+					Files: map[string][]byte{
+						"foo.py": []byte("print('hello world')"),
+						"bar.py": []byte("print('hello world')"),
+					},
+				},
+			},
+			want: map[string]string{
+				"ENTRYPOINT": "foo.py",
+			},
+			wantErr: false,
+		}, {
+			name: "no extraction if no python files",
+			args: args{
+				r: reporeader.TestRepoReader{
+					Files: map[string][]byte{
+						"foo.notpy": []byte("print('hello world')"),
+						"bar":       []byte("print('hello world')"),
+					},
+				},
+			},
+			want:    map[string]string{},
+			wantErr: false,
+		},
+		{
+			name: "empty extraction with no files",
+			args: args{
+				r: reporeader.TestRepoReader{
+					Files: map[string][]byte{},
+				},
+			},
+			want:    map[string]string{},
+			wantErr: false,
+		},
+		{
+			name: "ignore files below depth root depth",
+			args: args{
+				r: reporeader.TestRepoReader{
+					Files: map[string][]byte{
+						"dir/foo.py": []byte("print('hello world')"),
+					},
+				},
+			},
+			want:    map[string]string{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := PythonExtractor{}
+			got, err := p.ReadDefaults(tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadDefaults() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReadDefaults() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -6,9 +6,12 @@ import (
 	"io/fs"
 	"path"
 
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v3"
+
+	"github.com/Azure/draft/pkg/languages/defaults"
+	"github.com/Azure/draft/pkg/reporeader"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/Azure/draft/pkg/config"
 	"github.com/Azure/draft/pkg/embedutils"
@@ -112,4 +115,35 @@ func CreateLanguagesFromEmbedFS(dockerfileTemplates embed.FS, dest string) *Lang
 	l.PopulateConfigs()
 
 	return l
+}
+
+func (l *Languages) ExtractDefaults(lowerLang string, r reporeader.RepoReader) ([]config.BuilderVarDefault, error) {
+	extractors := []reporeader.VariableExtractor{
+		&defaults.PythonExtractor{},
+	}
+	extractedValues := make(map[string]string)
+	for _, extractor := range extractors {
+		if extractor.MatchesLanguage(lowerLang) {
+			newDefaults, err := extractor.ReadDefaults(r)
+			if err != nil {
+				return nil, fmt.Errorf("error reading defaults for language %s: %v", lowerLang, err)
+			}
+			for k, v := range newDefaults {
+				if _, ok := extractedValues[k]; ok {
+					log.Debugf("duplicate default %s for language %s with extractor %s", k, lowerLang, extractor.GetName())
+				}
+				extractedValues[k] = v
+			}
+		}
+	}
+
+	var extractedDefaults []config.BuilderVarDefault
+	for k, v := range extractedValues {
+		extractedDefaults = append(extractedDefaults, config.BuilderVarDefault{
+			Name:  k,
+			Value: v,
+		})
+	}
+
+	return extractedDefaults, nil
 }

--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -133,6 +133,7 @@ func (l *Languages) ExtractDefaults(lowerLang string, r reporeader.RepoReader) (
 					log.Debugf("duplicate default %s for language %s with extractor %s", k, lowerLang, extractor.GetName())
 				}
 				extractedValues[k] = v
+				log.Debugf("extracted default %s=%s with extractor:%s", k, v, extractor.GetName())
 			}
 		}
 	}

--- a/pkg/languages/languages.go
+++ b/pkg/languages/languages.go
@@ -122,6 +122,11 @@ func (l *Languages) ExtractDefaults(lowerLang string, r reporeader.RepoReader) (
 		&defaults.PythonExtractor{},
 	}
 	extractedValues := make(map[string]string)
+	var extractedDefaults []config.BuilderVarDefault
+	if r == nil {
+		log.Debugf("no repo reader provided, returning empty list of defaults")
+		return extractedDefaults, nil
+	}
 	for _, extractor := range extractors {
 		if extractor.MatchesLanguage(lowerLang) {
 			newDefaults, err := extractor.ReadDefaults(r)
@@ -138,7 +143,6 @@ func (l *Languages) ExtractDefaults(lowerLang string, r reporeader.RepoReader) (
 		}
 	}
 
-	var extractedDefaults []config.BuilderVarDefault
 	for k, v := range extractedValues {
 		extractedDefaults = append(extractedDefaults, config.BuilderVarDefault{
 			Name:  k,

--- a/pkg/reporeader/readers/localfsreader.go
+++ b/pkg/reporeader/readers/localfsreader.go
@@ -1,0 +1,70 @@
+package readers
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Azure/draft/pkg/reporeader"
+)
+
+type LocalFSReader struct {
+}
+
+type LocalFileFinder struct {
+	Patterns   []string
+	FoundFiles []string
+	MaxDepth   int
+}
+
+func (l *LocalFileFinder) walkFunc(path string, info os.DirEntry, err error) error {
+	if err != nil {
+		return err
+	}
+
+	// Skip directories that are too deep
+	if info.IsDir() && strings.Count(path, string(os.PathSeparator)) > l.MaxDepth {
+		fmt.Println("skip", path)
+		return fs.SkipDir
+	}
+
+	if info.IsDir() {
+		return nil
+	}
+
+	for _, pattern := range l.Patterns {
+		if matched, err := filepath.Match(pattern, filepath.Base(path)); err != nil {
+			return err
+		} else if matched {
+			l.FoundFiles = append(l.FoundFiles, path)
+		}
+	}
+	return nil
+}
+
+func (r *LocalFSReader) FindFiles(path string, patterns []string, maxDepth int) ([]string, error) {
+	l := LocalFileFinder{
+		Patterns: patterns,
+		MaxDepth: maxDepth,
+	}
+	err := filepath.WalkDir(path, l.walkFunc)
+	if err != nil {
+		return nil, err
+	}
+	return l.FoundFiles, nil
+}
+
+var _ reporeader.RepoReader = &LocalFSReader{}
+
+func (r *LocalFSReader) Exists(path string) bool {
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return true
+	}
+	return false
+}
+
+func (r *LocalFSReader) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/pkg/reporeader/reporeader.go
+++ b/pkg/reporeader/reporeader.go
@@ -1,5 +1,7 @@
 package reporeader
 
+import "path/filepath"
+
 type RepoReader interface {
 	Exists(path string) bool
 	ReadFile(path string) ([]byte, error)
@@ -11,4 +13,43 @@ type VariableExtractor interface {
 	ReadDefaults(r RepoReader) (map[string]string, error)
 	MatchesLanguage(lowerlang string) bool
 	GetName() string
+}
+
+type TestRepoReader struct {
+	Files map[string][]byte
+}
+
+func (r TestRepoReader) Exists(path string) bool {
+	if r.Files != nil {
+		_, ok := r.Files[path]
+		return ok
+	}
+	return false
+}
+
+func (r TestRepoReader) ReadFile(path string) ([]byte, error) {
+	if r.Files != nil {
+		return r.Files[path], nil
+	}
+	return nil, nil
+}
+
+func (r TestRepoReader) FindFiles(path string, patterns []string, maxDepth int) ([]string, error) {
+	var files []string
+	if r.Files == nil {
+		return files, nil
+	}
+	for k := range r.Files {
+		for _, pattern := range patterns {
+			if matched, err := filepath.Match(pattern, filepath.Base(k)); err != nil {
+				return nil, err
+			} else if matched {
+				fileDepth := len(filepath.SplitList(k))
+				if fileDepth < maxDepth {
+					files = append(files, k)
+				}
+			}
+		}
+	}
+	return files, nil
 }

--- a/pkg/reporeader/reporeader.go
+++ b/pkg/reporeader/reporeader.go
@@ -1,10 +1,15 @@
 package reporeader
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"strings"
+)
 
 type RepoReader interface {
 	Exists(path string) bool
 	ReadFile(path string) ([]byte, error)
+	// FindFiles returns a list of files that match the given patterns searching up to
+	// maxDepth nested sub-directories. maxDepth of 0 limits files to the root dir.
 	FindFiles(path string, patterns []string, maxDepth int) ([]string, error)
 }
 
@@ -15,6 +20,7 @@ type VariableExtractor interface {
 	GetName() string
 }
 
+// TestRepoReader is a RepoReader that can be used for testing, and takes a list of relative file paths with their contents
 type TestRepoReader struct {
 	Files map[string][]byte
 }
@@ -44,8 +50,9 @@ func (r TestRepoReader) FindFiles(path string, patterns []string, maxDepth int) 
 			if matched, err := filepath.Match(pattern, filepath.Base(k)); err != nil {
 				return nil, err
 			} else if matched {
-				fileDepth := len(filepath.SplitList(k))
-				if fileDepth < maxDepth {
+				splitPath := strings.Split(k, string(filepath.Separator))
+				fileDepth := len(splitPath) - 1
+				if fileDepth <= maxDepth {
 					files = append(files, k)
 				}
 			}

--- a/pkg/reporeader/reporeader.go
+++ b/pkg/reporeader/reporeader.go
@@ -1,0 +1,14 @@
+package reporeader
+
+type RepoReader interface {
+	Exists(path string) bool
+	ReadFile(path string) ([]byte, error)
+	FindFiles(path string, patterns []string, maxDepth int) ([]string, error)
+}
+
+// VariableExtractor is an interface that can be implemented for extracting variables from a repo's files
+type VariableExtractor interface {
+	ReadDefaults(r RepoReader) (map[string]string, error)
+	MatchesLanguage(lowerlang string) bool
+	GetName() string
+}


### PR DESCRIPTION
# Description

add a new interface and pattern for extracting defaults from a repo in draft.
the current pattern only supports using pre- set defaults, which can then be replaced by a user-provided value.

Similar to the way the `TemplateWriter` interface was used to abstract the filesystem writing operations, this PR introduces the `RepoReader` interface that abstracts reading data from a repo's files.

The main goal of this is to allow more intelligent defaults such as detecting a compatible image version or entrypoint script by reading the files in a repo during `draft create` execution.

By allowing prompt defaults to be set through extracting information from the repo files, we can greatly improve the probability that a default value is correct.
An example of this is the great work on #214  that could leverage this interface to standardize how we read data from the repo and organize the procedure using `extractors` that each apply to specific languages

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Existing unit and integration tests pass

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

