### PR TITLE
Replacing ManifestFile Path property with []byte content

### DIFF
--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -60,8 +60,6 @@ func TestRunValidate(t *testing.T) {
 	assert.Greater(t, numViolations, 0)
 
 	// Scenario 4: Test Helm
-	makeTempDir(t)
-	t.Cleanup(func() { cleanupDir(t, tempDir) })
 
 	manifestFiles, err = preprocessing.GetManifestFiles(chartPath)
 	assert.Nil(t, err)
@@ -85,14 +83,11 @@ func TestRunValidate_Kustomize(t *testing.T) {
 	kustomizationPath, _ := filepath.Abs("../pkg/safeguards/tests/kustomize/overlays/production")
 	kustomizationFilePath, _ := filepath.Abs("../pkg/safeguards/tests/kustomize/overlays/production/kustomization.yaml")
 
-	makeTempDir(t)
-	t.Cleanup(func() { cleanupDir(t, tempDir) })
-
 	var manifestFiles []types.ManifestFile
 	var err error
 
 	// Scenario 1a: kustomizationPath leads to a directory containing kustomization.yaml - expect success
-	manifestFiles, err = preprocessing.RenderKustomizeManifest(kustomizationPath, tempDir)
+	manifestFiles, err = preprocessing.RenderKustomizeManifest(kustomizationPath)
 	assert.Nil(t, err)
 	v, err := safeguards.GetManifestResults(ctx, manifestFiles)
 	assert.Nil(t, err)
@@ -100,7 +95,7 @@ func TestRunValidate_Kustomize(t *testing.T) {
 	assert.Equal(t, numViolations, 1)
 
 	// Scenario 1b: kustomizationFilePath path leads to a specific kustomization.yaml - expect success
-	manifestFiles, err = preprocessing.RenderKustomizeManifest(kustomizationFilePath, tempDir)
+	manifestFiles, err = preprocessing.RenderKustomizeManifest(kustomizationFilePath)
 	assert.Nil(t, err)
 	v, err = safeguards.GetManifestResults(ctx, manifestFiles)
 	assert.Nil(t, err)

--- a/cmd/validate_test_helpers.go
+++ b/cmd/validate_test_helpers.go
@@ -1,14 +1,8 @@
 package cmd
 
 import (
-	"os"
-	"path/filepath"
-	"testing"
-
-	types "github.com/Azure/draft/pkg/safeguards/types"
+	"github.com/Azure/draft/pkg/safeguards/types"
 )
-
-var tempDir, _ = filepath.Abs("./testdata")
 
 const (
 	chartPath         = "../pkg/safeguards/tests/testmanifests/validchart"
@@ -22,17 +16,4 @@ func countTestViolations(results []types.ManifestResult) int {
 	}
 
 	return numViolations
-}
-
-func makeTempDir(t *testing.T) {
-	if err := os.MkdirAll(tempDir, 0755); err != nil {
-		t.Fatalf("failed to create temporary output directory: %s", err)
-	}
-}
-
-func cleanupDir(t *testing.T, dir string) {
-	err := os.RemoveAll(dir)
-	if err != nil {
-		t.Fatalf("Failed to clean directory: %s", err)
-	}
 }

--- a/pkg/safeguards/helpers.go
+++ b/pkg/safeguards/helpers.go
@@ -125,7 +125,6 @@ func GetManifestFiles(p string) ([]c.ManifestFile, error) {
 			return fmt.Errorf("error walking path %s with error: %w", walkPath, err)
 		}
 
-		fmt.Println("walkPath: ", walkPath)
 		if !info.IsDir() && info.Name() != "" && IsYAML(walkPath) {
 			log.Debugf("%s is not a directory, appending to manifestFiles", info.Name())
 			byteContent, err := os.ReadFile(p)
@@ -153,7 +152,7 @@ func GetManifestFiles(p string) ([]c.ManifestFile, error) {
 	return manifestFiles, nil
 }
 
-// getManifestFiles uses filepath.Walk to retrieve a list of the manifest files within a directory of .yaml files
+// GetManifestFilesFromDir uses filepath.Walk to retrieve a list of the manifest files within a directory of .yaml files
 func GetManifestFilesFromDir(p string) ([]c.ManifestFile, error) {
 	var manifestFiles []c.ManifestFile
 
@@ -173,7 +172,7 @@ func GetManifestFilesFromDir(p string) ([]c.ManifestFile, error) {
 
 			byteContent, err := os.ReadFile(walkPath)
 			if err != nil {
-				return fmt.Errorf("could not read file %s: %v", walkPath, err)
+				return fmt.Errorf("could not read file %s: %s", walkPath, err)
 			}
 			manifest.Name = info.Name()
 			manifest.ManifestContent = byteContent

--- a/pkg/safeguards/helpers.go
+++ b/pkg/safeguards/helpers.go
@@ -110,48 +110,6 @@ func IsYAML(path string) bool {
 	return filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml"
 }
 
-// GetManifestFiles uses filepath.Walk to retrieve a list of the manifest files within the given manifest path
-func GetManifestFiles(p string) ([]types.ManifestFile, error) {
-	var manifestFiles []types.ManifestFile
-
-	err := filepath.Walk(p, func(walkPath string, info fs.FileInfo, err error) error {
-		manifest := types.ManifestFile{}
-		// skip when walkPath is just given path and also a directory
-		if p == walkPath && info.IsDir() {
-			return nil
-		}
-
-		if err != nil {
-			return fmt.Errorf("error walking path %s with error: %w", walkPath, err)
-		}
-
-		if !info.IsDir() && info.Name() != "" && IsYAML(walkPath) {
-			log.Debugf("%s is not a directory, appending to manifestFiles", info.Name())
-			byteContent, err := os.ReadFile(p)
-			if err != nil {
-				return fmt.Errorf("could not read file %s: %s", p, err)
-			}
-			manifest.Name = info.Name()
-			manifest.ManifestContent = byteContent
-			manifestFiles = append(manifestFiles, manifest)
-		} else if !IsYAML(p) {
-			log.Debugf("%s is not a manifest file, skipping...", info.Name())
-		} else {
-			log.Debugf("%s is a directory, skipping...", info.Name())
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("could not walk directory: %s", err)
-	}
-	if len(manifestFiles) == 0 {
-		return nil, fmt.Errorf(" found within given path")
-	}
-
-	return manifestFiles, nil
-}
-
 // GetManifestFilesFromDir uses filepath.Walk to retrieve a list of the manifest files within a directory of .yaml files
 func GetManifestFilesFromDir(p string) ([]types.ManifestFile, error) {
 	var manifestFiles []types.ManifestFile

--- a/pkg/safeguards/helpers.go
+++ b/pkg/safeguards/helpers.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	c "github.com/Azure/draft/pkg/safeguards/types"
+	"github.com/Azure/draft/pkg/safeguards/types"
 )
 
 // retrieves the constraint client that does all rego code related operations
@@ -36,20 +36,20 @@ func getConstraintClient() (*constraintclient.Client, error) {
 
 // sorts the list of supported safeguards versions and returns the last item in the list
 func getLatestSafeguardsVersion() string {
-	semver.Sort(c.SupportedVersions)
-	return c.SupportedVersions[len(c.SupportedVersions)-1]
+	semver.Sort(types.SupportedVersions)
+	return types.SupportedVersions[len(types.SupportedVersions)-1]
 }
 
-func updateSafeguardPaths(safeguardList *[]c.Safeguard) {
+func updateSafeguardPaths(safeguardList *[]types.Safeguard) {
 	for _, sg := range *safeguardList {
-		sg.TemplatePath = fmt.Sprintf("%s/%s/%s", c.SelectedVersion, sg.Name, c.TemplateFileName)
-		sg.ConstraintPath = fmt.Sprintf("%s/%s/%s", c.SelectedVersion, sg.Name, c.ConstraintFileName)
+		sg.TemplatePath = fmt.Sprintf("%s/%s/%s", types.SelectedVersion, sg.Name, types.TemplateFileName)
+		sg.ConstraintPath = fmt.Sprintf("%s/%s/%s", types.SelectedVersion, sg.Name, types.ConstraintFileName)
 	}
 }
 
 // adds Safeguard_CRIP to full list of Safeguards
 func AddSafeguardCRIP() {
-	fc.Safeguards = append(fc.Safeguards, c.Safeguard_CRIP)
+	fc.Safeguards = append(fc.Safeguards, types.Safeguard_CRIP)
 }
 
 // loads constraint templates, constraints into constraint client
@@ -111,11 +111,11 @@ func IsYAML(path string) bool {
 }
 
 // GetManifestFiles uses filepath.Walk to retrieve a list of the manifest files within the given manifest path
-func GetManifestFiles(p string) ([]c.ManifestFile, error) {
-	var manifestFiles []c.ManifestFile
+func GetManifestFiles(p string) ([]types.ManifestFile, error) {
+	var manifestFiles []types.ManifestFile
 
 	err := filepath.Walk(p, func(walkPath string, info fs.FileInfo, err error) error {
-		manifest := c.ManifestFile{}
+		manifest := types.ManifestFile{}
 		// skip when walkPath is just given path and also a directory
 		if p == walkPath && info.IsDir() {
 			return nil
@@ -153,11 +153,11 @@ func GetManifestFiles(p string) ([]c.ManifestFile, error) {
 }
 
 // GetManifestFilesFromDir uses filepath.Walk to retrieve a list of the manifest files within a directory of .yaml files
-func GetManifestFilesFromDir(p string) ([]c.ManifestFile, error) {
-	var manifestFiles []c.ManifestFile
+func GetManifestFilesFromDir(p string) ([]types.ManifestFile, error) {
+	var manifestFiles []types.ManifestFile
 
 	err := filepath.Walk(p, func(walkPath string, info fs.FileInfo, err error) error {
-		manifest := c.ManifestFile{}
+		manifest := types.ManifestFile{}
 		// skip when walkPath is just given path and also a directory
 		if p == walkPath && info.IsDir() {
 			return nil

--- a/pkg/safeguards/helpers.go
+++ b/pkg/safeguards/helpers.go
@@ -125,11 +125,58 @@ func GetManifestFiles(p string) ([]c.ManifestFile, error) {
 			return fmt.Errorf("error walking path %s with error: %w", walkPath, err)
 		}
 
+		fmt.Println("walkPath: ", walkPath)
+		if !info.IsDir() && info.Name() != "" && IsYAML(walkPath) {
+			log.Debugf("%s is not a directory, appending to manifestFiles", info.Name())
+			byteContent, err := os.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("could not read file %s: %s", p, err)
+			}
+			manifest.Name = info.Name()
+			manifest.ManifestContent = byteContent
+			manifestFiles = append(manifestFiles, manifest)
+		} else if !IsYAML(p) {
+			log.Debugf("%s is not a manifest file, skipping...", info.Name())
+		} else {
+			log.Debugf("%s is a directory, skipping...", info.Name())
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not walk directory: %s", err)
+	}
+	if len(manifestFiles) == 0 {
+		return nil, fmt.Errorf(" found within given path")
+	}
+
+	return manifestFiles, nil
+}
+
+// getManifestFiles uses filepath.Walk to retrieve a list of the manifest files within a directory of .yaml files
+func GetManifestFilesFromDir(p string) ([]c.ManifestFile, error) {
+	var manifestFiles []c.ManifestFile
+
+	err := filepath.Walk(p, func(walkPath string, info fs.FileInfo, err error) error {
+		manifest := c.ManifestFile{}
+		// skip when walkPath is just given path and also a directory
+		if p == walkPath && info.IsDir() {
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("error walking path %s with error: %w", walkPath, err)
+		}
+
 		if !info.IsDir() && info.Name() != "" && IsYAML(walkPath) {
 			log.Debugf("%s is not a directory, appending to manifestFiles", info.Name())
 
+			byteContent, err := os.ReadFile(walkPath)
+			if err != nil {
+				return fmt.Errorf("could not read file %s: %v", walkPath, err)
+			}
 			manifest.Name = info.Name()
-			manifest.Path = walkPath
+			manifest.ManifestContent = byteContent
 			manifestFiles = append(manifestFiles, manifest)
 		} else if !IsYAML(p) {
 			log.Debugf("%s is not a manifest file, skipping...", info.Name())

--- a/pkg/safeguards/helpers_test.go
+++ b/pkg/safeguards/helpers_test.go
@@ -2,18 +2,20 @@ package safeguards
 
 import (
 	"context"
+	"os"
 	"testing"
 
-	"github.com/Azure/draft/pkg/safeguards/preprocessing"
+	"github.com/Azure/draft/pkg/safeguards/types"
 	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/stretchr/testify/assert"
-
-	c "github.com/Azure/draft/pkg/safeguards/types"
 )
 
-func validateOneTestManifestFail(ctx context.Context, t *testing.T, c *constraintclient.Client, testFc c.FileCrawler, testManifestPaths []string) {
+func validateOneTestManifestFail(ctx context.Context, t *testing.T, c *constraintclient.Client, testFc types.FileCrawler, testManifestPaths []string) {
 	for _, path := range testManifestPaths {
-		errManifests, err := testFc.ReadManifests(path)
+		byteContent, err := os.ReadFile(path)
+		assert.Nil(t, err)
+
+		errManifests, err := testFc.ReadManifests(byteContent)
 		assert.Nil(t, err)
 
 		err = loadManifestObjects(ctx, c, errManifests)
@@ -26,9 +28,12 @@ func validateOneTestManifestFail(ctx context.Context, t *testing.T, c *constrain
 	}
 }
 
-func validateOneTestManifestSuccess(ctx context.Context, t *testing.T, c *constraintclient.Client, testFc c.FileCrawler, testManifestPaths []string) {
+func validateOneTestManifestSuccess(ctx context.Context, t *testing.T, c *constraintclient.Client, testFc types.FileCrawler, testManifestPaths []string) {
 	for _, path := range testManifestPaths {
-		successManifests, err := testFc.ReadManifests(path)
+		byteContent, err := os.ReadFile(path)
+		assert.Nil(t, err)
+
+		successManifests, err := testFc.ReadManifests(byteContent)
 		assert.Nil(t, err)
 
 		err = loadManifestObjects(ctx, c, successManifests)
@@ -43,7 +48,7 @@ func validateOneTestManifestSuccess(ctx context.Context, t *testing.T, c *constr
 
 func validateAllTestManifestsFail(ctx context.Context, t *testing.T, testManifestPaths []string) {
 	for _, path := range testManifestPaths {
-		manifestFiles, err := preprocessing.GetManifestFiles(path)
+		manifestFiles, err := GetManifestFilesFromDir(path)
 		assert.Nil(t, err)
 
 		// error case - should throw error
@@ -57,7 +62,7 @@ func validateAllTestManifestsFail(ctx context.Context, t *testing.T, testManifes
 
 func validateAllTestManifestsSuccess(ctx context.Context, t *testing.T, testManifestPaths []string) {
 	for _, path := range testManifestPaths {
-		manifestFiles, err := preprocessing.GetManifestFilesFromDir(path)
+		manifestFiles, err := GetManifestFilesFromDir(path)
 		assert.Nil(t, err)
 
 		// success case - should not throw error

--- a/pkg/safeguards/manifestresults.go
+++ b/pkg/safeguards/manifestresults.go
@@ -73,7 +73,7 @@ func GetManifestResults(ctx context.Context, manifestFiles []types.ManifestFile)
 	// aggregate of every manifest object into one list
 	allManifestObjects := []*unstructured.Unstructured{}
 	for _, m := range manifestFiles {
-		manifestObjects, err := fc.ReadManifests(m.Path) // read all the objects stored in a single file
+		manifestObjects, err := fc.ReadManifests(m.ManifestContent) // read all the objects stored in a single file
 		if err != nil {
 			log.Errorf("reading objects %s", err.Error())
 			return manifestResults, err

--- a/pkg/safeguards/preprocessing/preprocessing.go
+++ b/pkg/safeguards/preprocessing/preprocessing.go
@@ -43,7 +43,7 @@ func GetManifestFiles(manifestsPath string) ([]sgTypes.ManifestFile, error) {
 		} else {
 			byteContent, err := os.ReadFile(manifestsPath)
 			if err != nil {
-				return nil, fmt.Errorf("could not read file %s: %v", manifestsPath, err)
+				return nil, fmt.Errorf("could not read file %s: %s", manifestsPath, err)
 			}
 			manifestFiles = append(manifestFiles, sgTypes.ManifestFile{
 				Name:            path.Base(manifestsPath),

--- a/pkg/safeguards/preprocessing/preprocessing_test.go
+++ b/pkg/safeguards/preprocessing/preprocessing_test.go
@@ -1,8 +1,7 @@
 package preprocessing
 
 import (
-	"os"
-	"path"
+	"bytes"
 	"path/filepath"
 	"testing"
 
@@ -11,95 +10,71 @@ import (
 
 // Test rendering a valid Helm chart with no subcharts and three templates
 func TestRenderHelmChart_Valid(t *testing.T) {
-	makeTempDir(t)
-	t.Cleanup(func() { cleanupDir(t, tempDir) })
-
-	manifestFiles, err := RenderHelmChart(false, chartPath, tempDir)
+	manifestFiles, err := RenderHelmChart(false, chartPath)
 	assert.Nil(t, err)
 
 	// Check that the output directory exists and contains expected files
-	expectedFiles := make(map[string]string)
-	expectedFiles["deployment.yaml"] = getManifestAsString(t, "../tests/testmanifests/expecteddeployment.yaml")
-	expectedFiles["service.yaml"] = getManifestAsString(t, "../tests/testmanifests/expectedservice.yaml")
-	expectedFiles["ingress.yaml"] = getManifestAsString(t, "../tests/testmanifests/expectedingress.yaml")
+	expectedFiles := make(map[string][]byte)
+	expectedFiles["deployment.yaml"] = getManifestAsBytes(t, "../tests/testmanifests/expecteddeployment.yaml")
+	expectedFiles["service.yaml"] = getManifestAsBytes(t, "../tests/testmanifests/expectedservice.yaml")
+	expectedFiles["ingress.yaml"] = getManifestAsBytes(t, "../tests/testmanifests/expectedingress.yaml")
 
-	for _, writtenFile := range manifestFiles {
-		expectedYaml := expectedFiles[writtenFile.Name]
-		writtenYaml := parseYAML(t, getManifestAsString(t, writtenFile.Path))
-		assert.Equal(t, writtenYaml, parseYAML(t, expectedYaml))
+	for i, writtenManifestFile := range manifestFiles {
+		writtenFileName := manifestFiles[i].Name
+		expectedYaml := bytes.TrimSpace(expectedFiles[writtenFileName])
+		assert.Equal(t, bytes.TrimSpace(writtenManifestFile.ManifestContent), expectedYaml)
 	}
 
-	cleanupDir(t, tempDir)
-	makeTempDir(t)
-
 	// Test by giving file directly
-	manifestFiles, err = RenderHelmChart(true, directPath_ToValidChart, tempDir)
+	manifestFiles, err = RenderHelmChart(true, directPath_ToValidChart)
 	assert.Nil(t, err)
 
-	for _, writtenFile := range manifestFiles {
-		expectedYaml := expectedFiles[writtenFile.Name]
-		writtenYaml := parseYAML(t, getManifestAsString(t, writtenFile.Path))
-		assert.Equal(t, writtenYaml, parseYAML(t, expectedYaml))
+	for i, writtenManifestFile := range manifestFiles {
+		writtenFileName := manifestFiles[i].Name
+		expectedYaml := bytes.TrimSpace(expectedFiles[writtenFileName])
+		assert.Equal(t, bytes.TrimSpace(writtenManifestFile.ManifestContent), expectedYaml)
 	}
 }
 
 // Should successfully render a Helm chart with sub charts and be able to render subchart separately within a helm chart
 func TestSubCharts(t *testing.T) {
-	makeTempDir(t)
-	t.Cleanup(func() { cleanupDir(t, tempDir) })
-
-	manifestFiles, err := RenderHelmChart(false, subcharts, tempDir)
+	manifestFiles, err := RenderHelmChart(false, subcharts)
 	assert.Nil(t, err)
 
-	// Assert that 3 files were created in temp dir: 1 from main chart, 2 from subcharts
-	files, _ := os.ReadDir(tempDir)
-	assert.Equal(t, len(files), 3)
+	expectedFiles := make(map[string][]byte)
+	expectedFiles["maindeployment.yaml"] = getManifestAsBytes(t, "../tests/testmanifests/expected-mainchart.yaml")
+	expectedFiles["deployment1.yaml"] = getManifestAsBytes(t, "../tests/testmanifests/expected-subchart1.yaml")
+	expectedFiles["deployment2.yaml"] = getManifestAsBytes(t, "../tests/testmanifests/expected-subchart2.yaml")
 
-	expectedFiles := make(map[string]string)
-	expectedFiles["maindeployment.yaml"] = getManifestAsString(t, "../tests/testmanifests/expected-mainchart.yaml")
-	expectedFiles["deployment1.yaml"] = getManifestAsString(t, "../tests/testmanifests/expected-subchart1.yaml")
-	expectedFiles["deployment2.yaml"] = getManifestAsString(t, "../tests/testmanifests/expected-subchart2.yaml")
-
-	for _, writtenFile := range manifestFiles {
-		expectedYaml := expectedFiles[writtenFile.Name]
-		writtenYaml := parseYAML(t, getManifestAsString(t, writtenFile.Path))
-		assert.Equal(t, writtenYaml, parseYAML(t, expectedYaml))
+	for i, writtenManifestFile := range manifestFiles {
+		writtenFileName := manifestFiles[i].Name
+		expectedYaml := bytes.TrimSpace(expectedFiles[writtenFileName])
+		assert.Equal(t, bytes.TrimSpace(writtenManifestFile.ManifestContent), expectedYaml)
 	}
-
-	cleanupDir(t, tempDir)
-	makeTempDir(t)
 
 	// Given a sub-chart dir, that specific sub chart only should be evaluated and rendered
-	_, err = RenderHelmChart(false, subchartDir, tempDir)
+	_, err = RenderHelmChart(false, subchartDir)
 	assert.Nil(t, err)
-
-	cleanupDir(t, tempDir)
-	makeTempDir(t)
 
 	// Given a Chart.yaml in the main directory, main chart and subcharts should be evaluated
-	_, err = RenderHelmChart(true, directPath_ToMainChartYaml, tempDir)
+	_, err = RenderHelmChart(true, directPath_ToMainChartYaml)
 	assert.Nil(t, err)
-
-	cleanupDir(t, tempDir)
-	makeTempDir(t)
 
 	// Given path to a sub-Chart.yaml with a dependency on another subchart, should render both subcharts, but not the main chart
-	manifestFiles, err = RenderHelmChart(true, directPath_ToSubchartYaml, tempDir)
+	manifestFiles, err = RenderHelmChart(true, directPath_ToSubchartYaml)
 	assert.Nil(t, err)
 
-	expectedFiles = make(map[string]string)
-	expectedFiles["deployment1.yaml"] = getManifestAsString(t, "../tests/testmanifests/expected-subchart1.yaml")
-	expectedFiles["deployment2.yaml"] = getManifestAsString(t, "../tests/testmanifests/expected-subchart2.yaml")
+	expectedFiles = make(map[string][]byte)
+	expectedFiles["deployment1.yaml"] = getManifestAsBytes(t, "../tests/testmanifests/expected-subchart1.yaml")
+	expectedFiles["deployment2.yaml"] = getManifestAsBytes(t, "../tests/testmanifests/expected-subchart2.yaml")
 
-	for _, writtenFile := range manifestFiles {
-		expectedYaml := expectedFiles[writtenFile.Name]
-		writtenYaml := parseYAML(t, getManifestAsString(t, writtenFile.Path))
-		assert.Equal(t, writtenYaml, parseYAML(t, expectedYaml))
+	assert.Equal(t, len(manifestFiles), 2)
+	for i, writtenManifestFile := range manifestFiles {
+		writtenFileName := manifestFiles[i].Name
+		expectedYaml := bytes.TrimSpace(expectedFiles[writtenFileName])
+		assert.Equal(t, bytes.TrimSpace(writtenManifestFile.ManifestContent), expectedYaml)
+		assert.NoFileExists(t, "maindeployment.yaml", "Unexpected file was created: maindeployment.yaml")
 	}
-
-	//expect mainchart.yaml to not exist
-	outputFilePath := filepath.Join(tempDir, "maindeployment.yaml")
-	assert.NoFileExists(t, outputFilePath, "Unexpected file was created: %s", outputFilePath)
 }
 
 /**
@@ -108,77 +83,83 @@ func TestSubCharts(t *testing.T) {
 
 // Should fail if the Chart.yaml is invalid
 func TestInvalidChartAndValues(t *testing.T) {
-	makeTempDir(t)
-	t.Cleanup(func() { cleanupDir(t, tempDir) })
-
-	_, err := RenderHelmChart(false, invalidChartPath, tempDir)
+	_, err := RenderHelmChart(false, invalidChartPath)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "failed to load main chart: validation: chart.metadata.name is required")
 
-	_, err = RenderHelmChart(true, directPath_ToValidChart, tempDir)
-	assert.Nil(t, err)
-
-	// Should fail if values.yaml doesn't contain all values necessary for templating
-	cleanupDir(t, tempDir)
-	makeTempDir(t)
-
-	_, err = RenderHelmChart(false, invalidValuesChart, tempDir)
+	_, err = RenderHelmChart(false, invalidValuesChart)
 	assert.NotNil(t, err)
 }
 
 func TestInvalidDeployments(t *testing.T) {
-	makeTempDir(t)
-	t.Cleanup(func() { cleanupDir(t, tempDir) })
-
-	_, err := RenderHelmChart(false, invalidDeploymentSyntax, tempDir)
+	_, err := RenderHelmChart(false, invalidDeploymentSyntax)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "parse error")
 	assert.Contains(t, err.Error(), "function \"selector\" not defined")
 
-	_, err = RenderHelmChart(false, invalidDeploymentValues, tempDir)
+	_, err = RenderHelmChart(false, invalidDeploymentValues)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "map has no entry for key")
 }
 
 // Test different helm folder structures
 func TestDifferentFolderStructures(t *testing.T) {
-	makeTempDir(t)
-	t.Cleanup(func() { cleanupDir(t, tempDir) })
-
-	manifestFiles, err := RenderHelmChart(false, folderwithHelpersTmpl, tempDir) // includes _helpers.tpl
+	manifestFiles, err := RenderHelmChart(false, folderwithHelpersTmpl) // includes _helpers.tpl
 	assert.Nil(t, err)
 
-	expectedFiles := make(map[string]string)
-	expectedFiles["deployment.yaml"] = getManifestAsString(t, "../tests/testmanifests/expected-helpers-deployment.yaml")
-	expectedFiles["service.yaml"] = getManifestAsString(t, "../tests/testmanifests/expected-helpers-service.yaml")
-	for _, writtenFile := range manifestFiles {
-		expectedYaml := expectedFiles[writtenFile.Name]
-		writtenYaml := parseYAML(t, getManifestAsString(t, writtenFile.Path))
-		assert.Equal(t, writtenYaml, parseYAML(t, expectedYaml))
+	expectedFiles := make(map[string][]byte)
+	expectedFiles["deployment.yaml"] = normalizeNewlines(getManifestAsBytes(t, "../tests/testmanifests/expected-helpers-deployment.yaml"))
+	expectedFiles["service.yaml"] = normalizeNewlines(getManifestAsBytes(t, "../tests/testmanifests/expected-helpers-service.yaml"))
+	for i, writtenManifestFile := range manifestFiles {
+		writtenFileName := manifestFiles[i].Name
+		expectedYaml := bytes.TrimSpace(expectedFiles[writtenFileName])
+		resFile := bytes.TrimSpace(normalizeNewlines(writtenManifestFile.ManifestContent))
+		assert.Equal(t, resFile, expectedYaml)
 	}
-	cleanupDir(t, tempDir)
-	makeTempDir(t)
 
-	manifestFiles, err = RenderHelmChart(false, multipleTemplateDirs, tempDir) // all manifests defined in one file
+	manifestFiles, err = RenderHelmChart(false, multipleTemplateDirs) // all manifests defined in one file
 	assert.Nil(t, err)
 
-	expectedFiles = make(map[string]string)
-	expectedFiles["resources.yaml"] = getManifestAsString(t, "../tests/testmanifests/expected-resources.yaml")
-	expectedFiles["service-1.yaml"] = getManifestAsString(t, "../tests/testmanifests/expectedservice.yaml")
-	expectedFiles["service-2.yaml"] = getManifestAsString(t, "../tests/testmanifests/expectedservice2.yaml")
-	for _, writtenFile := range manifestFiles {
-		expectedYaml := expectedFiles[writtenFile.Name]
-		writtenYaml := parseYAML(t, getManifestAsString(t, writtenFile.Path))
-		assert.Equal(t, writtenYaml, parseYAML(t, expectedYaml))
+	expectedFiles = make(map[string][]byte)
+	expectedFiles["resources.yaml"] = normalizeNewlines(getManifestAsBytes(t, "../tests/testmanifests/expected-resources.yaml"))
+	expectedFiles["service-1.yaml"] = normalizeNewlines(getManifestAsBytes(t, "../tests/testmanifests/expectedservice.yaml"))
+	expectedFiles["service-2.yaml"] = normalizeNewlines(getManifestAsBytes(t, "../tests/testmanifests/expectedservice2.yaml"))
+	for i, writtenManifestFile := range manifestFiles {
+		writtenFileName := manifestFiles[i].Name
+		expectedYaml := bytes.TrimSpace(expectedFiles[writtenFileName])
+		resFile := bytes.TrimSpace(normalizeNewlines(writtenManifestFile.ManifestContent))
+		assert.Equal(t, string(resFile), string(expectedYaml))
 	}
 }
 
 // Test rendering a valid kustomization.yaml
 func TestRenderKustomizeManifest_Valid(t *testing.T) {
-	makeTempDir(t)
-	t.Cleanup(func() { cleanupDir(t, tempDir) })
+	_, err := RenderKustomizeManifest(kustomizationPath)
+	assert.Nil(t, err)
+}
 
-	_, err := RenderKustomizeManifest(kustomizationPath, tempDir)
+// TODO: later update these tests to validate the file content returned in the ManifestFile struct
+func TestGetManifestFiles(t *testing.T) {
+	// Test Helm
+	_, err := GetManifestFiles(chartPath)
+	assert.Nil(t, err)
+	_, err = GetManifestFiles(kustomizationPath)
+	assert.Nil(t, err)
+
+	// Test Kustomize
+	_, err = GetManifestFiles(kustomizationPath)
+	assert.Nil(t, err)
+
+	// Test Normal Directory with manifest files
+	absPath, err := filepath.Abs("../tests/all/success")
+	assert.Nil(t, err)
+	_, err = GetManifestFiles(absPath)
+	assert.Nil(t, err)
+
+	// test single manifest file
+	manifestPathFileSuccess, err := filepath.Abs("../tests/all/success/all-success-manifest-1.yaml")
+	assert.Nil(t, err)
+	_, err = GetManifestFiles(manifestPathFileSuccess)
 	assert.Nil(t, err)
 }
 
@@ -219,43 +200,4 @@ func TestIsHelm(t *testing.T) {
 	// invalid path
 	ishelm = isHelm(false, "invalid/path")
 	assert.False(t, ishelm)
-}
-
-// TestIsYAML tests the IsYAML function for proper returns
-func TestIsYAML(t *testing.T) {
-	dirNotYaml, _ := filepath.Abs("../tests/not-yaml")
-	dirYaml, _ := filepath.Abs("../tests/all/success")
-	fileNotYaml, _ := filepath.Abs("../tests/not-yaml/readme.md")
-	fileYaml, _ := filepath.Abs("/tests/all/success/all-success-manifest-1.yaml")
-
-	assert.False(t, IsYAML(fileNotYaml))
-	assert.True(t, IsYAML(fileYaml))
-
-	manifestFiles, err := GetManifestFiles(dirNotYaml)
-	assert.Nil(t, manifestFiles)
-	assert.NotNil(t, err)
-
-	manifestFiles, err = GetManifestFiles(dirYaml)
-	assert.NotNil(t, manifestFiles)
-	assert.Nil(t, err)
-}
-
-// TestIsDirectory tests the isDirectory function for proper returns
-func TestIsDirectory(t *testing.T) {
-	testWd, _ := os.Getwd()
-	pathTrue := testWd
-	pathFalse := path.Join(testWd, "preprocessing.go")
-	pathError := ""
-
-	isDir, err := IsDirectory(pathTrue)
-	assert.True(t, isDir)
-	assert.Nil(t, err)
-
-	isDir, err = IsDirectory(pathFalse)
-	assert.False(t, isDir)
-	assert.Nil(t, err)
-
-	isDir, err = IsDirectory(pathError)
-	assert.False(t, isDir)
-	assert.NotNil(t, err)
 }

--- a/pkg/safeguards/preprocessing/preprocessing_test_helpers.go
+++ b/pkg/safeguards/preprocessing/preprocessing_test_helpers.go
@@ -30,6 +30,7 @@ const (
 	kustomizationFilePath = "../tests/kustomize/overlays/production/kustomization.yaml"
 )
 
+// Returns the content of a manifest file as bytes
 func getManifestAsBytes(t *testing.T, filePath string) []byte {
 	yamlFileContent, err := os.ReadFile(filePath)
 	if err != nil {
@@ -39,25 +40,21 @@ func getManifestAsBytes(t *testing.T, filePath string) []byte {
 	return yamlFileContent
 }
 
-// replace newlines with strings for easy .yaml byte comparison
+// Normalize returns, newlines, extra characters with strings for easy .yaml byte comparison
 func normalizeNewlines(data []byte) []byte {
 	str := string(data)
 
-	// Replace newlines and carriage returns with a single newline
+	// Replace various newline characters with a single newline
 	str = strings.ReplaceAll(str, "\r\n", "\n")
 	str = strings.ReplaceAll(str, "\r", "\n")
 
-	// Replace YAML block scalars' indicators with empty space
-	// Handles cases like "data: config.yaml: |"
-	re := regexp.MustCompile(`(\s*\|\s*)`)
-	str = re.ReplaceAllString(str, " ")
-
-	// Replace multiple spaces with a single space
+	// Replace YAML block scalars' indicators and multiple spaces
+	str = regexp.MustCompile(`(\s*\|\s*)`).ReplaceAllString(str, " ")
 	str = strings.Join(strings.Fields(str), " ")
 
 	// Normalize empty mappings and fields
-	str = regexp.MustCompile(`(\{\s*\})`).ReplaceAllString(str, "{}")
-	str = regexp.MustCompile(`(\s*:\s*)`).ReplaceAllString(str, ": ")
+	str = regexp.MustCompile(`\{\s*\}`).ReplaceAllString(str, "{}")
+	str = regexp.MustCompile(`\s*:\s*`).ReplaceAllString(str, ": ")
 
 	return []byte(str)
 }

--- a/pkg/safeguards/preprocessing/preprocessing_test_helpers.go
+++ b/pkg/safeguards/preprocessing/preprocessing_test_helpers.go
@@ -2,13 +2,12 @@ package preprocessing
 
 import (
 	"os"
+	"regexp"
+	"strings"
 	"testing"
-
-	"gopkg.in/yaml.v3"
 )
 
 const (
-	tempDir                 = "testdata" // Rendered files are stored here before they are read for comparison
 	chartPath               = "../tests/testmanifests/validchart"
 	invalidChartPath        = "../tests/testmanifests/invalidchart"
 	invalidValuesChart      = "../tests/testmanifests/invalidvalues"
@@ -31,34 +30,34 @@ const (
 	kustomizationFilePath = "../tests/kustomize/overlays/production/kustomization.yaml"
 )
 
-func makeTempDir(t *testing.T) {
-	if err := CreateTempDir(tempDir); err != nil {
-		t.Fatalf("failed to create temporary output directory: %s", err)
-	}
-}
-
-func cleanupDir(t *testing.T, dir string) {
-	err := os.RemoveAll(dir)
-	if err != nil {
-		t.Fatalf("Failed to clean directory: %s", err)
-	}
-}
-
-func parseYAML(t *testing.T, content string) map[string]interface{} {
-	var result map[string]interface{}
-	err := yaml.Unmarshal([]byte(content), &result)
-	if err != nil {
-		t.Fatalf("Failed to parse YAML: %s", err)
-	}
-	return result
-}
-
-func getManifestAsString(t *testing.T, filePath string) string {
+func getManifestAsBytes(t *testing.T, filePath string) []byte {
 	yamlFileContent, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("Failed to read YAML file: %s", err)
 	}
 
-	yamlContentString := string(yamlFileContent)
-	return yamlContentString
+	return yamlFileContent
+}
+
+// replace newlines with strings for easy .yaml byte comparison
+func normalizeNewlines(data []byte) []byte {
+	str := string(data)
+
+	// Replace newlines and carriage returns with a single newline
+	str = strings.ReplaceAll(str, "\r\n", "\n")
+	str = strings.ReplaceAll(str, "\r", "\n")
+
+	// Replace YAML block scalars' indicators with empty space
+	// Handles cases like "data: config.yaml: |"
+	re := regexp.MustCompile(`(\s*\|\s*)`)
+	str = re.ReplaceAllString(str, " ")
+
+	// Replace multiple spaces with a single space
+	str = strings.Join(strings.Fields(str), " ")
+
+	// Normalize empty mappings and fields
+	str = regexp.MustCompile(`(\{\s*\})`).ReplaceAllString(str, "{}")
+	str = regexp.MustCompile(`(\s*:\s*)`).ReplaceAllString(str, ": ")
+
+	return []byte(str)
 }

--- a/pkg/safeguards/tests/testmanifests/expected-resources.yaml
+++ b/pkg/safeguards/tests/testmanifests/expected-resources.yaml
@@ -35,11 +35,6 @@ data:
     ingress:
       enabled: true
       hostname: example.com
-      annotations: {}
+      annotations:
       tls: false
-      tlsSecret: ""
-
-
-
-
-
+      tlsSecret:

--- a/pkg/safeguards/types/types.go
+++ b/pkg/safeguards/types/types.go
@@ -2,9 +2,9 @@ package types
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io/fs"
-	"os"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	api "github.com/open-policy-agent/gatekeeper/v3/apis"
@@ -26,8 +26,8 @@ type Safeguard struct {
 }
 
 type ManifestFile struct {
-	Name string
-	Path string
+	Name            string
+	ManifestContent []byte
 }
 
 type ManifestResult struct {
@@ -37,16 +37,14 @@ type ManifestResult struct {
 }
 
 // methods for retrieval of manifest, constraint templates, and constraints
-func (fc FileCrawler) ReadManifests(path string) ([]*unstructured.Unstructured, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("opening file %q: %w", path, err)
-	}
-	defer file.Close()
+func (fc FileCrawler) ReadManifests(manifestBytes []byte) ([]*unstructured.Unstructured, error) {
+	// Create a new bytes.Reader from the byte slice
+	bufReader := bufio.NewReader(bytes.NewReader(manifestBytes))
 
-	manifests, err := reader.ReadK8sResources(bufio.NewReader(file))
+	// Read the Kubernetes resources using the reader
+	manifests, err := reader.ReadK8sResources(bufReader)
 	if err != nil {
-		return nil, fmt.Errorf("reading file %q: %w", path, err)
+		return nil, fmt.Errorf("reading manifests: %w", err)
 	}
 
 	return manifests, nil


### PR DESCRIPTION
# Description

Replacing ManifestFile Path property with yaml content as []byte. There is no need to write rendered manifests to a temporary directory now. Manifests are rendered and written in memory for validation to handle later.

Fixes # (issue)
Feature # (details)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Refactor

# How Has This Been Tested?
Unit tests were updated to ensure validation is not dependent on writing rendered files to a temp dir. All files are written/returned in memory

- [ ] Test A
- [ ] Test B


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

