### PR TITLE
Added k8s/deploy Inputs for Private Cluster Support

### DIFF
--- a/template/workflows/helm/.github/workflows/azure-kubernetes-service-helm.yml
+++ b/template/workflows/helm/.github/workflows/azure-kubernetes-service-helm.yml
@@ -134,5 +134,7 @@ jobs:
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
           images: |
             ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
-          namespace: ${{ env.NAMESPACE }}
+          resource-group: ${{ env.CLUSTER_RESOURCE_GROUP }}
+          name: ${{ env.CLUSTER_NAME }}
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER }}
+          namespace: ${{ env.NAMESPACE }}

--- a/template/workflows/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
+++ b/template/workflows/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
@@ -129,5 +129,7 @@ jobs:
           manifests: ${{ steps.bake.outputs.manifestsBundle }}
           images: |
             ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
-          namespace: ${{ env.NAMESPACE }}
+          resource-group: ${{ env.CLUSTER_RESOURCE_GROUP }}
+          name: ${{ env.CLUSTER_NAME }}
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER }}
+          namespace: ${{ env.NAMESPACE }}

--- a/template/workflows/manifests/.github/workflows/azure-kubernetes-service.yml
+++ b/template/workflows/manifests/.github/workflows/azure-kubernetes-service.yml
@@ -116,6 +116,8 @@ jobs:
           manifests: ${{ env.DEPLOYMENT_MANIFEST_PATH }}
           images: |
             ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }}
-          namespace: ${{ env.NAMESPACE }}
+          resource-group: ${{ env.CLUSTER_RESOURCE_GROUP }}
+          name: ${{ env.CLUSTER_NAME }}
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER }}
+          namespace: ${{ env.NAMESPACE }}
           


### PR DESCRIPTION
# Description

This PR adds the resource group and cluster name fields to the k8s/deploy action within the workflow templates. These are necessary as k8s/deploy requires them to run az aks command invoke for kubectl commands within the private cluster.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. Is it a  breaking change which will impact consuming tool(s).

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

