### PR TITLE
default interactive true

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -125,6 +125,7 @@ func (cc *createCmd) initConfig() error {
 
 func (cc *createCmd) run() error {
 	log.Debugf("config: %s", cc.createConfigPath)
+	log.Debugf("interactive: %t", interactive)
 
 	flagVariablesMap = flagVariablesToMap(cc.flagVariables)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,6 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&provider, "provider", "p", "azure", "cloud provider")
 	rootCmd.PersistentFlags().BoolVarP(&silent, "silent", "", false, "enable silent logging")
 	rootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "", false, "enable dry run mode in which no files are written to disk")
-	rootCmd.PersistentFlags().BoolVarP(&interactive, "interactive", "", false, "toggle interactive prompting for user input (default is true, use --interactive=false to disable)")
+	rootCmd.PersistentFlags().BoolVarP(&interactive, "interactive", "", true, "toggle interactive prompting for user input (default is true, use --interactive=false to disable)")
 	rootCmd.PersistentFlags().StringVar(&dryRunFile, "dry-run-file", "", "optional file to write dry run summary in json format into (requires --dry-run flag)")
 }


### PR DESCRIPTION
fix https://github.com/Azure/draft/issues/561

the interactive flag introduced a bug defaulting to skipping port inputs on the `draft create` command