### PR TITLE
add `interactive` flag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [0.17.5] - 2025-03-11
+
+### Added
+
+- [510](https://github.com/Azure/draft/pull/510) Add build context for ADO pipelines
+- [509](https://github.com/Azure/draft/pull/509) Add Ingress Manifest Template
+- [502](https://github.com/Azure/draft/pull/502) Add Auth type for Azure login in github workflow
+
 ## [0.17.4] - 2025-02-05
 
 ### Added

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -362,12 +362,14 @@ func (cc *createCmd) generateDeployment() error {
 			if err != nil {
 				return fmt.Errorf("getting current directory: %w", err)
 			}
+
 			defaultAppName := fmt.Sprintf("%s-workflow", filepath.Base(currentDir))
-			defaultAppName, err = ToValidAppName(defaultAppName)
-			if err != nil {
+			if validName, err := ToValidAppName(defaultAppName); err != nil {
 				log.Debugf("unable to convert default app name %q to a valid name: %v", defaultAppName, err)
-				log.Debugf("using default app name %q", defaultAppName)
+				log.Debugf("using default app name %q", "my-app")
 				defaultAppName = "my-app"
+			} else {
+				defaultAppName = validName
 			}
 			appVar, err := deployTemplate.Config.GetVariable("APPNAME")
 			if err != nil || appVar == nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ var provider string
 var silent bool
 var dryRun bool
 var dryRunFile string
+var interactive bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -62,5 +63,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&provider, "provider", "p", "azure", "cloud provider")
 	rootCmd.PersistentFlags().BoolVarP(&silent, "silent", "", false, "enable silent logging")
 	rootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "", false, "enable dry run mode in which no files are written to disk")
+	rootCmd.PersistentFlags().BoolVarP(&interactive, "interactive", "", false, "toggle interactive prompting for user input (default is true, use --interactive=false to disable)")
 	rootCmd.PersistentFlags().StringVar(&dryRunFile, "dry-run-file", "", "optional file to write dry run summary in json format into (requires --dry-run flag)")
 }

--- a/cmd/setupgh.go
+++ b/cmd/setupgh.go
@@ -92,7 +92,7 @@ func fillSetUpConfig(sc *providers.SetUpCmd, gh providers.GhClient, az providers
 			return fmt.Errorf("getting current directory: %w", err)
 		}
 		defaultAppName := fmt.Sprintf("%s-workflow", filepath.Base(currentDir))
-		defaultAppName, err = toValidAppName(defaultAppName)
+		defaultAppName, err = ToValidAppName(defaultAppName)
 		if err != nil {
 			log.Debugf("unable to convert default app name %q to a valid name: %v", defaultAppName, err)
 			log.Debugf("using default app name %q", defaultAppName)
@@ -149,7 +149,7 @@ func fillSetUpConfig(sc *providers.SetUpCmd, gh providers.GhClient, az providers
 	return nil
 }
 
-func toValidAppName(name string) (string, error) {
+func ToValidAppName(name string) (string, error) {
 	// replace all underscores with hyphens
 	cleanedName := strings.ReplaceAll(name, "_", "-")
 	// replace all spaces with hyphens

--- a/cmd/setupgh_test.go
+++ b/cmd/setupgh_test.go
@@ -85,7 +85,7 @@ func TestToValidAppName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testCaseName, func(t *testing.T) {
-			result, err := toValidAppName(tc.nameInput)
+			result, err := ToValidAppName(tc.nameInput)
 			if tc.shouldError {
 				assert.Error(t, err)
 			} else {

--- a/pkg/linguist/linguist.go
+++ b/pkg/linguist/linguist.go
@@ -302,7 +302,6 @@ func Alias(lang *Language) *Language {
 		"c#":         "csharp",
 		"go module":  "gomodule",
 		"typescript": "javascript",
-		"xml":        "javascript",
 	}
 
 	if alias, ok := packAliases[strings.ToLower(lang.Language)]; ok {


### PR DESCRIPTION
# Description

In order to better serve automated and batch workflows, as well as the wrapped-binary consumption patter, i propose adding a new `interactive` flag that will error on stderr instead of interactively prompting.

this will open up automation options like running in github actions with better error handing

Fixes # (issue)
Feature # (details)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

## How Has This Been Tested?

Provide instructions so we can reproduce, and list any relevant details for your test configuration. Please mention if this is a breaking change which will impact consuming tool(s).

- [ ] Unit Test:
- [ ] E2E Test:
- [ ] Other Test:


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

