### PR TITLE
reduce base resource requests to 0.5Gi and 0.5 cpu

### DIFF
--- a/pkg/fixtures/deployments/helm/charts/values.yaml
+++ b/pkg/fixtures/deployments/helm/charts/values.yaml
@@ -34,8 +34,8 @@ resources:
     cpu: "1"
     memory: "1Gi"
   requests:
-    cpu: "1"
-    memory: "1Gi"
+    cpu: "0.5"
+    memory: "0.5Gi"
 
 autoscaling:
   enabled: false

--- a/pkg/fixtures/deployments/kustomize/base/deployment.yaml
+++ b/pkg/fixtures/deployments/kustomize/base/deployment.yaml
@@ -24,8 +24,8 @@ spec:
             - containerPort: 80
           resources:
             requests:
-              cpu: "1"
-              memory: "1Gi"
+              cpu: "0.5"
+              memory: "0.5Gi"
             limits:
               cpu: "1"
               memory: "1Gi"

--- a/pkg/fixtures/deployments/manifest/manifests/deployment.yaml
+++ b/pkg/fixtures/deployments/manifest/manifests/deployment.yaml
@@ -24,8 +24,8 @@ spec:
             - containerPort: 80
           resources:
             requests:
-              cpu: "1"
-              memory: "1Gi"
+              cpu: "0.5"
+              memory: "0.5Gi"
             limits:
               cpu: "1"
               memory: "1Gi"

--- a/template/deployments/helm/draft.yaml
+++ b/template/deployments/helm/draft.yaml
@@ -70,7 +70,7 @@ variables:
     kind: "kubernetesResourceRequest"
     default:
       disablePrompt: true
-      value: "1"
+      value: "0.5"
     description: "resource request for CPU"
     versions: ">=0.0.1"
   - name: "MEMREQ"
@@ -78,7 +78,7 @@ variables:
     kind: "kubernetesResourceRequest"
     default:
       disablePrompt: true
-      value: "1Gi"
+      value: "0.5Gi"
     description: "resource request for Memory"
     versions: ">=0.0.1"
   - name: "CPULIMIT"

--- a/template/deployments/kustomize/draft.yaml
+++ b/template/deployments/kustomize/draft.yaml
@@ -70,7 +70,7 @@ variables:
     kind: "kubernetesResourceRequest"
     default:
       disablePrompt: true
-      value: "1"
+      value: "0.5"
     description: "resource request for CPU"
     versions: ">=0.0.1"
   - name: "MEMREQ"
@@ -78,7 +78,7 @@ variables:
     kind: "kubernetesResourceRequest"
     default:
       disablePrompt: true
-      value: "1Gi"
+      value: "0.5Gi"
     description: "resource request for Memory"
     versions: ">=0.0.1"
   - name: "CPULIMIT"

--- a/template/deployments/manifests/draft.yaml
+++ b/template/deployments/manifests/draft.yaml
@@ -70,7 +70,7 @@ variables:
     kind: "kubernetesResourceRequest"
     default:
       disablePrompt: true
-      value: "1"
+      value: "0.5"
     description: "resource request for CPU"
     versions: ">=0.0.1"
   - name: "MEMREQ"
@@ -78,7 +78,7 @@ variables:
     kind: "kubernetesResourceRequest"
     default:
       disablePrompt: true
-      value: "1Gi"
+      value: "0.5Gi"
     description: "resource request for Memory"
     versions: ">=0.0.1"
   - name: "CPULIMIT"


### PR DESCRIPTION
reduce our base resource requests to 0.5 cpu and 0.5Gi to better fit our target workload sizes and avoid requesting unnecessary resources