### PR TITLE
release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [0.17.1] - 2025-01-24
+
+### Added
+- [#447](https://github.com/Azure/draft/pull/447) Add fleet support to workflows, (pending cli implementation). Bump k8s-deploy to v5
+
 ## [0.17.0] - 2024-12-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "draft",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Release v0.17.1 update to include fleet bump and k8s-deploy v5 with privatecluster tmp dir fix https://github.com/Azure/k8s-deploy/pull/327
