### PR TITLE
fix ingress name variable

### DIFF
--- a/pkg/fixtures/manifests/ingress/ingress.yaml
+++ b/pkg/fixtures/manifests/ingress/ingress.yaml
@@ -26,4 +26,4 @@ spec:
   tls:
     - hosts:
         - "test-host.com"
-      secretName: "keyvault-test-service"
+      secretName: "keyvault-test-ingress"

--- a/template/manifests/Ingress/manifests/ingress.yaml
+++ b/template/manifests/Ingress/manifests/ingress.yaml
@@ -32,6 +32,6 @@ spec:
   tls:
     - hosts:
         - "{{ .Config.GetVariableValue "HOST"}}"
-      secretName: "keyvault-{{ .Config.GetVariableValue "SERVICENAME"}}"
+      secretName: "keyvault-{{ .Config.GetVariableValue "INGRESSNAME"}}"
   {{- end}}
 {{- end}}


### PR DESCRIPTION
update ingress name variable to use the correct variable from draft.yaml https://github.com/Azure/draft/blob/fdbedf7c7ecbb3a72eba0567ac6aac0b4ffadd66/template/manifests/Ingress/manifests/draft.yaml#L7
