### PR TITLE
use default k8s probe settings

### DIFF
--- a/pkg/fixtures/deployments/helm/charts/values.yaml
+++ b/pkg/fixtures/deployments/helm/charts/values.yaml
@@ -58,11 +58,11 @@ readinessProbe:
 startupProbe:
   tcpSocket:
     port: 80
-  periodSeconds: 1
-  timeoutSeconds: 3
-  failureThreshold: 1
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
   successThreshold: 1
-  initialDelaySeconds: 5
+  initialDelaySeconds: 0
 
 nodeSelector: {}
 

--- a/pkg/fixtures/deployments/kustomize/base/deployment.yaml
+++ b/pkg/fixtures/deployments/kustomize/base/deployment.yaml
@@ -49,11 +49,11 @@ spec:
           startupProbe:
             tcpSocket:
               port: 80
-            periodSeconds: 1
-            timeoutSeconds: 3
-            failureThreshold: 1
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
             successThreshold: 1
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
           securityContext:
             seccompProfile:
               type: RuntimeDefault

--- a/pkg/fixtures/deployments/manifest/manifests/deployment.yaml
+++ b/pkg/fixtures/deployments/manifest/manifests/deployment.yaml
@@ -49,11 +49,11 @@ spec:
           startupProbe:
             tcpSocket:
               port: 80
-            periodSeconds: 1
-            timeoutSeconds: 3
-            failureThreshold: 1
+            periodSeconds: 10
+            timeoutSeconds: 1
+            failureThreshold: 3
             successThreshold: 1
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
           securityContext:
             seccompProfile:
               type: RuntimeDefault

--- a/template/deployments/helm/draft.yaml
+++ b/template/deployments/helm/draft.yaml
@@ -122,7 +122,7 @@ variables:
     kind: "kubernetesProbePeriod"
     default:
       disablePrompt: true
-      value: 1
+      value: 10
     description: "kubernetes startup probe period in seconds"
     versions: ">=0.0.1"
   - name: "STARTUPTIMEOUT"
@@ -130,7 +130,7 @@ variables:
     kind: "kubernetesProbeTimeout"
     default:
       disablePrompt: true
-      value: 3
+      value: 1
     description: "kubernetes startup probe timeout in seconds"
     versions: ">=0.0.1"
   - name: "STARTUPFAILURETHRESHOLD"
@@ -138,7 +138,7 @@ variables:
     kind: "kubernetesProbeThreshold"
     default:
       disablePrompt: true
-      value: 1
+      value: 3
     description: "kubernetes startup probe failure threshold"
     versions: ">=0.0.1"
   - name: "STARTUPSUCCESSTHRESHOLD"
@@ -154,7 +154,7 @@ variables:
     kind: "kubernetesProbeDelay"
     default:
       disablePrompt: true
-      value: 5
+      value: 0
     description: "kubernetes startup probe initial delay in seconds"
     versions: ">=0.0.1"
   - name: "READINESSPERIOD"

--- a/template/deployments/kustomize/draft.yaml
+++ b/template/deployments/kustomize/draft.yaml
@@ -122,7 +122,7 @@ variables:
     kind: "kubernetesProbePeriod"
     default:
       disablePrompt: true
-      value: 1
+      value: 10
     description: "kubernetes startup probe period in seconds"
     versions: ">=0.0.1"
   - name: "STARTUPTIMEOUT"
@@ -130,7 +130,7 @@ variables:
     kind: "kubernetesProbeTimeout"
     default:
       disablePrompt: true
-      value: 3
+      value: 1
     description: "kubernetes startup probe timeout in seconds"
     versions: ">=0.0.1"
   - name: "STARTUPFAILURETHRESHOLD"
@@ -138,7 +138,7 @@ variables:
     kind: "kubernetesProbeThreshold"
     default:
       disablePrompt: true
-      value: 1
+      value: 3
     description: "kubernetes startup probe failure threshold"
     versions: ">=0.0.1"
   - name: "STARTUPSUCCESSTHRESHOLD"
@@ -154,7 +154,7 @@ variables:
     kind: "kubernetesProbeDelay"
     default:
       disablePrompt: true
-      value: 5
+      value: 0
     description: "kubernetes startup probe initial delay in seconds"
     versions: ">=0.0.1"
   - name: "READINESSPERIOD"

--- a/template/deployments/manifests/draft.yaml
+++ b/template/deployments/manifests/draft.yaml
@@ -122,7 +122,7 @@ variables:
     kind: "kubernetesProbePeriod"
     default:
       disablePrompt: true
-      value: 1
+      value: 10
     description: "kubernetes startup probe period in seconds"
     versions: ">=0.0.1"
   - name: "STARTUPTIMEOUT"
@@ -130,7 +130,7 @@ variables:
     kind: "kubernetesProbeTimeout"
     default:
       disablePrompt: true
-      value: 3
+      value: 1
     description: "kubernetes startup probe timeout in seconds"
     versions: ">=0.0.1"
   - name: "STARTUPFAILURETHRESHOLD"
@@ -138,7 +138,7 @@ variables:
     kind: "kubernetesProbeThreshold"
     default:
       disablePrompt: true
-      value: 1
+      value: 3
     description: "kubernetes startup probe failure threshold"
     versions: ">=0.0.1"
   - name: "STARTUPSUCCESSTHRESHOLD"
@@ -154,7 +154,7 @@ variables:
     kind: "kubernetesProbeDelay"
     default:
       disablePrompt: true
-      value: 5
+      value: 0
     description: "kubernetes startup probe initial delay in seconds"
     versions: ">=0.0.1"
   - name: "READINESSPERIOD"

--- a/test/integration/clojure/helm.yaml
+++ b/test/integration/clojure/helm.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "8-jdk-alpine"

--- a/test/integration/clojure/kustomize.yaml
+++ b/test/integration/clojure/kustomize.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "8-jdk-alpine"

--- a/test/integration/clojure/manifest.yaml
+++ b/test/integration/clojure/manifest.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "8-jdk-alpine"

--- a/test/integration/gradle/helm.yaml
+++ b/test/integration/gradle/helm.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "11-jre"

--- a/test/integration/gradle/kustomize.yaml
+++ b/test/integration/gradle/kustomize.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "11-jre"

--- a/test/integration/gradle/manifest.yaml
+++ b/test/integration/gradle/manifest.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "11-jre"

--- a/test/integration/java/helm.yaml
+++ b/test/integration/java/helm.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "11-jre"

--- a/test/integration/java/kustomize.yaml
+++ b/test/integration/java/kustomize.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "11-jre"

--- a/test/integration/java/manifest.yaml
+++ b/test/integration/java/manifest.yaml
@@ -10,8 +10,6 @@ deployVariables:
     value: "testapp"
   - name: "IMAGENAME"
     value: "host.minikube.internal:5001/testapp"
-  - name: "STARTUPINITIALDELAY"
-    value: 30
 languageVariables:
   - name: "VERSION"
     value: "11-jre"


### PR DESCRIPTION
use the default k8s probe values instead of overriding them on tests https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes