### PR TITLE
update draft to go 1.22

### DIFF
--- a/.github/workflows/e2e-info.yml
+++ b/.github/workflows/e2e-info.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.2
+          go-version: 1.22
       - name: make
         run: make
       - name: Validate JSON

--- a/.github/workflows/integration-install.yml
+++ b/.github/workflows/integration-install.yml
@@ -43,9 +43,9 @@ jobs:
           elif command -v /c/Users/runneradmin/.local/bin/draft &> /dev/null
           then
             echo "install_dir=/c/Users/runneradmin/.local/bin/draft" >> $GITHUB_ENV
-          elif command -v /Users/runner/.local/bin &> /dev/null
+          elif command -v /c/Users/runner/.local/bin &> /dev/null
           then
-            echo "install_dir=/Users/runner/.local/bin" >> $GITHUB_ENV
+            echo "install_dir=/c/Users/runner/.local/bin" >> $GITHUB_ENV
           else 
             echo "draft could not be found"
             exit 1

--- a/.github/workflows/integration-install.yml
+++ b/.github/workflows/integration-install.yml
@@ -43,6 +43,9 @@ jobs:
           elif command -v /c/Users/runneradmin/.local/bin/draft &> /dev/null
           then
             echo "install_dir=/c/Users/runneradmin/.local/bin/draft" >> $GITHUB_ENV
+          elif command -v /Users/runner/.local/bin &> /dev/null
+          then
+            echo "install_dir=/Users/runner/.local/bin" >> $GITHUB_ENV
           else 
             echo "draft could not be found"
             exit 1

--- a/.github/workflows/integration-install.yml
+++ b/.github/workflows/integration-install.yml
@@ -43,9 +43,9 @@ jobs:
           elif command -v /c/Users/runneradmin/.local/bin/draft &> /dev/null
           then
             echo "install_dir=/c/Users/runneradmin/.local/bin/draft" >> $GITHUB_ENV
-          elif command -v /c/Users/runner/.local/bin &> /dev/null
+          elif command -v /Users/runner/.local/bin &> /dev/null
           then
-            echo "install_dir=/c/Users/runner/.local/bin" >> $GITHUB_ENV
+            echo "install_dir=/Users/runner/.local/bin" >> $GITHUB_ENV
           else 
             echo "draft could not be found"
             exit 1

--- a/.github/workflows/integration-install.yml
+++ b/.github/workflows/integration-install.yml
@@ -43,9 +43,9 @@ jobs:
           elif command -v /c/Users/runneradmin/.local/bin/draft &> /dev/null
           then
             echo "install_dir=/c/Users/runneradmin/.local/bin/draft" >> $GITHUB_ENV
-          elif command -v /Users/runner/.local/bin &> /dev/null
+          elif command -v /Users/runner/.local/bin/draft &> /dev/null
           then
-            echo "install_dir=/Users/runner/.local/bin" >> $GITHUB_ENV
+            echo "install_dir=/Users/runner/.local/bin/draft" >> $GITHUB_ENV
           else 
             echo "draft could not be found"
             exit 1

--- a/.github/workflows/integration-json.yml
+++ b/.github/workflows/integration-json.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.2
+          go-version: 1.22
       - name: make
         run: make
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -7,17 +7,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      deployments: read
-      packages: none
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.2
+          go-version: 1.22
       - name: make
         run: make
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -2,7 +2,7 @@
 name: draft Linux Integrations
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, staging ]
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -6,17 +6,12 @@ on:
 jobs:
   build:
     runs-on: windows-latest
-    permissions:
-      actions: read
-      contents: read
-      deployments: read
-      packages: none
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.22
       - name: make
         run: make
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -1,7 +1,7 @@
 name: draft Windows Integrations
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request:
+    branches: [ main, staging ]
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.18.2
+        go-version: 1.22
     # Check if the newest tag already exists
     - name: Check if tag exist
       uses: mukunku/tag-exists-action@5dfe2bf779fe5259360bb10b2041676713dcc8a3 # v1.1.0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,6 +14,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.22
       - name: make
         run: make run-unit-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine
+FROM golang:1.22-alpine
 
 WORKDIR /draft
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,16 @@ FROM golang:1.22-alpine
 
 WORKDIR /draft
 
-RUN apk add build-base
+RUN apk add gcc musl-dev python3-dev libffi-dev openssl-dev cargo make
 RUN apk add py3-pip
-RUN apk add python3-dev libffi-dev openssl-dev cargo
-RUN pip install --upgrade pip
-RUN pip install azure-cli
+
+RUN python3 -m venv az-cli-env
+RUN az-cli-env/bin/pip install --upgrade pip
+RUN az-cli-env/bin/pip install --upgrade azure-cli
+RUN az-cli-env/bin/az --version
+
+ENV PATH "$PATH:/draft/az-cli-env/bin"
+
 RUN apk add github-cli
 
 COPY . ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/draft
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/draft
 
