### PR TITLE
fix: query resource group under giving subscription id

### DIFF
--- a/pkg/providers/azure.go
+++ b/pkg/providers/azure.go
@@ -203,7 +203,7 @@ func (sc *SetUpCmd) ValidateSetUpConfig() error {
 		return err
 	}
 
-	if err := isValidResourceGroup(sc.ResourceGroupName); err != nil {
+	if err := isValidResourceGroup(sc.SubscriptionID, sc.ResourceGroupName); err != nil {
 		return err
 	}
 

--- a/pkg/providers/providersutils.go
+++ b/pkg/providers/providersutils.go
@@ -167,16 +167,19 @@ func IsSubscriptionIdValid(subscriptionId string) error {
 	return nil
 }
 
-func isValidResourceGroup(resourceGroup string) error {
+func isValidResourceGroup(
+	subscriptionId string,
+	resourceGroup string,
+) error {
 	if resourceGroup == "" {
 		return errors.New("resource group cannot be empty")
 	}
 
 	query := fmt.Sprintf("[?name=='%s']", resourceGroup)
-	getResourceGroupCmd := exec.Command("az", "group", "list", "--query", query)
+	getResourceGroupCmd := exec.Command("az", "group", "list", "--subscription", subscriptionId, "--query", query)
 	out, err := getResourceGroupCmd.CombinedOutput()
 	if err != nil {
-		log.Errorf("failed to validate resourcegroup: %s", err)
+		log.Errorf("failed to validate resource group %q from subscription %q: %s", resourceGroup, subscriptionId, err)
 		return err
 	}
 
@@ -186,7 +189,7 @@ func isValidResourceGroup(resourceGroup string) error {
 	}
 
 	if len(rg) == 0 {
-		return errors.New("resource group not found")
+		return fmt.Errorf("resource group %q not found from subscription %q", resourceGroup, subscriptionId)
 	}
 
 	return nil


### PR DESCRIPTION
# Description

When there are multiple subscriptions under the local azure account, the `setup-gh` command would fail to discover the correct resource group with error like this:

```
Error: resource group not found
```

This is because the resource group validation logic is expecting 1) the local `azcli` has fetched all subscriptions 2) the resource group is created under the active subscription. However these assumptions are incorrect when running with command like this:

```
$ draft setup-gh -s <my-sub-id> -g <my-rg-name>
```

To get the resource group correctly, this pull request added `--subscription` parameter on the query command. I also enhanced the error message a bit to provide more details on missing resource group error.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested this change from my local with above command.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

