### PR TITLE
Removing annotate-namespace for fleet resources

### DIFF
--- a/pkg/fixtures/workflows/github/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
+++ b/pkg/fixtures/workflows/github/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
@@ -176,5 +176,5 @@ jobs:
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER == 'true' }}
           namespace: ${{ env.NAMESPACE }}
           resource-type: ${{ env.CLUSTER_RESOURCE_TYPE }}
-          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE }}!='Microsoft.ContainerService/fleets'
+          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE != 'Microsoft.ContainerService/fleets' }}
 

--- a/pkg/fixtures/workflows/github/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
+++ b/pkg/fixtures/workflows/github/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
@@ -176,4 +176,5 @@ jobs:
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER == 'true' }}
           namespace: ${{ env.NAMESPACE }}
           resource-type: ${{ env.CLUSTER_RESOURCE_TYPE }}
+          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE }}!='Microsoft.ContainerService/fleets'
 

--- a/pkg/fixtures/workflows/github/manifests/.github/workflows/azure-kubernetes-service.yml
+++ b/pkg/fixtures/workflows/github/manifests/.github/workflows/azure-kubernetes-service.yml
@@ -161,3 +161,4 @@ jobs:
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER == 'true' }}
           namespace: ${{ env.NAMESPACE }}
           resource-type: ${{ env.CLUSTER_RESOURCE_TYPE }}
+          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE }}!='Microsoft.ContainerService/fleets'

--- a/pkg/fixtures/workflows/github/manifests/.github/workflows/azure-kubernetes-service.yml
+++ b/pkg/fixtures/workflows/github/manifests/.github/workflows/azure-kubernetes-service.yml
@@ -161,4 +161,4 @@ jobs:
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER == 'true' }}
           namespace: ${{ env.NAMESPACE }}
           resource-type: ${{ env.CLUSTER_RESOURCE_TYPE }}
-          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE }}!='Microsoft.ContainerService/fleets'
+          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE != 'Microsoft.ContainerService/fleets' }}

--- a/template/workflows/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
+++ b/template/workflows/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
@@ -176,5 +176,5 @@ jobs:
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER == 'true' }}
           namespace: ${{ env.NAMESPACE }}
           resource-type: ${{ env.CLUSTER_RESOURCE_TYPE }}
-          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE }}!='Microsoft.ContainerService/fleets'
+          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE != 'Microsoft.ContainerService/fleets' }}
 `}}

--- a/template/workflows/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
+++ b/template/workflows/kustomize/.github/workflows/azure-kubernetes-service-kustomize.yml
@@ -176,4 +176,5 @@ jobs:
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER == 'true' }}
           namespace: ${{ env.NAMESPACE }}
           resource-type: ${{ env.CLUSTER_RESOURCE_TYPE }}
+          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE }}!='Microsoft.ContainerService/fleets'
 `}}

--- a/template/workflows/manifests/.github/workflows/azure-kubernetes-service.yml
+++ b/template/workflows/manifests/.github/workflows/azure-kubernetes-service.yml
@@ -162,4 +162,5 @@ jobs:
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER == 'true' }}
           namespace: ${{ env.NAMESPACE }}
           resource-type: ${{ env.CLUSTER_RESOURCE_TYPE }}
+          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE }}!='Microsoft.ContainerService/fleets'
 `}}

--- a/template/workflows/manifests/.github/workflows/azure-kubernetes-service.yml
+++ b/template/workflows/manifests/.github/workflows/azure-kubernetes-service.yml
@@ -162,5 +162,5 @@ jobs:
           private-cluster: ${{ steps.isPrivate.outputs.PRIVATE_CLUSTER == 'true' }}
           namespace: ${{ env.NAMESPACE }}
           resource-type: ${{ env.CLUSTER_RESOURCE_TYPE }}
-          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE }}!='Microsoft.ContainerService/fleets'
+          annotate-namespace: ${{ env.CLUSTER_RESOURCE_TYPE != 'Microsoft.ContainerService/fleets' }}
 `}}


### PR DESCRIPTION
# Description

Please include the related issue if relevant, and motivation/context. Please also list any dependencies required for this change.
For a Fleet workflow, the user doesn't necessarily have permissions to annotate the namespace. By default, we will turn this off for fleet resources in the workflow to fix this warning: 
<img width="595" alt="image" src="https://github.com/user-attachments/assets/efb17536-9d83-409b-8c9d-1a191c063e93" />

Fixes # (issue)
Feature # (details)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactor

## How Has This Been Tested?

Provide instructions so we can reproduce, and list any relevant details for your test configuration. Please mention if this is a breaking change which will impact consuming tool(s).

- [x] Unit Test:
- [ ] E2E Test:
- [ ] Other Test:


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