-go 1.18
+go 1.22
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/draft
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -158,8 +158,9 @@ install() {
       exit 1
   fi
 
-  if [[ "$ARCH" != "x86_64" ]]; then
-       echo "Draft CLI is only available for linux x86_64 architecture"
+  log INFO "validating ARCH: $ARCH"
+  if [[ "$ARCH" != "x86_64" && "$ARCH" != "arm64" ]]; then
+       echo "Draft CLI is only available for linux x86_64 and arm64 architecture"
        file_issue_prompt
        exit 1
   fi

--- a/template/dockerfiles/go/Dockerfile
+++ b/template/dockerfiles/go/Dockerfile
@@ -6,8 +6,7 @@ WORKDIR /go/src/app
 COPY . .
 
 ARG GO111MODULE=off
-RUN go get -d -v ./...
-RUN go build -v -o app ./...
+RUN go build -v -o app ./main.go
 RUN mv ./app /go/bin/
 
 CMD ["app"]

--- a/template/dockerfiles/gomodule/Dockerfile
+++ b/template/dockerfiles/gomodule/Dockerfile
@@ -5,7 +5,7 @@ EXPOSE {{PORT}}
 WORKDIR /go/src/app
 COPY . .
 
-RUN go mod vendor
+RUN go get
 RUN go build -v -o app
 RUN mv ./app /go/bin/
 

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -26,7 +26,7 @@ echo "# this file is generated using gen_integration.sh
 name: draft Linux Integrations
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, staging ]
   workflow_dispatch:
 jobs:
   build:
@@ -52,8 +52,8 @@ jobs:
 
 echo "name: draft Windows Integrations
 on:
-  pull_request_review:
-    types: [submitted]
+  pull_request:
+    branches: [ main, staging ]
   workflow_dispatch:
 jobs:
   build:

--- a/test/gen_integration.sh
+++ b/test/gen_integration.sh
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18.2
+          go-version: 1.22
       - name: make
         run: make
       - uses: actions/upload-artifact@v3
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.22
       - name: make
         run: make
       - uses: actions/upload-artifact@v3

--- a/test/integration/go/helm.yaml
+++ b/test/integration/go/helm.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.20"
+    value: "1.22"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/go/helm.yaml
+++ b/test/integration/go/helm.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.22"
+    value: "1.22.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/go/kustomize.yaml
+++ b/test/integration/go/kustomize.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.20"
+    value: "1.22"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/go/kustomize.yaml
+++ b/test/integration/go/kustomize.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.22"
+    value: "1.22.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/go/manifest.yaml
+++ b/test/integration/go/manifest.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.20"
+    value: "1.22"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/go/manifest.yaml
+++ b/test/integration/go/manifest.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.22"
+    value: "1.22.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/gomodule/helm.yaml
+++ b/test/integration/gomodule/helm.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.22"
+    value: "1.22.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/gomodule/helm.yaml
+++ b/test/integration/gomodule/helm.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.18"
+    value: "1.22"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/gomodule/kustomize.yaml
+++ b/test/integration/gomodule/kustomize.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.22"
+    value: "1.22.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/gomodule/kustomize.yaml
+++ b/test/integration/gomodule/kustomize.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.18"
+    value: "1.22"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/gomodule/manifest.yaml
+++ b/test/integration/gomodule/manifest.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.22"
+    value: "1.22.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/gomodule/manifest.yaml
+++ b/test/integration/gomodule/manifest.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.18"
+    value: "1.22"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/helm.yaml
+++ b/test/integration/rust/helm.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.70.0"
+    value: "1.60.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/helm.yaml
+++ b/test/integration/rust/helm.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.60.0"
+    value: "1.77.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/kustomize.yaml
+++ b/test/integration/rust/kustomize.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.70.0"
+    value: "1.60.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/kustomize.yaml
+++ b/test/integration/rust/kustomize.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.60.0"
+    value: "1.77.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/manifest.yaml
+++ b/test/integration/rust/manifest.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.70.0"
+    value: "1.60.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration/rust/manifest.yaml
+++ b/test/integration/rust/manifest.yaml
@@ -12,7 +12,7 @@ deployVariables:
     value: "host.minikube.internal:5001/testapp"
 languageVariables:
   - name: "VERSION"
-    value: "1.60.0"
+    value: "1.77.0"
   - name: "BUILDERVERSION"
     value: "null"
   - name: "PORT"

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -1,14 +1,14 @@
 [
   {
     "language": "gomodule",
-    "version": "1.18",
+    "version": "1.22",
     "port": "1323",
     "serviceport": 80,
     "repo": "gambtho/go_echo"
   },
   {
     "language": "go",
-    "version": "1.20",
+    "version": "1.22",
     "port": "8080",
     "serviceport": 8080,
     "repo": "davidgamero/go-echo-no-mod"

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -22,7 +22,7 @@
   },
   {
     "language": "rust",
-    "version": "1.59.0",
+    "version": "1.60.0",
     "port": "8000",
     "serviceport": 80,
     "repo": "OliverMKing/tiny-http-hello-world"

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -1,14 +1,14 @@
 [
   {
     "language": "gomodule",
-    "version": "1.22",
+    "version": "1.22.0",
     "port": "1323",
     "serviceport": 80,
     "repo": "gambtho/go_echo"
   },
   {
     "language": "go",
-    "version": "1.22",
+    "version": "1.22.0",
     "port": "8080",
     "serviceport": 8080,
     "repo": "davidgamero/go-echo-no-mod"

--- a/test/integration_config.json
+++ b/test/integration_config.json
@@ -22,7 +22,7 @@
   },
   {
     "language": "rust",
-    "version": "1.60.0",
+    "version": "1.77.0",
     "port": "8000",
     "serviceport": 80,
     "repo": "OliverMKing/tiny-http-hello-world"


### PR DESCRIPTION
Update draft to go 1.22

Update go non-module dockerfile template as the entrypoint file is needed it is hard-coded to `main.go`- this can be updated later to use the ENTRYPOINT variable