### PR TITLE
retry releases to get tag name

### DIFF
--- a/.github/workflows/integration-install.yml
+++ b/.github/workflows/integration-install.yml
@@ -11,9 +11,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Get Draft Cli version
+        uses: actions/github-script@v6
+        id: get_draft_version
+        with:
+          result-encoding: string
+          retries : 3
+          script: |
+            const tag_url = context.payload.repository.releases_url.replace('{/id}', '/latest');
+            const response = await github.request(tag_url);
+            return response.data.tag_name;
       - name: Run Install Script
         shell: bash
         run: ./scripts/install.sh
+        env:
+          DRAFT_CLI_VERSION: ${{ steps.get_draft_version.outputs.result }}
       - name: Validate Command is Installed
         shell: bash
         run: |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,12 +112,30 @@ download_draft_cli_stable_version(){
     FILENAME="draft-$OS-$ARCH"
   fi
   log INFO "Starting Draft CLI Download for $FILENAME"
-  DRAFTCLIVERSION=$(curl -L -s https://api.github.com/repos/Azure/draft/releases/latest | jq -r '.tag_name')
-  log INFO "Starting Draft CLI Version $DRAFTCLIVERSION"
+  get_draft_cli_version
   DRAFTCLIURL="https://github.com/Azure/draft/releases/download/$DRAFTCLIVERSION/$FILENAME"
   curl -o /tmp/draftcli -fLO $DRAFTCLIURL
   chmod +x /tmp/draftcli
   log INFO "Finished Draft CLI download complete."
+}
+
+get_draft_cli_version() {
+  retry=0
+  log INFO "Getting Draft CLI version"
+  while [ -z "${DRAFTCLIVERSION}" ];
+  do 
+    DRAFTCLIVERSION=$(curl -L -s https://api.github.com/repos/Azure/draft/releases/latest | jq -r '.tag_name')
+    if [ -z "${DRAFTCLIVERSION}" ]; then
+      log INFO "Unable to get Draft CLI version"
+      retry=$((retry++))
+      if [ $retry -eq 5 ]; then
+        log ERROR "Unable to get Draft CLI version"
+        exit 1
+      fi
+      sleep 5
+    fi
+  done
+  log INFO "Draft CLI Version $DRAFTCLIVERSION"
 }
 
 file_issue_prompt() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,30 +112,15 @@ download_draft_cli_stable_version(){
     FILENAME="draft-$OS-$ARCH"
   fi
   log INFO "Starting Draft CLI Download for $FILENAME"
-  get_draft_cli_version
-  DRAFTCLIURL="https://github.com/Azure/draft/releases/download/$DRAFTCLIVERSION/$FILENAME"
+  # For Github actions integration-install tests DRAFT_CLI_VERSION will be set an env variable i.e., check integration-install.yml, but when the user runs the script locally, it will be empty.
+  if [ -z "${DRAFT_CLI_VERSION}" ]; then
+    DRAFT_CLI_VERSION=$(curl -L -s https://api.github.com/repos/Azure/draft/releases/latest | jq -r '.tag_name')
+  fi
+  log INFO "Draft CLI Version $DRAFT_CLI_VERSION"
+  DRAFTCLIURL="https://github.com/Azure/draft/releases/download/$DRAFT_CLI_VERSION/$FILENAME"
   curl -o /tmp/draftcli -fLO $DRAFTCLIURL
   chmod +x /tmp/draftcli
   log INFO "Finished Draft CLI download complete."
-}
-
-get_draft_cli_version() {
-  retry=0
-  log INFO "Getting Draft CLI version"
-  while [ -z "${DRAFTCLIVERSION}" ];
-  do 
-    DRAFTCLIVERSION=$(curl -L -s https://api.github.com/repos/Azure/draft/releases/latest | jq -r '.tag_name')
-    if [ -z "${DRAFTCLIVERSION}" ]; then
-      log INFO "Unable to get Draft CLI version"
-      retry=$((retry++))
-      if [ $retry -eq 5 ]; then
-        log ERROR "Unable to get Draft CLI version"
-        exit 1
-      fi
-      sleep 5
-    fi
-  done
-  log INFO "Draft CLI Version $DRAFTCLIVERSION"
 }
 
 file_issue_prompt() {


### PR DESCRIPTION
# Description

This PR is to fix the issue where GH action for install script fails intermittent, introducing retry will retry getting the tag name from releases.  

Root cause: due to github rate limiting for unauthenticated requests , it is failing with below error. Fixing this with authenticated requests using github token from env variable. 

![image](https://github.com/Azure/draft/assets/105889062/77640d52-6c3c-4f1c-8037-14771e6021a0)
 

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [x] Manual Test via GH actions



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

