### PR TITLE
adding logic for generating default app name

### DIFF
--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -198,13 +198,8 @@ func RunDefaultableStringPrompt(customPrompt config.BuilderVar, defaultValue str
 		return nil
 	}
 
-	defaultString := ""
-	if defaultValue != "" {
-		defaultString = " (default: " + defaultValue + ")"
-	}
-
 	prompt := &promptui.Prompt{
-		Label:    "Please enter " + customPrompt.Description + defaultString,
+		Label:    "Please enter " + customPrompt.Description + " (default: " + defaultValue + ")",
 		Validate: validatorFunc,
 		Stdin:    Stdin,
 		Stdout:   Stdout,

--- a/pkg/prompts/prompts.go
+++ b/pkg/prompts/prompts.go
@@ -325,12 +325,12 @@ func sanitizeAppName(name string) string {
 	if sanitized == "" {
 		sanitized = defaultAppName
 	} else {
-		// Trim leading and trailing '-', '_', '.'
-		sanitized = strings.Trim(sanitized, "-._")
 		// Ensure the length does not exceed 63 characters
 		if len(sanitized) > 63 {
 			sanitized = sanitized[:63]
 		}
+		// Trim leading and trailing '-', '_', '.'
+		sanitized = strings.Trim(sanitized, "-._")
 	}
 	return sanitized
 }


### PR DESCRIPTION
# Description

Prompt the user to enter the application name.
Sanitize the user input.
If the user does not provide any input, uses the current directory name as the default.
Sanitize the directory name and ensure it meets the K8s label standards.
If neither the user input nor the directory name meets the standards, default to "my-app".

If the user input is empty it defaults to the directory name
<img width="1123" alt="Screenshot 2024-06-07 at 11 56 42 AM" src="https://github.com/Azure/draft/assets/59590642/d30bbc7e-6409-4654-8f68-26d547e89feb">

validator for app name
<img width="1004" alt="Screenshot 2024-06-07 at 5 24 57 PM" src="https://github.com/Azure/draft/assets/59590642/8c9ee793-31db-4cab-9a2f-86b7f2f0fe28">


Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

