### PR TITLE
Changes in correlation with new GH Action Permission Changes.

### DIFF
--- a/.github/workflows/e2e-info.yml
+++ b/.github/workflows/e2e-info.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/integration-install.yml
+++ b/.github/workflows/integration-install.yml
@@ -9,6 +9,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
     steps:
       - uses: actions/checkout@v3
       - name: Get Draft Cli version

--- a/.github/workflows/integration-json.yml
+++ b/.github/workflows/integration-json.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
     steps:
       - uses: actions/checkout@v2
       - name: Set up Go

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      packages: none
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go

--- a/.github/workflows/poll-starter.yml
+++ b/.github/workflows/poll-starter.yml
@@ -12,6 +12,12 @@ env:
 jobs:
   poll:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      deployments: read
+      pull-requests: write
+      packages: none
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -10,6 +10,11 @@ jobs:
   Release-Artifacts:
     name: Draft Release
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      deployments: read
+      packages: none
     steps:
     # Checkout code
     - name: Checkout


### PR DESCRIPTION
These changes are made in correlation with the following changes coming soon in the GH actions permissions. Please take a kind look. ❤️🙏☕️

* https://docs.opensource.microsoft.com/github/apps/permission-changes/

To start with going with the most safest option with read only permission, for `publish` we need the `write for content`. Given this will spread pretty soon lets try this out and I will gradually open similarity changes in other repos I know.

<img width="676" alt="Screenshot 2024-01-22 at 11 41 38 AM" src="https://github.com/Azure/vscode-bridge-to-kubernetes/assets/6233295/5106db83-6dcd-41ac-942a-90a03cfaac96">

For, release only workflow **Sample test** if we do `content: read` for publish we will get some error like this which I tested in my fork for other project.

<img width="1714" alt="Screenshot 2024-01-22 at 11 27 19 AM" src="https://github.com/Azure/vscode-bridge-to-kubernetes/assets/6233295/b00462d5-d971-43d2-9c06-0d7c65f6b91c">

Thank you. ❤️🙏
