### PR TITLE
cluster resource type default enforcement

### DIFF
--- a/.github/workflows/integration-per-language.yml
+++ b/.github/workflows/integration-per-language.yml
@@ -331,7 +331,6 @@ jobs:
           --variable CONTAINERNAME=someContainer \
           --variable CLUSTERRESOURCEGROUP=someClusterResourceGroup \
           --variable CLUSTERNAME=someAksCluster \
-          --variable CLUSTERRESOURCETYPE=Microsoft.ContainerService/managedClusters \
           --variable DOCKERFILE=./Dockerfile \
           --variable BUILDCONTEXTPATH=. \
           --variable NAMESPACE=default
@@ -485,7 +484,18 @@ jobs:
           curl -m 3 $SERVICEIP:${{env.serviceport}}
           sleep 5
           kill $tunnelPID
-      - run: ./draft -v generate-workflow -d ./langtest/ --deploy-type manifests --variable WORKFLOWNAME=someWorkflow --variable BRANCHNAME=main --variable ACRRESOURCEGROUP=someAcrResourceGroup --variable AZURECONTAINERREGISTRY=someRegistry --variable CONTAINERNAME=someContainer --variable CLUSTERRESOURCEGROUP=someClusterResourceGroup --variable CLUSTERNAME=someAksCluster --variable CLUSTERRESOURCETYPE=Microsoft.ContainerService/managedClusters --variable DOCKERFILE=./Dockerfile --variable BUILDCONTEXTPATH=. --variable NAMESPACE=default
+      - run: ./draft -v generate-workflow\
+          --deploy-type manifests\
+          --variable WORKFLOWNAME=someWorkflow \
+          --variable BRANCHNAME=main \
+          --variable ACRRESOURCEGROUP=someAcrResourceGroup \
+          --variable AZURECONTAINERREGISTRY=someRegistry \
+          --variable CONTAINERNAME=someContainer \
+          --variable CLUSTERRESOURCEGROUP=someClusterResourceGroup \
+          --variable CLUSTERNAME=someAksCluster \
+          --variable DOCKERFILE=./Dockerfile \
+          --variable BUILDCONTEXTPATH=. \
+          --variable NAMESPACE=default
       # Validate generated workflow yaml
       - name: Install action-validator with asdf
         uses: asdf-vm/actions/install@v1

--- a/.github/workflows/integration-per-language.yml
+++ b/.github/workflows/integration-per-language.yml
@@ -158,7 +158,6 @@ jobs:
           --variable CONTAINERNAME=someContainer \
           --variable CLUSTERRESOURCEGROUP=someClusterResourceGroup \
           --variable CLUSTERNAME=someAksCluster \
-          --variable CLUSTERRESOURCETYPE=Microsoft.ContainerService/managedClusters \
           --variable DOCKERFILE=./Dockerfile \
           --variable BUILDCONTEXTPATH=. \
           --variable NAMESPACE=default

--- a/pkg/config/draftconfig_template_test.go
+++ b/pkg/config/draftconfig_template_test.go
@@ -39,6 +39,7 @@ var validVariableKinds = map[string]bool{
 	"azureServiceConnection":     true,
 	"containerImageName":         true,
 	"containerImageVersion":      true,
+	"clusterResourceType":        true,
 	"dirPath":                    true,
 	"dockerFileName":             true,
 	"envVarMap":                  true,

--- a/template/workflows/helm/draft.yaml
+++ b/template/workflows/helm/draft.yaml
@@ -94,3 +94,11 @@ variables:
       value: "false"
     description: "enable creation of target namespace if it does not exist"
     versions: ">=0.0.1"
+  - name: "CLUSTERRESOURCETYPE" 
+    type: "string"
+    kind: "clusterResourceType"
+    default:
+      disablePrompt: true
+      value: "Microsoft.ContainerService/managedClusters"
+    description: "ARM resource type for cluster"
+    versions: ">=0.0.1"

--- a/template/workflows/kustomize/draft.yaml
+++ b/template/workflows/kustomize/draft.yaml
@@ -78,3 +78,11 @@ variables:
       value: "false"
     description: "enable creation of target namespace if it does not exist"
     versions: ">=0.0.1"
+  - name: "CLUSTERRESOURCETYPE" 
+    type: "string"
+    kind: "clusterResourceType"
+    default:
+      disablePrompt: true
+      value: "Microsoft.ContainerService/managedClusters"
+    description: "ARM resource type for cluster"
+    versions: ">=0.0.1"

--- a/template/workflows/manifests/draft.yaml
+++ b/template/workflows/manifests/draft.yaml
@@ -78,3 +78,11 @@ variables:
       value: "false"
     description: "enable creation of target namespace if it does not exist"
     versions: ">=0.0.1"
+  - name: "CLUSTERRESOURCETYPE" 
+    type: "string"
+    kind: "clusterResourceType"
+    default:
+      disablePrompt: true
+      value: "Microsoft.ContainerService/managedClusters"
+    description: "ARM resource type for cluster"
+    versions: ">=0.0.1"


### PR DESCRIPTION
enforce default clusterresourcetype in draft.yaml instead of tests

don't prompt for this variable, instead allow override, but default to AKS managed clusters