### PR TITLE
bump rust version to fix e2e

### DIFF
--- a/template/dockerfiles/rust/draft.yaml
+++ b/template/dockerfiles/rust/draft.yaml
@@ -9,9 +9,9 @@ variables:
     type: int
   - name: "VERSION"
     description: "the version of rust used by the application"
-    exampleValues: ["1.58.0","1.56", "1.55", "1.54", "1.53"]
+    exampleValues: ["1.60.0","1.58", "1.56", "1.54", "1.53"]
 variableDefaults:
   - name: "VERSION"
-    value: "1.58.0"
+    value: "1.60.0"
   - name: "PORT"
     value: "80"

--- a/template/dockerfiles/rust/draft.yaml
+++ b/template/dockerfiles/rust/draft.yaml
@@ -9,9 +9,9 @@ variables:
     type: int
   - name: "VERSION"
     description: "the version of rust used by the application"
-    exampleValues: ["1.60.0","1.58", "1.56", "1.54", "1.53"]
+    exampleValues: ["1.70.0","1.65.0", "1.60", "1.54", "1.53"]
 variableDefaults:
   - name: "VERSION"
-    value: "1.60.0"
+    value: "1.70.0"
   - name: "PORT"
     value: "80"

--- a/test/integration/rust/helm.yaml
+++ b/test/integration/rust/helm.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.59.0"
+    value: "1.60.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/helm.yaml
+++ b/test/integration/rust/helm.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.60.0"
+    value: "1.70.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/kustomize.yaml
+++ b/test/integration/rust/kustomize.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.59.0"
+    value: "1.60.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/kustomize.yaml
+++ b/test/integration/rust/kustomize.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.60.0"
+    value: "1.70.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/manifest.yaml
+++ b/test/integration/rust/manifest.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.59.0"
+    value: "1.60.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/manifest.yaml
+++ b/test/integration/rust/manifest.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.60.0"
+    value: "1.70.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"


### PR DESCRIPTION
# Description

The current default rust version is no longer compatible with the required packages, causing cargo to fail. This bumps it to a compatible version

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

