### PR TITLE
Scan workflows for unpinned GitHub Actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,9 @@ updates:
     directory: "/template/workflows/manifests/.github/workflows"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
### Intention behind this PR is as follows:

Enable depdneabot for following

1. **Checks for Updates:**  
   - Dependabot scans **GitHub Actions workflows** (e.g., `.github/workflows/*.yml`).
   - Identifies actions that need updating (e.g., `actions/setup-go@v5` → latest SHA).

2. **Creates PRs for Updates:**  
   - It **replaces outdated versions** with the latest **commit SHA**.
   - Adds a **"dependencies" label** to PRs for easy identification.

4. **Runs on a Weekly Schedule:**  
   - Dependabot checks for new versions **once a week**.

Thanks heaps and FYI: @davidgamero ❤️ lets merge this https://github.com/Azure/draft/pull/487 and then we can get this in for all resolving from next week onwards, thanks heaps

