### PR TITLE
no dependabot groups they didnt work 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,10 @@ updates:
     directory: /
     schedule:
       interval: "weekly"
-    groups:
-      # Group updates together, so that they are all applied in a single PR.
-      # Grouped updates are currently in beta and is subject to change.
-      # xref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
-      k8s-go-deps:
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-      go-deps:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:
       interval: weekly
-    groups:
-      actions:
-        patterns:
-          - "*"
   - package-ecosystem: "github-actions"
     directory: "/template/workflows/helm/.github/workflows"
     schedule:


### PR DESCRIPTION
# Description

the grouped dependabot PRs are leading to failed integration tests with several manual interventions on the PRs, so i proposed reverting to individual PRs to allow merging the version bumps that work