### PR TITLE
Make replica count configurable across all deployment templates

### DIFF
--- a/pkg/fixtures/deployments/helm/charts/values.yaml
+++ b/pkg/fixtures/deployments/helm/charts/values.yaml
@@ -1,7 +1,7 @@
 # Default values for testapp.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 2
+replicaCount: 1
 
 namespace: default
 

--- a/pkg/fixtures/deployments/kustomize/base/deployment-override-workload-identity.yaml
+++ b/pkg/fixtures/deployments/kustomize/base/deployment-override-workload-identity.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.azure.com/generator: draft
   namespace: default
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: testapp

--- a/pkg/fixtures/deployments/kustomize/base/deployment.yaml
+++ b/pkg/fixtures/deployments/kustomize/base/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.azure.com/generator: draft
   namespace: default
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: testapp

--- a/pkg/fixtures/deployments/manifest/manifests/deployment-override-workload-identity.yaml
+++ b/pkg/fixtures/deployments/manifest/manifests/deployment-override-workload-identity.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.azure.com/generator: draft
   namespace: default
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: testapp

--- a/pkg/fixtures/deployments/manifest/manifests/deployment.yaml
+++ b/pkg/fixtures/deployments/manifest/manifests/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.azure.com/generator: draft
   namespace: default
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: testapp

--- a/template/deployments/helm/charts/values.yaml
+++ b/template/deployments/helm/charts/values.yaml
@@ -1,7 +1,7 @@
 # Default values for {{ .Config.GetVariableValue "APPNAME"}}.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 2
+replicaCount: {{ .Config.GetVariableValue "REPLICACOUNT" }}
 
 namespace: {{ .Config.GetVariableValue "NAMESPACE" }}
 

--- a/template/deployments/helm/draft.yaml
+++ b/template/deployments/helm/draft.yaml
@@ -30,6 +30,14 @@ variables:
       value: default
     description: " the namespace to place new resources in"
     versions: ">=0.0.1"
+  - name: "REPLICACOUNT"
+    type: "int"
+    kind: "kubernetesReplicas"
+    default:
+      disablePrompt: true
+      value: 1
+    description: "the number of replicas for the deployment"
+    versions: ">=0.0.1"
   - name: "IMAGENAME"
     type: "string"
     kind: "containerImageName"

--- a/template/deployments/kustomize/base/deployment.yaml
+++ b/template/deployments/kustomize/base/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.azure.com/generator: {{ .Config.GetVariableValue "GENERATORLABEL" }}
   namespace: {{ .Config.GetVariableValue "NAMESPACE" }}
 spec:
-  replicas: 2
+  replicas: {{ .Config.GetVariableValue "REPLICACOUNT" }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Config.GetVariableValue "APPNAME" }}

--- a/template/deployments/kustomize/draft.yaml
+++ b/template/deployments/kustomize/draft.yaml
@@ -30,6 +30,14 @@ variables:
       value: default
     description: " the namespace to place new resources in"
     versions: ">=0.0.1"
+  - name: "REPLICACOUNT"
+    type: "int"
+    kind: "kubernetesReplicas"
+    default:
+      disablePrompt: true
+      value: 1
+    description: "the number of replicas for the deployment"
+    versions: ">=0.0.1"
   - name: "IMAGENAME"
     type: "string"
     kind: "containerImageName"

--- a/template/deployments/manifests/draft.yaml
+++ b/template/deployments/manifests/draft.yaml
@@ -30,6 +30,14 @@ variables:
       value: default
     description: " the namespace to place new resources in"
     versions: ">=0.0.1"
+  - name: "REPLICACOUNT"
+    type: "int"
+    kind: "kubernetesReplicas"
+    default:
+      disablePrompt: true
+      value: 1
+    description: "the number of replicas for the deployment"
+    versions: ">=0.0.1"
   - name: "IMAGENAME"
     type: "string"
     kind: "containerImageName"

--- a/template/deployments/manifests/manifests/deployment.yaml
+++ b/template/deployments/manifests/manifests/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.azure.com/generator: {{ .Config.GetVariableValue "GENERATORLABEL" }}
   namespace: {{ .Config.GetVariableValue "NAMESPACE" }}
 spec:
-  replicas: 2
+  replicas: {{ .Config.GetVariableValue "REPLICACOUNT" }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Config.GetVariableValue "APPNAME" }}

--- a/test/templates/unsupported_no_of_containers.yaml
+++ b/test/templates/unsupported_no_of_containers.yaml
@@ -6,7 +6,7 @@ metadata:
     app: my-app
     kubernetes.azure.com/generator: draft
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: my-app


### PR DESCRIPTION
## Summary
This PR makes the replica count configurable across all deployment templates (Helm, Kustomize, and Manifests) instead of using hardcoded values.

## Changes
- Add `REPLICACOUNT` variable to all deployment template `draft.yaml` files
- Set default value to 1 replica (configurable by users)
- Replace hardcoded `replicas: 2` with `{{ .Config.GetVariableValue "REPLICACOUNT" }}`
- Update all test fixtures to use `replicas: 1` to match the new default
- Ensure consistency across all three deployment template types

## Benefits
- Users can now customize replica count when generating deployments
- Consistent behavior across all deployment template types
- Follows the same pattern as other configurable variables in the project

## Usage
Users can override the replica count when generating deployments:
```bash
draft create deployment --variable REPLICACOUNT=3

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Refactor

## How Has This Been Tested?

Provide instructions so we can reproduce, and list any relevant details for your test configuration. Please mention if this is a breaking change which will impact consuming tool(s).

- [ ] Unit Test:
- [ ] E2E Test:
- [ ] Other Test:


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

